### PR TITLE
Remove errors from detected field queries

### DIFF
--- a/src/components/Explore/LogsByService/LogsByServiceScene.tsx
+++ b/src/components/Explore/LogsByService/LogsByServiceScene.tsx
@@ -229,7 +229,7 @@ export class LogsByServiceScene extends SceneObjectBase<LogSceneState> {
             detectedFields,
           });
         }
-        const newType = (res.type ? ` | ${res.type}` : '') + ` | err!=""`;
+        const newType = res.type ? ` | ${res.type}` : '';
         if (variable.getValue() !== newType) {
           variable.changeValueTo(newType);
         }

--- a/src/components/Explore/LogsByService/LogsByServiceScene.tsx
+++ b/src/components/Explore/LogsByService/LogsByServiceScene.tsx
@@ -229,7 +229,7 @@ export class LogsByServiceScene extends SceneObjectBase<LogSceneState> {
             detectedFields,
           });
         }
-        const newType = res.type ? ` | ${res.type}` : '';
+        const newType = (res.type ? ` | ${res.type}` : '') + ` | err!=""`;
         if (variable.getValue() !== newType) {
           variable.changeValueTo(newType);
         }

--- a/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
@@ -208,7 +208,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
         new SceneCSSGridLayout({
           templateColumns: '1fr',
           autoRows: '200px',
-          children: children.map((child) => child.clone()),
+          children: children.map(child => child.clone()),
         }),
       ],
     });
@@ -311,7 +311,7 @@ function buildQuery(tagKey: string) {
     editorMode: 'code',
     maxLines: 1000,
     intervalMs: 2000,
-    legendFormat: `{{${tagKey}}}`,
+    legendFormat: `{{${tagKey}}}`
   };
 }
 
@@ -351,7 +351,7 @@ function buildNormalLayout(variable: CustomVariable) {
               body: new SceneReactObject({
                 reactNode: <LoadingPlaceholder text="Loading..." />,
               }),
-            }),
+            })
           ],
           isLazy: true,
         }),
@@ -369,7 +369,7 @@ function buildNormalLayout(variable: CustomVariable) {
               body: new SceneReactObject({
                 reactNode: <LoadingPlaceholder text="Loading..." />,
               }),
-            }),
+            })
           ],
           isLazy: true,
         }),

--- a/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
@@ -208,7 +208,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
         new SceneCSSGridLayout({
           templateColumns: '1fr',
           autoRows: '200px',
-          children: children.map(child => child.clone()),
+          children: children.map((child) => child.clone()),
         }),
       ],
     });
@@ -300,7 +300,7 @@ function getExpr(field: string) {
       `(${field}) [$__auto]) by ()`
     );
   }
-  return `sum by (${field}) (count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__  [$__auto]))`;
+  return `sum by (${field}) (count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__ | ${field}!=""   [$__auto]))`;
 }
 
 function buildQuery(tagKey: string) {
@@ -311,7 +311,7 @@ function buildQuery(tagKey: string) {
     editorMode: 'code',
     maxLines: 1000,
     intervalMs: 2000,
-    legendFormat: `{{${tagKey}}}`
+    legendFormat: `{{${tagKey}}}`,
   };
 }
 
@@ -351,7 +351,7 @@ function buildNormalLayout(variable: CustomVariable) {
               body: new SceneReactObject({
                 reactNode: <LoadingPlaceholder text="Loading..." />,
               }),
-            })
+            }),
           ],
           isLazy: true,
         }),
@@ -369,7 +369,7 @@ function buildNormalLayout(variable: CustomVariable) {
               body: new SceneReactObject({
                 reactNode: <LoadingPlaceholder text="Loading..." />,
               }),
-            })            
+            }),
           ],
           isLazy: true,
         }),

--- a/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
@@ -297,7 +297,7 @@ function buildNormalLayout(variable: CustomVariable) {
     .setCustomFieldConfig('lineWidth', 0)
     .setCustomFieldConfig('pointSize', 0)
     .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
-    .setTitle(variable.getValueText())
+    .setTitle(variable.getValueText());
 
   const body = bodyOpts.build();
 
@@ -332,8 +332,8 @@ function buildNormalLayout(variable: CustomVariable) {
               body: new SceneReactObject({
                 reactNode: <LoadingPlaceholder text="Loading..." />,
               }),
-            })
-          ]
+            }),
+          ],
         }),
         getLayoutChild: getLayoutChild(
           getLabelValue,
@@ -349,7 +349,7 @@ function buildNormalLayout(variable: CustomVariable) {
               body: new SceneReactObject({
                 reactNode: <LoadingPlaceholder text="Loading..." />,
               }),
-            })
+            }),
           ],
         }),
         getLayoutChild: getLayoutChild(

--- a/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
@@ -297,7 +297,7 @@ function buildNormalLayout(variable: CustomVariable) {
     .setCustomFieldConfig('lineWidth', 0)
     .setCustomFieldConfig('pointSize', 0)
     .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
-    .setTitle(variable.getValueText());
+    .setTitle(variable.getValueText())
 
   const body = bodyOpts.build();
 
@@ -332,8 +332,8 @@ function buildNormalLayout(variable: CustomVariable) {
               body: new SceneReactObject({
                 reactNode: <LoadingPlaceholder text="Loading..." />,
               }),
-            }),
-          ],
+            })
+          ]
         }),
         getLayoutChild: getLayoutChild(
           getLabelValue,
@@ -349,7 +349,7 @@ function buildNormalLayout(variable: CustomVariable) {
               body: new SceneReactObject({
                 reactNode: <LoadingPlaceholder text="Loading..." />,
               }),
-            }),
+            })
           ],
         }),
         getLayoutChild: getLayoutChild(

--- a/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
@@ -270,7 +270,7 @@ export function buildAllLayout(options: Array<SelectableValue<string>>) {
 }
 
 function getExpr(tagKey: string) {
-  return `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__ [$__auto])) by (${tagKey})`;
+  return `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__ | ${tagKey}!="" [$__auto])) by (${tagKey})`;
 }
 
 function buildQuery(tagKey: string) {


### PR DESCRIPTION
This fixes time series graphs in detected fields from showing a "Value" time series, which is the volume of the logs that are not aggregated by the label of the current query.

fixes: #67

Before:
![image](https://github.com/grafana/explore-logs/assets/109082771/cd67f4f5-0620-4ea6-b472-2f791c45290f)

After:
<img width="1724" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/dde7e689-6229-43c1-96a0-be5e98c2f314">
