### PR TITLE
Table: Refactor url state to use react-router 

### DIFF
--- a/src/components/Context/ScenesTableContext.tsx
+++ b/src/components/Context/ScenesTableContext.tsx
@@ -7,9 +7,9 @@ type ScenesTableContextType = TablePanelProps;
 const ScenesTableContext = createContext<ScenesTableContextType>({
   filters: [],
   addFilter: (filter: AdHocVariableFilter) => {},
-  setSelectedColumns: (cols: string[]) => {},
+  // setSelectedColumns: (cols: string[]) => {},
   timeRange: undefined,
-  selectedColumns: [],
+  // selectedColumns: [],
   selectedLine: undefined,
 });
 
@@ -17,17 +17,15 @@ export const ScenesTableContextProvider = ({
   children,
   filters,
   addFilter,
-  selectedColumns,
-  setSelectedColumns,
+  // selectedColumns,
+  // setSelectedColumns,
   selectedLine,
   timeRange,
 }: {
   children: ReactNode;
 } & ScenesTableContextType) => {
   return (
-    <ScenesTableContext.Provider
-      value={{ filters, addFilter, selectedColumns, setSelectedColumns, selectedLine, timeRange }}
-    >
+    <ScenesTableContext.Provider value={{ filters, addFilter, selectedLine, timeRange }}>
       {children}
     </ScenesTableContext.Provider>
   );

--- a/src/components/Context/ScenesTableContext.tsx
+++ b/src/components/Context/ScenesTableContext.tsx
@@ -7,9 +7,7 @@ type ScenesTableContextType = TablePanelProps;
 const ScenesTableContext = createContext<ScenesTableContextType>({
   filters: [],
   addFilter: (filter: AdHocVariableFilter) => {},
-  // setSelectedColumns: (cols: string[]) => {},
   timeRange: undefined,
-  // selectedColumns: [],
   selectedLine: undefined,
 });
 
@@ -17,8 +15,6 @@ export const ScenesTableContextProvider = ({
   children,
   filters,
   addFilter,
-  // selectedColumns,
-  // setSelectedColumns,
   selectedLine,
   timeRange,
 }: {

--- a/src/components/Context/TableColumnsContext.tsx
+++ b/src/components/Context/TableColumnsContext.tsx
@@ -37,6 +37,25 @@ const TableColumnsContext = createContext<TableColumnsContextType>({
   setBodyState: () => {},
 });
 
+function setDefaultColumns(columns: FieldNameMetaStore, handleSetColumns: (newColumns: FieldNameMetaStore) => void) {
+  const pendingColumns = { ...columns };
+
+  pendingColumns[DATAPLANE_TIMESTAMP_NAME] = {
+    index: 0,
+    active: true,
+    type: 'TIME_FIELD',
+    percentOfLinesWithLabel: 100,
+    cardinality: Infinity,
+  };
+  pendingColumns[DATAPLANE_BODY_NAME] = {
+    index: 1,
+    active: true,
+    type: 'BODY_FIELD',
+    percentOfLinesWithLabel: 100,
+    cardinality: Infinity,
+  };
+  handleSetColumns(pendingColumns);
+}
 export const TableColumnContextProvider = ({
   children,
   initialColumns,
@@ -81,25 +100,10 @@ export const TableColumnContextProvider = ({
 
       // If we're missing all fields, the user must have removed the last column, let's revert back to the default state
       if (activeFields.length === 0) {
-        const pendingColumns = { ...columns };
-
-        pendingColumns[DATAPLANE_TIMESTAMP_NAME] = {
-          index: 0,
-          active: true,
-          type: 'TIME_FIELD',
-          percentOfLinesWithLabel: 100,
-          cardinality: Infinity,
-        };
-        pendingColumns[DATAPLANE_BODY_NAME] = {
-          index: 1,
-          active: true,
-          type: 'BODY_FIELD',
-          percentOfLinesWithLabel: 100,
-          cardinality: Infinity,
-        };
-        handleSetColumns(pendingColumns);
+        setDefaultColumns(columns, handleSetColumns);
       }
 
+      // Reset any local search state
       setFilteredColumns(undefined);
     }
   }, [columns, history, logsFrame, setFilteredColumns, handleSetColumns]);

--- a/src/components/Explore/LogsByService/Tabs/LogsListScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/LogsListScene.tsx
@@ -24,13 +24,12 @@ const VISUALIZATION_TYPE_LOCALSTORAGE_KEY = 'grafana.explore.logs.visualisationT
 export interface LogsListSceneState extends SceneObjectState {
   loading?: boolean;
   panel?: SceneFlexLayout;
-  tableColumns?: string[];
   selectedLine?: SelectedTableRow;
   visualizationType: LogsVisualizationType;
 }
 
 export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
-  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['tableColumns', 'selectedLine'] });
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['selectedLine'] });
 
   constructor(state: Partial<LogsListSceneState>) {
     super({
@@ -54,12 +53,8 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
 
   getUrlState() {
     let stateUpdate: Partial<{
-      tableColumns?: string;
       selectedLine?: string;
     }> = {};
-    if (this.state.tableColumns?.length) {
-      stateUpdate.tableColumns = JSON.stringify(this.state.tableColumns);
-    }
     if (this.state.selectedLine) {
       stateUpdate.selectedLine = JSON.stringify(this.state.selectedLine);
     }
@@ -68,14 +63,6 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
 
   updateFromUrl(values: SceneObjectUrlValues) {
     const stateUpdate: Partial<LogsListSceneState> = {};
-    // Selected table columns
-    if (typeof values.tableColumns === 'string') {
-      const tableColumns = JSON.parse(values.tableColumns);
-      if (tableColumns !== this.state.tableColumns) {
-        stateUpdate.tableColumns = tableColumns;
-      }
-    }
-
     // Selected line
     if (typeof values.selectedLine === 'string') {
       const selectedLine = JSON.parse(values.selectedLine);
@@ -126,12 +113,6 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
       panel: this.getVizPanel({
         filters,
         addFilter,
-        selectedColumns: this.state.tableColumns ?? null,
-        setSelectedColumns: (cols) => {
-          this.setState({
-            tableColumns: cols,
-          });
-        },
         selectedLine: this.state.selectedLine,
         timeRange: range,
       }),
@@ -175,10 +156,6 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
 export interface TablePanelProps {
   filters: AdHocVariableFilter[];
   addFilter: (filter: AdHocVariableFilter) => void;
-  //@todo need to rip out
-  selectedColumns: string[] | null;
-  setSelectedColumns: (cols: string[]) => void;
-  //@todo need to get and set timerange in url
   selectedLine?: SelectedTableRow;
   timeRange?: TimeRange;
 }

--- a/src/components/Explore/LogsByService/Tabs/LogsListScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/LogsListScene.tsx
@@ -175,6 +175,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
 export interface TablePanelProps {
   filters: AdHocVariableFilter[];
   addFilter: (filter: AdHocVariableFilter) => void;
+  //@todo need to rip out
   selectedColumns: string[] | null;
   setSelectedColumns: (cols: string[]) => void;
   //@todo need to get and set timerange in url

--- a/src/components/Explore/panels/tablePanel.tsx
+++ b/src/components/Explore/panels/tablePanel.tsx
@@ -60,9 +60,6 @@ export interface VizTypeProps {
 }
 
 export const getTablePanel = (tableProps: TablePanelProps, vizTypeProps: VizTypeProps) => {
-  // const search = new URLSearchParams(window.location.search);
-  // const columnsFromUrl = search.get('tableColumns');
-  //
   return new VizPanel({
     pluginId: LOGS_TABLE_PLUGIN_ID,
     options: tableProps,

--- a/src/components/Explore/panels/tablePanel.tsx
+++ b/src/components/Explore/panels/tablePanel.tsx
@@ -60,13 +60,9 @@ export interface VizTypeProps {
 }
 
 export const getTablePanel = (tableProps: TablePanelProps, vizTypeProps: VizTypeProps) => {
-  const search = new URLSearchParams(window.location.search);
-  const columnsFromUrl = search.get('tableColumns');
-  // Hack
-  if (columnsFromUrl && !tableProps.selectedColumns?.length) {
-    tableProps.selectedColumns = JSON.parse(columnsFromUrl);
-  }
-
+  // const search = new URLSearchParams(window.location.search);
+  // const columnsFromUrl = search.get('tableColumns');
+  //
   return new VizPanel({
     pluginId: LOGS_TABLE_PLUGIN_ID,
     options: tableProps,

--- a/src/components/Table/ColumnSelection/ColumnSelectionDrawerWrap.tsx
+++ b/src/components/Table/ColumnSelection/ColumnSelectionDrawerWrap.tsx
@@ -15,7 +15,6 @@ export function getReorderColumn(setColumns: (cols: FieldNameMetaStore) => void)
     }
 
     const pendingLabelState = { ...columns };
-
     const keys = Object.keys(pendingLabelState)
       .filter((key) => pendingLabelState[key].active)
       .map((key) => ({

--- a/src/components/Table/ColumnSelection/ColumnSelectionDrawerWrap.tsx
+++ b/src/components/Table/ColumnSelection/ColumnSelectionDrawerWrap.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { ClickOutsideWrapper } from '@grafana/ui';
 
@@ -40,6 +40,7 @@ export function getReorderColumn(setColumns: (cols: FieldNameMetaStore) => void)
 
 export function ColumnSelectionDrawerWrap() {
   const { columns, setColumns, setVisible, filteredColumns, setFilteredColumns } = useTableColumnContext();
+  const [searchValue, setSearchValue] = useState<string>('');
   const toggleColumn = (columnName: string) => {
     if (!columns || !(columnName in columns)) {
       console.warn('failed to get column', columns);
@@ -101,6 +102,7 @@ export function ColumnSelectionDrawerWrap() {
       }
 
       setFilteredColumns(pendingFilteredLabelState);
+      setSearchValue('');
     }
   };
 
@@ -119,6 +121,8 @@ export function ColumnSelectionDrawerWrap() {
     });
 
     setColumns(pendingLabelState);
+    setFilteredColumns(pendingLabelState);
+    setSearchValue('');
   };
 
   return (
@@ -126,10 +130,11 @@ export function ColumnSelectionDrawerWrap() {
       onClick={() => {
         setVisible(false);
         setFilteredColumns(columns);
+        setSearchValue('');
       }}
       useCapture={true}
     >
-      <LogsColumnSearch />
+      <LogsColumnSearch searchValue={searchValue} setSearchValue={setSearchValue} />
       <LogsTableMultiSelect
         toggleColumn={toggleColumn}
         filteredColumnsWithMeta={filteredColumns}

--- a/src/components/Table/ColumnSelection/LogsColumnSearch.tsx
+++ b/src/components/Table/ColumnSelection/LogsColumnSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -15,9 +15,13 @@ function getStyles(theme: GrafanaTheme2) {
     }),
   };
 }
-export function LogsColumnSearch() {
+
+interface LogsColumnSearchProps {
+  searchValue: string;
+  setSearchValue: (value: string) => void;
+}
+export function LogsColumnSearch({ searchValue, setSearchValue }: LogsColumnSearchProps) {
   const { columns, setFilteredColumns } = useTableColumnContext();
-  const [searchValue, setSearchValue] = useState<string>('');
 
   // uFuzzy search dispatcher, adds any matches to the local state
   const dispatcher = (data: string[][]) => {

--- a/src/components/Table/ColumnSelection/LogsTableAvailableFields.tsx
+++ b/src/components/Table/ColumnSelection/LogsTableAvailableFields.tsx
@@ -54,7 +54,7 @@ export const LogsTableAvailableFields = (props: {
   labels: Record<string, FieldNameMeta>;
   valueFilter: (value: string) => boolean;
   toggleColumn: (columnName: string) => void;
-}): JSX.Element => {
+}): React.ReactElement => {
   const { labels, valueFilter, toggleColumn } = props;
   const theme = useTheme2();
   const styles = getLogsFieldsStyles(theme);
@@ -63,7 +63,7 @@ export const LogsTableAvailableFields = (props: {
     // Otherwise show list with a hardcoded order
     return (
       <div className={styles.columnWrapper}>
-        {labelKeys.sort(sortLabels(labels)).map((labelName, index) => (
+        {labelKeys.sort(sortLabels(labels)).map((labelName) => (
           <div
             key={labelName}
             className={styles.wrap}

--- a/src/components/Table/LogLineCellComponent.tsx
+++ b/src/components/Table/LogLineCellComponent.tsx
@@ -12,6 +12,7 @@ import { LogLinePill } from '@/components/Table/LogLinePill';
 import { Scroller } from '@/components/Table/Scroller';
 import { css } from '@emotion/css';
 import { LineActionIcons } from '@/components/Table/LineActionIcons';
+import { DATAPLANE_BODY_NAME } from '@/services/logsFrame';
 
 export type SelectedTableRow = {
   row: number;
@@ -73,25 +74,27 @@ export const LogLineCellComponent = (props: Props) => {
    */
   const renderLabels = (labels: Labels, onClick: (label: string) => void, value: unknown) => {
     const columnLabelNames = Object.keys(columns);
-    const labelNames = columnLabelNames.sort((a, b) => {
-      // Sort level first
-      if (a === 'level') {
-        return -1;
-      }
-      if (b === 'level') {
-        return 1;
-      }
-      // Then sort links
-      if (columns[a].type === 'LINK_FIELD') {
-        return -1;
-      }
-      if (columns[b].type === 'LINK_FIELD') {
-        return 1;
-      }
+    const labelNames = columnLabelNames
+      .filter((name) => name !== DATAPLANE_BODY_NAME)
+      .sort((a, b) => {
+        // Sort level first
+        if (a === 'level') {
+          return -1;
+        }
+        if (b === 'level') {
+          return 1;
+        }
+        // Then sort links
+        if (columns[a].type === 'LINK_FIELD') {
+          return -1;
+        }
+        if (columns[b].type === 'LINK_FIELD') {
+          return 1;
+        }
 
-      // Finally sort fields by cardinality descending
-      return columns[a].cardinality > columns[b].cardinality ? -1 : 1;
-    });
+        // Finally sort fields by cardinality descending
+        return columns[a].cardinality > columns[b].cardinality ? -1 : 1;
+      });
 
     const filteredLabels = labelNames.filter(
       (label) =>

--- a/src/components/Table/LogLineCellComponent.tsx
+++ b/src/components/Table/LogLineCellComponent.tsx
@@ -13,6 +13,7 @@ import { Scroller } from '@/components/Table/Scroller';
 import { css } from '@emotion/css';
 import { LineActionIcons } from '@/components/Table/LineActionIcons';
 import { DATAPLANE_BODY_NAME } from '@/services/logsFrame';
+import { RawLogLineText } from '@/components/Table/RawLogLineText';
 
 export type SelectedTableRow = {
   row: number;
@@ -22,14 +23,6 @@ export type SelectedTableRow = {
 interface Props extends CustomCellRendererProps {
   labels: Labels;
   fieldIndex: number;
-}
-
-function RawLogLineText(props: { styles: { rawLogLine: string; content: string }; value: unknown }) {
-  return (
-    <div className={props.styles.rawLogLine}>
-      <>{props.value}</>
-    </div>
-  );
 }
 export const LogLineCellComponent = (props: Props) => {
   let value = props.value;
@@ -161,11 +154,11 @@ export const LogLineCellComponent = (props: Props) => {
           {/* Labels */}
           {isAuto && hasLabels && <>{labels}</>}
           {bodyState === LogLineState.labels && hasLabels && <>{labels}</>}
-          {bodyState === LogLineState.labels && !hasLabels && <div className={styles.rawLogLine}>No unique labels</div>}
+          {bodyState === LogLineState.labels && !hasLabels && <RawLogLineText value={'No unique labels'} />}
 
           {/* Raw log line*/}
-          {isAuto && !hasLabels && <RawLogLineText styles={styles} value={value} />}
-          {bodyState === LogLineState.text && <RawLogLineText styles={styles} value={value} />}
+          {isAuto && !hasLabels && <RawLogLineText value={value} />}
+          {bodyState === LogLineState.text && <RawLogLineText value={value} />}
 
           {isHover && <Scroller scrollerRef={ref} />}
         </div>
@@ -175,14 +168,6 @@ export const LogLineCellComponent = (props: Props) => {
 };
 
 export const getStyles = (theme: GrafanaTheme2, bgColor?: string) => ({
-  rawLogLine: css({
-    fontFamily: theme.typography.fontFamilyMonospace,
-    height: '35px',
-    lineHeight: '35px',
-    paddingRight: theme.spacing(1.5),
-    paddingLeft: theme.spacing(1),
-    fontSize: theme.typography.bodySmall.fontSize,
-  }),
   content: css`
     white-space: nowrap;
     overflow-x: auto;

--- a/src/components/Table/LogLineCellComponent.tsx
+++ b/src/components/Table/LogLineCellComponent.tsx
@@ -38,7 +38,7 @@ export const LogLineCellComponent = (props: Props) => {
   const theme = useTheme2();
   const bgColor = getBgColorForCell(props);
   const styles = getStyles(theme, bgColor);
-  const { setColumns, columns, setVisible, bodyState } = useTableColumnContext();
+  const { columns, setVisible, bodyState } = useTableColumnContext();
   const { logsFrame } = useQueryContext();
   const [isHover, setIsHover] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
@@ -51,28 +51,11 @@ export const LogLineCellComponent = (props: Props) => {
     value = formattedValueToString(displayValue);
   }
 
-  const onClick = (label: string) => {
-    const pendingColumns = { ...columns };
-
-    const length = Object.keys(columns).filter((c) => columns[c].active).length;
-    if (pendingColumns[label].active) {
-      pendingColumns[label].active = false;
-      pendingColumns[label].index = undefined;
-    } else {
-      pendingColumns[label].active = true;
-      pendingColumns[label].index = length;
-    }
-
-    setColumns(pendingColumns);
-  };
-
   /**
    * Render labels as log line pills
    * @param labels Label[]
-   * @param onClick
-   * @param value raw log line
    */
-  const renderLabels = (labels: Labels, onClick: (label: string) => void, value: unknown) => {
+  const renderLabels = (labels: Labels) => {
     const columnLabelNames = Object.keys(columns);
     const labelNames = columnLabelNames
       .filter((name) => name !== DATAPLANE_BODY_NAME)
@@ -111,6 +94,7 @@ export const LogLineCellComponent = (props: Props) => {
         const rawValue = field?.values[props.rowIndex];
         const isDerived = !labelValue && !!rawValue;
 
+        // @todo This is confusing and needs refactor
         if (labelValue) {
           return (
             <LogLinePill
@@ -124,10 +108,10 @@ export const LogLineCellComponent = (props: Props) => {
               label={label}
               isDerivedField={false}
               value={labelValue}
-              showColumn={onClick}
             />
           );
         }
+
         if (isDerived && untransformedField?.name) {
           const untransformedValue = untransformedField?.values[props.rowIndex];
           // are derived fields always strings?
@@ -145,7 +129,6 @@ export const LogLineCellComponent = (props: Props) => {
                 key={untransformedField.name}
                 label={untransformedField.name}
                 isDerivedField={true}
-                showColumn={onClick}
               />
             );
           }
@@ -156,7 +139,7 @@ export const LogLineCellComponent = (props: Props) => {
       .filter((v) => v);
   };
 
-  const labels = renderLabels(props.labels, onClick, props.value);
+  const labels = renderLabels(props.labels);
   const isAuto = bodyState === LogLineState.auto;
   const hasLabels = labels.length > 0;
 

--- a/src/components/Table/LogLineCellComponent.tsx
+++ b/src/components/Table/LogLineCellComponent.tsx
@@ -5,13 +5,13 @@ import { FieldType, formattedValueToString, GrafanaTheme2, Labels } from '@grafa
 import { CustomCellRendererProps, useTheme2 } from '@grafana/ui';
 
 import { useQueryContext } from '@/components/Context/QueryContext';
-import { useTableColumnContext } from '@/components/Context/TableColumnsContext';
+import { LogLineState, useTableColumnContext } from '@/components/Context/TableColumnsContext';
 import { getBgColorForCell } from '@/components/Table/DefaultCellComponent';
 import { DefaultCellWrapComponent } from '@/components/Table/DefaultCellWrapComponent';
 import { LogLinePill } from '@/components/Table/LogLinePill';
 import { Scroller } from '@/components/Table/Scroller';
-import { LineActionIcons } from '@/components/Table/LineActionIcons';
 import { css } from '@emotion/css';
+import { LineActionIcons } from '@/components/Table/LineActionIcons';
 
 export type SelectedTableRow = {
   row: number;
@@ -23,6 +23,13 @@ interface Props extends CustomCellRendererProps {
   fieldIndex: number;
 }
 
+function RawLogLineText(props: { styles: { rawLogLine: string; content: string }; value: unknown }) {
+  return (
+    <div className={props.styles.rawLogLine}>
+      <>{props.value}</>
+    </div>
+  );
+}
 export const LogLineCellComponent = (props: Props) => {
   let value = props.value;
   const field = props.field;
@@ -30,7 +37,7 @@ export const LogLineCellComponent = (props: Props) => {
   const theme = useTheme2();
   const bgColor = getBgColorForCell(props);
   const styles = getStyles(theme, bgColor);
-  const { setColumns, columns, setVisible } = useTableColumnContext();
+  const { setColumns, columns, setVisible, bodyState } = useTableColumnContext();
   const { logsFrame } = useQueryContext();
   const [isHover, setIsHover] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
@@ -45,6 +52,7 @@ export const LogLineCellComponent = (props: Props) => {
 
   const onClick = (label: string) => {
     const pendingColumns = { ...columns };
+
     const length = Object.keys(columns).filter((c) => columns[c].active).length;
     if (pendingColumns[label].active) {
       pendingColumns[label].active = false;
@@ -58,8 +66,7 @@ export const LogLineCellComponent = (props: Props) => {
   };
 
   /**
-   * What if we never even rendered the log line as written, and always re-created it using labels.
-   * Assuming we're always parsing our log line with logfmt, this should work? And give the UI more control in visualization and interaction?
+   * Render labels as log line pills
    * @param labels Label[]
    * @param onClick
    * @param value raw log line
@@ -94,63 +101,61 @@ export const LogLineCellComponent = (props: Props) => {
         columns[label].cardinality > 1
     );
 
-    if (!filteredLabels.length) {
-      return (
-        <div className={styles.rawLogLine}>
-          <>{value}</>
-        </div>
-      );
-    }
+    return filteredLabels
+      .map((label) => {
+        const labelValue = labels[label];
+        const untransformedField = logsFrame?.raw?.fields.find((field) => field.name === label);
+        const rawValue = field?.values[props.rowIndex];
+        const isDerived = !labelValue && !!rawValue;
 
-    return filteredLabels.map((label) => {
-      const labelValue = labels[label];
-      const untransformedField = logsFrame?.raw?.fields.find((field) => field.name === label);
-      const rawValue = field?.values[props.rowIndex];
-      const isDerived = !labelValue && !!rawValue;
-
-      if (labelValue) {
-        return (
-          <LogLinePill
-            originalFrame={undefined}
-            field={field}
-            columns={columns}
-            rowIndex={props.rowIndex}
-            frame={props.frame}
-            showColumns={() => setVisible(true)}
-            key={label}
-            label={label}
-            isDerivedField={false}
-            value={labelValue}
-            showColumn={onClick}
-          />
-        );
-      }
-      if (isDerived && untransformedField?.name) {
-        const untransformedValue = untransformedField?.values[props.rowIndex];
-        // are derived fields always strings?
-        if (untransformedField?.type === FieldType.string && untransformedValue) {
+        if (labelValue) {
           return (
             <LogLinePill
-              originalFrame={logsFrame?.raw}
-              originalField={untransformedField}
+              originalFrame={undefined}
               field={field}
-              value={untransformedValue}
               columns={columns}
               rowIndex={props.rowIndex}
               frame={props.frame}
               showColumns={() => setVisible(true)}
-              key={untransformedField.name}
-              label={untransformedField.name}
-              isDerivedField={true}
+              key={label}
+              label={label}
+              isDerivedField={false}
+              value={labelValue}
               showColumn={onClick}
             />
           );
         }
-      }
+        if (isDerived && untransformedField?.name) {
+          const untransformedValue = untransformedField?.values[props.rowIndex];
+          // are derived fields always strings?
+          if (untransformedField?.type === FieldType.string && untransformedValue) {
+            return (
+              <LogLinePill
+                originalFrame={logsFrame?.raw}
+                originalField={untransformedField}
+                field={field}
+                value={untransformedValue}
+                columns={columns}
+                rowIndex={props.rowIndex}
+                frame={props.frame}
+                showColumns={() => setVisible(true)}
+                key={untransformedField.name}
+                label={untransformedField.name}
+                isDerivedField={true}
+                showColumn={onClick}
+              />
+            );
+          }
+        }
 
-      return null;
-    });
+        return null;
+      })
+      .filter((v) => v);
   };
+
+  const labels = renderLabels(props.labels, onClick, props.value);
+  const isAuto = bodyState === LogLineState.auto;
+  const hasLabels = labels.length > 0;
 
   return (
     <DefaultCellWrapComponent
@@ -167,8 +172,14 @@ export const LogLineCellComponent = (props: Props) => {
         <div className={styles.content}>
           {/* First Field gets the icons */}
           {props.fieldIndex === 0 && <LineActionIcons rowIndex={props.rowIndex} value={value} />}
-          {/* @todo component*/}
-          <>{renderLabels(props.labels, onClick, props.value)}</>
+          {/* Labels */}
+          {isAuto && hasLabels && <>{labels}</>}
+          {bodyState === LogLineState.labels && hasLabels && <>{labels}</>}
+          {bodyState === LogLineState.labels && !hasLabels && <div className={styles.rawLogLine}>No unique labels</div>}
+
+          {/* Raw log line*/}
+          {isAuto && !hasLabels && <RawLogLineText styles={styles} value={value} />}
+          {bodyState === LogLineState.text && <RawLogLineText styles={styles} value={value} />}
 
           {isHover && <Scroller scrollerRef={ref} />}
         </div>

--- a/src/components/Table/LogsTableHeaderWrap.tsx
+++ b/src/components/Table/LogsTableHeaderWrap.tsx
@@ -87,7 +87,12 @@ export function LogsTableHeaderWrap(props: {
               }
             }}
           >
-            <Icon name={'text-fields'} size={'xl'} />
+            {bodyState === LogLineState.text ? (
+              <Icon name={'brackets-curly'} size={'xl'} />
+            ) : (
+              <Icon name={'text-fields'} size={'xl'} />
+            )}
+
             {bodyState === LogLineState.text ? 'Show labels' : 'Show log text'}
           </a>
         </div>

--- a/src/components/Table/LogsTableHeaderWrap.tsx
+++ b/src/components/Table/LogsTableHeaderWrap.tsx
@@ -3,11 +3,12 @@ import { FieldNameMetaStore } from '@/components/Table/TableTypes';
 import { useTableHeaderContext } from '@/components/Context/TableHeaderContext';
 import { useTableColumnContext } from '@/components/Context/TableColumnsContext';
 import { Icon } from '@grafana/ui';
-import React from 'react';
+import React, { useCallback } from 'react';
+import { Field } from '@grafana/data';
 
 export function LogsTableHeaderWrap(props: {
   headerProps: LogsTableHeaderProps;
-  removeColumn: () => void;
+  // removeColumn: () => void;
   openColumnManagementDrawer: () => void;
 
   // Moves the current column forward or backward one index
@@ -15,12 +16,21 @@ export function LogsTableHeaderWrap(props: {
   slideRight: (cols: FieldNameMetaStore) => void;
 }) {
   const { setHeaderMenuActive } = useTableHeaderContext();
-  const { columns } = useTableColumnContext();
+  const { columns, setColumns } = useTableColumnContext();
+
+  const hideColumn = useCallback(
+    (field: Field) => {
+      const pendingColumnState = { ...columns };
+      pendingColumnState[field.name].active = false;
+      setColumns(pendingColumnState);
+    },
+    [columns, setColumns]
+  );
 
   return (
     <LogsTableHeader {...props.headerProps}>
       <div>
-        <a onClick={props.removeColumn}>
+        <a onClick={() => hideColumn(props.headerProps.field)}>
           <Icon name={'minus'} size={'xl'} />
           Remove column
         </a>

--- a/src/components/Table/LogsTableHeaderWrap.tsx
+++ b/src/components/Table/LogsTableHeaderWrap.tsx
@@ -8,7 +8,6 @@ import { Field } from '@grafana/data';
 
 export function LogsTableHeaderWrap(props: {
   headerProps: LogsTableHeaderProps;
-  // removeColumn: () => void;
   openColumnManagementDrawer: () => void;
 
   // Moves the current column forward or backward one index

--- a/src/components/Table/RawLogLineText.tsx
+++ b/src/components/Table/RawLogLineText.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
+import { css } from '@emotion/css';
+import { useTheme2 } from '@grafana/ui';
+
+export function RawLogLineText(props: { value: unknown }) {
+  const theme = useTheme2();
+  const styles = getStyles(theme);
+  return (
+    <div className={styles.rawLogLine}>
+      <>{props.value}</>
+    </div>
+  );
+}
+
+export const getStyles = (theme: GrafanaTheme2, bgColor?: string) => ({
+  rawLogLine: css({
+    fontFamily: theme.typography.fontFamilyMonospace,
+    height: '35px',
+    lineHeight: '35px',
+    paddingRight: theme.spacing(1.5),
+    paddingLeft: theme.spacing(1),
+    fontSize: theme.typography.bodySmall.fontSize,
+  }),
+});

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -85,13 +85,6 @@ export const Table = (props: Props) => {
   const templateSrv = getTemplateSrv();
   const replace = useMemo(() => templateSrv.replace.bind(templateSrv), [templateSrv]);
 
-  const hideColumn = (field: Field) => {
-    const pendingColumnState = { ...columns };
-    pendingColumnState[field.name].active = false;
-
-    setColumns(pendingColumnState);
-  };
-
   const prepareTableFrame = useCallback(
     (frame: DataFrame): DataFrame => {
       if (!frame.length) {
@@ -126,9 +119,6 @@ export const Table = (props: Props) => {
               <TableHeaderContextProvider>
                 <LogsTableHeaderWrap
                   headerProps={{ ...props, fieldIndex: index }}
-                  removeColumn={() => {
-                    hideColumn(props.field);
-                  }}
                   openColumnManagementDrawer={() => setVisible(true)}
                   slideLeft={(cols: FieldNameMetaStore) => reorderColumn(cols, index, index + 1)}
                   slideRight={(cols: FieldNameMetaStore) => reorderColumn(cols, index, index - 1)}
@@ -149,7 +139,6 @@ export const Table = (props: Props) => {
     },
     // This function is building the table dataframe that will be transformed, even though the components within the dataframe (cells, headers) can mutate the dataframe!
     // If we try to update the dataframe whenever the columns are changed (which are rebuilt using this dataframe after being transformed), react will infinitely update frame -> columns -> frame -> ...
-    // Maybe
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [timeZone, theme, labels]
   );

--- a/src/components/Table/TableWrap.tsx
+++ b/src/components/Table/TableWrap.tsx
@@ -28,6 +28,8 @@ export type SpecialFieldsType = {
 // matches common ISO 8601
 const iso8601Regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3,})?(?:Z|[-+]\d{2}:?\d{2})$/;
 
+export const TABLE_COLUMNS_URL_PARAM = 'tableColumns';
+
 interface TableWrapProps {}
 
 const getStyles = (theme: GrafanaTheme2) => ({
@@ -46,11 +48,10 @@ export const TableWrap = (props: TableWrapProps) => {
   const timeZone = getTimeZone();
 
   // This function is called when we want to grab the column names that are currently stored in the URL.
-  // If we rely on the state being passed in from scenes we have to force a re-render of the entire table, which reverts any state not stored in scenes (modals, menus, column widths, etc)
-  // So instead we have to grab the current columns directly from the URL. This could lead to bugs,
+  // So instead we have to grab the current columns directly from the URL.
   const getColumnsFromProps = useCallback((fieldNames: FieldNameMetaStore) => {
     const searchParams = new URLSearchParams(location.search);
-    const tableColumnsRaw = searchParams.get('tableColumns');
+    const tableColumnsRaw = searchParams.get(TABLE_COLUMNS_URL_PARAM);
     const tableColumnsFromUrl: string[] = tableColumnsRaw ? JSON.parse(tableColumnsRaw) : [];
     const previouslySelected = tableColumnsFromUrl;
     if (previouslySelected?.length) {

--- a/src/components/Table/TableWrap.tsx
+++ b/src/components/Table/TableWrap.tsx
@@ -101,7 +101,7 @@ export const TableWrap = (props: TableWrapProps) => {
   return (
     <section className={styles.section}>
       <TableColumnContextProvider logsFrame={logsFrame} initialColumns={pendingLabelState}>
-        <Table logsFrame={logsFrame} timeZone={timeZone} height={height - 220} width={width - 50} labels={labels} />
+        <Table logsFrame={logsFrame} timeZone={timeZone} height={height - 270} width={width - 50} labels={labels} />
       </TableColumnContextProvider>
     </section>
   );


### PR DESCRIPTION
Syncing the selected columns between scenes and react was causing bugs, and scenes doesn't need to know which columns are selected within the react table. Using react router to manually set url state keeps viz specific logic out of scenes, and is easier to maintain