### PR TITLE
Remove parser from all volume queries

### DIFF
--- a/src/components/Explore/LogsByService/LogTimeSeriesPanel.tsx
+++ b/src/components/Explore/LogsByService/LogTimeSeriesPanel.tsx
@@ -120,7 +120,7 @@ export class LogTimeSeriesPanel extends SceneObjectBase<LogTimeSeriesPanelState>
 function buildQuery() {
   return {
     refId: 'A',
-    expr: `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME} | drop __error__ [$__auto])) by (level)`,
+    expr: `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME} | __error__="" [$__auto])) by (level)`,
     queryType: 'range',
     editorMode: 'code',
   };

--- a/src/components/Explore/LogsByService/LogTimeSeriesPanel.tsx
+++ b/src/components/Explore/LogsByService/LogTimeSeriesPanel.tsx
@@ -120,7 +120,7 @@ export class LogTimeSeriesPanel extends SceneObjectBase<LogTimeSeriesPanelState>
 function buildQuery() {
   return {
     refId: 'A',
-    expr: `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME} | __error__="" [$__auto])) by (level)`,
+    expr: `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME} [$__auto])) by (level)`,
     queryType: 'range',
     editorMode: 'code',
   };

--- a/src/components/Explore/LogsByService/LogTimeSeriesPanel.tsx
+++ b/src/components/Explore/LogsByService/LogTimeSeriesPanel.tsx
@@ -10,7 +10,7 @@ import {
   SceneQueryRunner,
   SceneDataTransformer,
 } from '@grafana/scenes';
-import { explorationDS, LOG_STREAM_SELECTOR_EXPR } from '../../../utils/shared';
+import { explorationDS, LOG_STREAM_SELECTOR_EXPR_VOLUME } from '../../../utils/shared';
 import { DrawStyle, StackingMode } from '@grafana/ui';
 import { DataFrame } from '@grafana/data';
 import { map, Observable } from 'rxjs';
@@ -120,7 +120,7 @@ export class LogTimeSeriesPanel extends SceneObjectBase<LogTimeSeriesPanelState>
 function buildQuery() {
   return {
     refId: 'A',
-    expr: `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__ [$__auto])) by (level)`,
+    expr: `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME} | drop __error__ [$__auto])) by (level)`,
     queryType: 'range',
     editorMode: 'code',
   };

--- a/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
@@ -299,7 +299,7 @@ function getExpr(field: string) {
       `(${field}) [$__auto]) by ()`
     );
   }
-  return `sum by (${field}) (count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME} | drop __error__  [$__auto]))`;
+  return `sum by (${field}) (count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME} | __error__=""  [$__auto]))`;
 }
 
 function buildQuery(tagKey: string) {

--- a/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
@@ -300,7 +300,7 @@ function getExpr(field: string) {
       `(${field}) [$__auto]) by ()`
     );
   }
-  return `sum by (${field}) (count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME} | __error__=""  [$__auto]))`;
+  return `sum by (${field}) (count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME}  [$__auto]))`;
 }
 
 function buildQuery(tagKey: string) {

--- a/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
@@ -27,6 +27,7 @@ import {
   ALL_VARIABLE_VALUE,
   explorationDS,
   LOG_STREAM_SELECTOR_EXPR,
+  LOG_STREAM_SELECTOR_EXPR_VOLUME,
   VAR_FIELD_GROUP_BY,
   VAR_FILTERS,
 } from '../../../../utils/shared';
@@ -298,7 +299,7 @@ function getExpr(field: string) {
       `(${field}) [$__auto]) by ()`
     );
   }
-  return `sum by (${field}) (count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__  [$__auto]))`;
+  return `sum by (${field}) (count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME} | drop __error__  [$__auto]))`;
 }
 
 function buildQuery(tagKey: string) {

--- a/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
@@ -27,7 +27,7 @@ import { StatusWrapper } from '../../StatusWrapper';
 import {
   ALL_VARIABLE_VALUE,
   explorationDS,
-  LOG_STREAM_SELECTOR_EXPR,
+  LOG_STREAM_SELECTOR_EXPR_VOLUME,
   VAR_DATASOURCE_EXPR,
   VAR_FILTERS,
   VAR_LABEL_GROUP_BY,
@@ -257,7 +257,7 @@ export function buildAllLayout(options: Array<SelectableValue<string>>) {
 }
 
 function getExpr(tagKey: string) {
-  return `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__ [$__auto])) by (${tagKey})`;
+  return `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME} | drop __error__ [$__auto])) by (${tagKey})`;
 }
 
 function buildQuery(tagKey: string) {

--- a/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
@@ -262,7 +262,7 @@ export function buildAllLayout(options: Array<SelectableValue<string>>) {
 }
 
 function getExpr(tagKey: string) {
-  return `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME} | __error__="" [$__auto])) by (${tagKey})`;
+  return `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME} [$__auto])) by (${tagKey})`;
 }
 
 function buildQuery(tagKey: string) {

--- a/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
@@ -257,7 +257,7 @@ export function buildAllLayout(options: Array<SelectableValue<string>>) {
 }
 
 function getExpr(tagKey: string) {
-  return `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME} | drop __error__ [$__auto])) by (${tagKey})`;
+  return `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR_VOLUME} | __error__="" [$__auto])) by (${tagKey})`;
 }
 
 function buildQuery(tagKey: string) {

--- a/src/pages/Explore/LogExploration.tsx
+++ b/src/pages/Explore/LogExploration.tsx
@@ -32,6 +32,7 @@ import {
   explorationDS,
   StartingPointSelectedEvent,
   VAR_DATASOURCE,
+  VAR_ERROR_FILTER,
   VAR_FIELDS,
   VAR_FILTERS,
   VAR_LINE_FILTER,
@@ -360,11 +361,18 @@ function getVariableSet(initialDS?: string, initialFilters?: AdHocVariableFilter
     const dsValue = `${newState.value}`;
     newState.value && localStorage.setItem(DS_LOCALSTORAGE_KEY, dsValue);
   });
+
+  const errorFilterVariable = new CustomVariable({
+    name: VAR_ERROR_FILTER,
+    value: '| __error__=""',
+    hide: VariableHide.hideVariable,
+  });
   return new SceneVariableSet({
     variables: [
       dsVariable,
       filterVariable,
       fieldsVariable,
+      errorFilterVariable,
       new CustomVariable({
         name: VAR_PATTERNS,
         value: '|= ``',

--- a/src/pages/Explore/SelectStartingPointScene.tsx
+++ b/src/pages/Explore/SelectStartingPointScene.tsx
@@ -394,7 +394,7 @@ function buildVolumeQuery(services: string[]) {
   const stream = `${SERVICE_NAME}=~"${services.join('|')}"`;
   return {
     refId: 'A',
-    expr: `sum by(${SERVICE_NAME}, level) (count_over_time({${stream}} | drop __error__ [$__auto]))`,
+    expr: `sum by(${SERVICE_NAME}, level) (count_over_time({${stream}} | __error__=""_ [$__auto]))`,
     queryType: 'range',
     legendFormat: '{{level}}',
     maxLines: 100,

--- a/src/pages/Explore/SelectStartingPointScene.tsx
+++ b/src/pages/Explore/SelectStartingPointScene.tsx
@@ -394,7 +394,7 @@ function buildVolumeQuery(services: string[]) {
   const stream = `${SERVICE_NAME}=~"${services.join('|')}"`;
   return {
     refId: 'A',
-    expr: `sum by(${SERVICE_NAME}, level) (count_over_time({${stream}} | __error__=""_ [$__auto]))`,
+    expr: `sum by(${SERVICE_NAME}, level) (count_over_time({${stream}} | __error__="" [$__auto]))`,
     queryType: 'range',
     legendFormat: '{{level}}',
     maxLines: 100,

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -24,9 +24,11 @@ export const VAR_LOGS_FORMAT = 'logsFormat';
 export const VAR_LOGS_FORMAT_EXPR = '${logsFormat}';
 export const VAR_LINE_FILTER = 'lineFilter';
 export const VAR_LINE_FILTER_EXPR = '${lineFilter}'
+export const VAR_ERROR_FILTER = 'errorFilter';
+export const VAR_ERROR_FILTER_EXPR = '${errorFilter}';
 
 export const LOG_STREAM_SELECTOR_EXPR = `${VAR_FILTERS_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LOGS_FORMAT_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FILTER_EXPR}`;
-export const LOG_STREAM_SELECTOR_EXPR_VOLUME = `${VAR_FILTERS_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FILTER_EXPR}`;
+export const LOG_STREAM_SELECTOR_EXPR_VOLUME = `${VAR_FILTERS_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FILTER_EXPR} ${VAR_ERROR_FILTER_EXPR}`.replace(/\s+/g, ' ').trimEnd();
 
 export const explorationDS = { uid: VAR_DATASOURCE_EXPR };
 

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -24,6 +24,7 @@ export const VAR_LOGS_FORMAT = 'logsFormat';
 export const VAR_LOGS_FORMAT_EXPR = '${logsFormat}';
 
 export const LOG_STREAM_SELECTOR_EXPR = `${VAR_FILTERS_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LOGS_FORMAT_EXPR} ${VAR_FIELDS_EXPR}`;
+export const LOG_STREAM_SELECTOR_EXPR_VOLUME = `${VAR_FILTERS_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_FIELDS_EXPR}`;
 export const explorationDS = { uid: VAR_DATASOURCE_EXPR };
 
 export const ALL_VARIABLE_VALUE = '$__all';

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -10,7 +10,7 @@ import {
 } from '@grafana/scenes';
 
 import { LogExploration } from '../pages/Explore';
-import { ALL_VARIABLE_VALUE, EXPLORATIONS_ROUTE, LOG_STREAM_SELECTOR_EXPR, VAR_DATASOURCE_EXPR, VAR_FILTERS } from './shared';
+import { ALL_VARIABLE_VALUE, EXPLORATIONS_ROUTE, LOG_STREAM_SELECTOR_EXPR_VOLUME, VAR_DATASOURCE_EXPR, VAR_FILTERS } from './shared';
 
 export function getExplorationFor(model: SceneObject): LogExploration {
   return sceneGraph.getAncestor(model, LogExploration);
@@ -37,7 +37,7 @@ export function getDataSource(exploration: LogExploration) {
 }
 
 export function getQueryExpr(exploration: LogExploration) {
-  return sceneGraph.interpolate(exploration, LOG_STREAM_SELECTOR_EXPR).replace(/\s+/g, ' ');
+  return sceneGraph.interpolate(exploration, LOG_STREAM_SELECTOR_EXPR_VOLUME).replace(/\s+/g, ' ');
 }
 
 export function getDataSourceName(dataSourceUid: string) {


### PR DESCRIPTION
This PR removed parser from log volume queries, as not needed anymore. There was an interpolation issue with using `| drop __error__`, but now when we are not using parser we can replace it with `__error__=""`