### PR TITLE
feat: remove logfmt in log volume queries

### DIFF
--- a/src/components/Explore/LogsByService/GoToExploreButton.tsx
+++ b/src/components/Explore/LogsByService/GoToExploreButton.tsx
@@ -6,7 +6,6 @@ import { LogExploration } from '../../../pages/Explore';
 import { getDataSource, getQueryExpr } from '../../../utils/utils';
 import { sceneGraph } from '@grafana/scenes';
 import { toURLRange, urlUtil } from '@grafana/data';
-import { VAR_LOGS_FORMAT_EXPR } from 'utils/shared';
 
 interface ShareExplorationButtonState {
   exploration: LogExploration;
@@ -14,15 +13,23 @@ interface ShareExplorationButtonState {
 
 export const GoToExploreButton = ({ exploration }: ShareExplorationButtonState) => {
   const onClick = () => {
-    const datasource = getDataSource(exploration)
-    const expr = getQueryExpr(exploration).replace(VAR_LOGS_FORMAT_EXPR, '')
-    const timeRange = sceneGraph.getTimeRange(exploration).state.value
+    const datasource = getDataSource(exploration);
+    const expr = getQueryExpr(exploration);
+    const timeRange = sceneGraph.getTimeRange(exploration).state.value;
     const exploreState = JSON.stringify({
-      ['loki-explore']: { range: toURLRange(timeRange.raw), queries: [{refId: 'logs',expr, datasource}], datasource}
-    })
+      ['loki-explore']: {
+        range: toURLRange(timeRange.raw),
+        queries: [{ refId: 'logs', expr, datasource }],
+        datasource,
+      },
+    });
     const link = urlUtil.renderUrl('/explore', { panes: exploreState, schemaVersion: 1 });
     window.open(link, '_blank');
   };
 
-  return <ToolbarButton variant={'canvas'} icon={'compass'} onClick={onClick}>Open in Explore</ToolbarButton>;
+  return (
+    <ToolbarButton variant={'canvas'} icon={'compass'} onClick={onClick}>
+      Open in Explore
+    </ToolbarButton>
+  );
 };

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -22,7 +22,7 @@ export const VAR_DATASOURCE = 'ds';
 export const VAR_DATASOURCE_EXPR = '${ds}';
 export const VAR_LOGS_FORMAT = 'logsFormat';
 
-export const LOG_STREAM_SELECTOR_EXPR = `${VAR_FILTERS_EXPR} ${VAR_PATTERNS_EXPR}${VAR_FIELDS_EXPR}`;
+export const LOG_STREAM_SELECTOR_EXPR = `${VAR_FILTERS_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_FIELDS_EXPR}`;
 export const explorationDS = { uid: VAR_DATASOURCE_EXPR };
 
 export const ALL_VARIABLE_VALUE = '$__all';

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -21,9 +21,8 @@ export const VAR_LABEL_GROUP_BY = 'labelBy';
 export const VAR_DATASOURCE = 'ds';
 export const VAR_DATASOURCE_EXPR = '${ds}';
 export const VAR_LOGS_FORMAT = 'logsFormat';
-export const VAR_LOGS_FORMAT_EXPR = '${logsFormat}';
 
-export const LOG_STREAM_SELECTOR_EXPR = `${VAR_FILTERS_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LOGS_FORMAT_EXPR} ${VAR_FIELDS_EXPR}`;
+export const LOG_STREAM_SELECTOR_EXPR = `${VAR_FILTERS_EXPR} ${VAR_PATTERNS_EXPR}${VAR_FIELDS_EXPR}`;
 export const explorationDS = { uid: VAR_DATASOURCE_EXPR };
 
 export const ALL_VARIABLE_VALUE = '$__all';


### PR DESCRIPTION
This is not required for log volume queries and actually are slowly down backend we have that labels all the time now that we can detect it in the backend.

NOTE:
Not sure why but if I remove the space between `${VAR_PATTERNS_EXPR}${VAR_FIELDS_EXPR}` if fails rendering  another matcher selector at the end

