### PR TITLE
chore: Remove duplicate flag

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -25,7 +25,7 @@ services:
       - '3100:3100'
     volumes:
       - ./config/loki-config.yaml:/etc/loki/local-config.yaml
-    command: -config.file=/etc/loki/local-config.yaml --pattern-ingester.enabled=true
+    command: -config.file=/etc/loki/local-config.yaml
     restart: on-failure
   generator:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       - '3100:3100'
     volumes:
       - ./config/loki-config.yaml:/etc/loki/local-config.yaml
-    command: -config.file=/etc/loki/local-config.yaml --pattern-ingester.enabled=true
+    command: -config.file=/etc/loki/local-config.yaml
     restart: on-failure
   generator:
     image: svennergr/fake-logs-generator:main-c8d21cc


### PR DESCRIPTION
It appears to be configured in loki-config.
see : https://github.com/grafana/explore-logs/blob/e938af139fba465a9bd2fa135d0a9a8734fa567b/config/loki-config.yaml#L20-L21
