### PR TITLE
fix: docker-compose without building

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ GF_INSTALL_PLUGINS=https://storage.googleapis.com/integration-artifacts/grafana-
 Test out the app using the following command to spin up Grafana, Loki, and the Logs Explore App:
 
 ```sh
-curl https://github.com/grafana/explore-logs/raw/main/docker-compose.yaml | docker compose -f - up
+curl https://github.com/grafana/explore-logs/raw/main/scripts/run.sh | sh
 ```
+
+This will download the https://github.com/grafana/explore-logs/blob/main/scripts/run.sh file and execute it. That shell file will download some configuration files into your `/tmp/explore-logs` directory and start the docker containers via `docker compose` from there.
 
 Once the docker container started, navigate to http://localhost:3000/a/grafana-lokiexplore-app/explore in order to use Explore Logs.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,5 @@ services:
     command: -config.file=/etc/loki/local-config.yaml --pattern-ingester.enabled=true
     restart: on-failure
   generator:
-    build:
-      context: ./generator
+    image: svennergr/fake-logs-generator:main-c8d21cc
     command: -url http://loki:3100/loki/api/v1/push

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,6 @@ version: '3.0'
 
 services:
   grafana:
-    container_name: 'grafana-logsapp'
     image: grafana/grafana:11.0.0-preview
     environment:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+mkdir -p /tmp/explore-logs/config
+mkdir -p /tmp/explore-logs/provisioning/datasources
+mkdir -p /tmp/explore-logs/provisioning/plugins
+
+# Download files
+curl https://raw.githubusercontent.com/grafana/explore-logs/main/config/loki-config.yaml -o /tmp/explore-logs/config/loki-config.yaml
+curl https://raw.githubusercontent.com/grafana/explore-logs/main/provisioning/datasources/default.yaml -o /tmp/explore-logs/provisioning/datasources/default.yaml
+curl https://raw.githubusercontent.com/grafana/explore-logs/main/provisioning/plugins/app.yaml -o /tmp/explore-logs/provisioning/plugins/app.yaml
+
+curl https://raw.githubusercontent.com/grafana/explore-logs/main/docker-compose.yaml -o /tmp/explore-logs/docker-compose.yaml
+
+docker compose -f /tmp/explore-logs/docker-compose.yaml up


### PR DESCRIPTION
We claimed that running `docker compose up` would not require the repo to be needed to checkout, but we were missing to use a pushed version of the `fake-logs-generator`. Fixing that by using a recent version I just pushed.

Fixes #211