### PR TITLE
Remove single cardinality graphs

### DIFF
--- a/src/components/Explore/LogsByService/LogsByServiceScene.tsx
+++ b/src/components/Explore/LogsByService/LogsByServiceScene.tsx
@@ -46,7 +46,7 @@ import { buildPatternsScene } from './Tabs/PatternsScene';
 import { buildFieldsBreakdownActionScene } from './Tabs/FieldsBreakdownScene';
 import { Unsubscribable } from 'rxjs';
 import { getLiveTailControl } from 'utils/scenes';
-import { extractFields, getCardinalityMapFromLabels } from '../../../utils/fields';
+import { extractFields, getCardinalityMapFromFrame } from '../../../utils/fields';
 import { GoToExploreButton } from './GoToExploreButton';
 import { GiveFeedback } from './GiveFeedback';
 import { renderLogQLLabelFilters } from 'pages/Explore';
@@ -222,7 +222,7 @@ export class LogsByServiceScene extends SceneObjectBase<LogSceneState> {
     if (newState.data?.state === LoadingState.Done) {
       const frame = newState.data?.series[0];
       if (frame) {
-        const cardinalityMap = getCardinalityMapFromLabels(frame);
+        const cardinalityMap = getCardinalityMapFromFrame(frame);
         const res = extractFields(frame);
         const detectedFields = res.fields
           .filter((f) => {

--- a/src/components/Explore/LogsByService/LogsByServiceScene.tsx
+++ b/src/components/Explore/LogsByService/LogsByServiceScene.tsx
@@ -46,7 +46,7 @@ import { buildPatternsScene } from './Tabs/PatternsScene';
 import { buildFieldsBreakdownActionScene } from './Tabs/FieldsBreakdownScene';
 import { Unsubscribable } from 'rxjs';
 import { getLiveTailControl } from 'utils/scenes';
-import { extractFields, getCardinalityMapFromFrame } from '../../../utils/fields';
+import { extractFields, getLabelCardinalityMap } from '../../../utils/fields';
 import { GoToExploreButton } from './GoToExploreButton';
 import { GiveFeedback } from './GiveFeedback';
 import { renderLogQLLabelFilters } from 'pages/Explore';
@@ -222,7 +222,8 @@ export class LogsByServiceScene extends SceneObjectBase<LogSceneState> {
     if (newState.data?.state === LoadingState.Done) {
       const frame = newState.data?.series[0];
       if (frame) {
-        const cardinalityMap = getCardinalityMapFromFrame(frame);
+        const labels = frame.fields.find((f) => f.name === 'labels')?.values;
+        const cardinalityMap = getLabelCardinalityMap(labels);
         const res = extractFields(frame);
         const detectedFields = res.fields
           .filter((f) => {

--- a/src/mocks/DataFrameMock.ts
+++ b/src/mocks/DataFrameMock.ts
@@ -1,0 +1,205 @@
+import { DataFrame, DataFrameType, FieldType } from '@grafana/data';
+
+export function getMockFrames() {
+  const logFrameA: DataFrame = {
+    refId: 'A',
+    fields: [
+      {
+        name: 'timestamp',
+        type: FieldType.time,
+        config: {},
+        values: [3, 4],
+      },
+      {
+        name: 'body',
+        type: FieldType.string,
+        config: {},
+        values: ['line1', 'line2'],
+      },
+      {
+        name: 'labels',
+        type: FieldType.other,
+        config: {},
+        values: [
+          {
+            label: 'value',
+            commonLabel: 'value1',
+          },
+          {
+            label: 'value2',
+            commonLabel: 'value1',
+            otherLabel: 'other value',
+          },
+        ],
+      },
+      {
+        name: 'tsNs',
+        type: FieldType.string,
+        config: {},
+        values: ['3000000', '4000000'],
+      },
+      {
+        name: 'id',
+        type: FieldType.string,
+        config: {},
+        values: ['id1', 'id2'],
+      },
+    ],
+    meta: {
+      custom: {
+        frameType: 'LabeledTimeValues',
+      },
+      stats: [
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
+        { displayName: 'Ingester: total reached', value: 1 },
+      ],
+    },
+    length: 2,
+  };
+
+  const logFrameB: DataFrame = {
+    refId: 'A',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: [1, 2],
+      },
+      {
+        name: 'Line',
+        type: FieldType.string,
+        config: {},
+        values: ['line3', 'line4'],
+      },
+      {
+        name: 'labels',
+        type: FieldType.other,
+        config: {},
+        values: [
+          {
+            otherLabel: 'other value',
+          },
+        ],
+      },
+      {
+        name: 'tsNs',
+        type: FieldType.string,
+        config: {},
+        values: ['1000000', '2000000'],
+      },
+      {
+        name: 'id',
+        type: FieldType.string,
+        config: {},
+        values: ['id3', 'id4'],
+      },
+    ],
+    meta: {
+      custom: {
+        frameType: 'LabeledTimeValues',
+      },
+      stats: [
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 22 },
+        { displayName: 'Ingester: total reached', value: 2 },
+      ],
+    },
+    length: 2,
+  };
+
+  const metricFrameA: DataFrame = {
+    refId: 'A',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: [3000000, 4000000],
+      },
+      {
+        name: 'Value',
+        type: FieldType.number,
+        config: {},
+        values: [5, 4],
+        labels: {
+          level: 'debug',
+        },
+      },
+    ],
+    meta: {
+      type: DataFrameType.TimeSeriesMulti,
+      stats: [
+        { displayName: 'Ingester: total reached', value: 1 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
+      ],
+    },
+    length: 2,
+  };
+
+  const metricFrameB: DataFrame = {
+    refId: 'A',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: [1000000, 2000000],
+      },
+      {
+        name: 'Value',
+        type: FieldType.number,
+        config: {},
+        values: [6, 7],
+        labels: {
+          level: 'debug',
+        },
+      },
+    ],
+    meta: {
+      type: DataFrameType.TimeSeriesMulti,
+      stats: [
+        { displayName: 'Ingester: total reached', value: 2 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 22 },
+      ],
+    },
+    length: 2,
+  };
+
+  const metricFrameC: DataFrame = {
+    refId: 'A',
+    name: 'some-time-series',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: [3000000, 4000000],
+      },
+      {
+        name: 'Value',
+        type: FieldType.number,
+        config: {},
+        values: [6, 7],
+        labels: {
+          level: 'error',
+        },
+      },
+    ],
+    meta: {
+      type: DataFrameType.TimeSeriesMulti,
+      stats: [
+        { displayName: 'Ingester: total reached', value: 2 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 33 },
+      ],
+    },
+    length: 2,
+  };
+
+  return {
+    logFrameA,
+    logFrameB,
+    metricFrameA,
+    metricFrameB,
+    metricFrameC,
+  };
+}

--- a/src/utils/fields.test.ts
+++ b/src/utils/fields.test.ts
@@ -1,10 +1,10 @@
 import { getMockFrames } from '../mocks/DataFrameMock';
-import { getCardinalityMapFromFrame } from './fields';
-
+import { getLabelCardinalityMap } from './fields';
 describe('getCardinalityMapFromFrame', () => {
   test('calculates cardinality map from dataframe', async () => {
     const frame = getMockFrames();
-    const map = getCardinalityMapFromFrame(frame.logFrameA);
+    const labels = frame.logFrameA.fields.find((f) => f.name === 'labels')?.values;
+    const map = getLabelCardinalityMap(labels);
     expect(map.get('label')?.valueSet.size).toBe(2);
     expect(map.get('commonLabel')?.valueSet.size).toBe(1);
     expect(map.get('otherLabel')?.valueSet.size).toBe(1);

--- a/src/utils/fields.test.ts
+++ b/src/utils/fields.test.ts
@@ -1,0 +1,12 @@
+import { getMockFrames } from '../mocks/DataFrameMock';
+import { getCardinalityMapFromFrame } from './fields';
+
+describe('getCardinalityMapFromFrame', () => {
+  test('calculates cardinality map from dataframe', async () => {
+    const frame = getMockFrames();
+    const map = getCardinalityMapFromFrame(frame.logFrameA);
+    expect(map.get('label')?.valueSet.size).toBe(2);
+    expect(map.get('commonLabel')?.valueSet.size).toBe(1);
+    expect(map.get('otherLabel')?.valueSet.size).toBe(1);
+  });
+});

--- a/src/utils/fields.ts
+++ b/src/utils/fields.ts
@@ -29,29 +29,26 @@ type labelValue = string;
 export function getCardinalityMapFromFrame(frame: DataFrame) {
   const labels = frame.fields.find((f) => f.name === 'labels')?.values as Labels[];
 
-  const cardinalityMap = new Map<labelName, { valueSet: Set<labelValue>; maxLength: number }>();
-  labels.forEach((fieldLabels) => {
+  const cardinalityMap = new Map<labelName, { valueSet: Set<labelValue> }>();
+  for (let i = 0; i < labels.length; i++) {
+    const fieldLabels = labels[i];
     const labelNames = Object.keys(fieldLabels);
-    labelNames.forEach((labelName) => {
+    for (let j = 0; j < labelNames.length; j++) {
+      const labelName = labelNames[j];
       if (cardinalityMap.has(labelName)) {
         const setObj = cardinalityMap.get(labelName);
         const values = setObj?.valueSet;
-        const maxLength = setObj?.maxLength;
 
         if (values && !values?.has(fieldLabels[labelName])) {
           values?.add(fieldLabels[labelName]);
-          if (maxLength && fieldLabels[labelName].length > maxLength) {
-            cardinalityMap.set(labelName, { maxLength: fieldLabels[labelName].length, valueSet: values });
-          }
         }
       } else {
         cardinalityMap.set(labelName, {
-          maxLength: fieldLabels[labelName].length,
           valueSet: new Set([fieldLabels[labelName]]),
         });
       }
-    });
-  });
+    }
+  }
 
   return cardinalityMap;
 }

--- a/src/utils/fields.ts
+++ b/src/utils/fields.ts
@@ -26,7 +26,7 @@ export function extractFields(data: DataFrame) {
 type labelName = string;
 type labelValue = string;
 
-export function getCardinalityMapFromLabels(frame: DataFrame) {
+export function getCardinalityMapFromFrame(frame: DataFrame) {
   const labels = frame.fields.find((f) => f.name === 'labels')?.values as Labels[];
 
   const cardinalityMap = new Map<labelName, { valueSet: Set<labelValue>; maxLength: number }>();


### PR DESCRIPTION
Fixes https://github.com/grafana/explore-logs/issues/130

Labels/detected fields with single cardinality cannot be added to filters, so let's remove any graph with a single non time field

FieldsBreakdownScene and LabelBreakdownScene were doing the same work in the buildAllLayout functions, I created a new parent class and moved the removeErrorsAndSingleCardinality and hideField functions to the new parent class.