### PR TITLE
chore: explore context

### DIFF
--- a/src/context/ScenesContext.tsx
+++ b/src/context/ScenesContext.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, ReactNode, useEffect, useState } from 'react';
+import { SceneObjectState } from '@grafana/scenes';
+
+interface ScenesContextType {
+  sceneObject: any;
+  updateSceneObject: (update: Partial<SceneObjectState>) => void;
+}
+
+export const ScenesContext = createContext<ScenesContextType | undefined>(undefined);
+
+export const ScenesContextProvider = ({ children, sceneObject }: { children: ReactNode; sceneObject: any }) => {
+  const [state, setState] = useState<SceneObjectState>(sceneObject.state);
+
+  const updateSceneObject = (update: Partial<SceneObjectState>) => {
+    sceneObject.setState(update);
+  };
+
+  useEffect(() => {
+    const subscription = sceneObject.subscribeToState((newState: any, prevState: any) => {
+      setState({ ...newState });
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sceneObject, state]);
+
+  return <ScenesContext.Provider value={{ sceneObject: state, updateSceneObject }}>{children}</ScenesContext.Provider>;
+};

--- a/src/pages/Explore/LogExploration.tsx
+++ b/src/pages/Explore/LogExploration.tsx
@@ -413,7 +413,7 @@ function getStyles(theme: GrafanaTheme2) {
         // The wrapper of each filter
         '& > div': {
           // the 'service_name' filter wrapper
-          '&:nth-child(2) > div':{
+          '&:nth-child(2) > div': {
             gap: 0,
           },
           // The actual inputs container

--- a/src/pages/Explore/LogExplorationPage.tsx
+++ b/src/pages/Explore/LogExplorationPage.tsx
@@ -2,11 +2,14 @@ import React, { useEffect, useState } from 'react';
 import { newLogsExploration } from '../../utils/utils';
 import { LogExploration } from './LogExploration';
 import { getUrlSyncManager } from '@grafana/scenes';
-
+import { ScenesContextProvider } from '../../context/ScenesContext';
 export const LogExplorationPage = () => {
   const [exploration] = useState(newLogsExploration());
-
-  return <LogExplorationView exploration={exploration} />;
+  return (
+    <ScenesContextProvider sceneObject={exploration}>
+      <LogExplorationView exploration={exploration} />;
+    </ScenesContextProvider>
+  );
 };
 
 export function LogExplorationView({ exploration }: { exploration: LogExploration }) {


### PR DESCRIPTION
### Description
This is a POC trying to figure out how to use react context with scene state. Most of the magic 🪄 happens in `ScenesContext.tsx` by dumping the Scenes state in there and constantly updating via subscriptions. The goal was to get() the latest scenes state into context and also set() scenes state through context. Right now everything is in scenes components, but ideally as an application grows a react component could import the context and update scenes through that.  

1. Context updates whenever scenes state updates and components seem to always get the latest ✅
2. I was able to update scenes state by cloning the class add the new state, however I could not repeat this magic with the time range. 🚫

Is there a better way people have found to mix scenes state and with larger app react context?

Go to [http://localhost:3000/a/grafana-lokiexplore-app/explore?logId=&var-fields=&var-filters=service_name%7C%3D%7Ctempo-distributor&var-ds=gdev-loki&var-patterns=&var-lineFilter=&mode=logs&actionView=logs&var-logsFormat=%20%7C%20logfmt](http://localhost:3000/a/grafana-lokiexplore-app/explore?logId=&var-fields=&var-filters=service_name%7C%3D%7Ctempo-distributor&var-ds=gdev-loki&var-patterns=&var-lineFilter=&mode=logs&actionView=logs&var-logsFormat=%20%7C%20logfmt) and click a tab 'labels', 'detected fieds', 'patterns' 
![Screenshot 2024-04-18 at 12 41 20 PM](https://github.com/grafana/explore-logs/assets/114438185/25c16a06-0cb1-44c4-ab5e-aac9e86c6b59)
The tab value changes when clicking on it by updating context
![Screenshot 2024-04-18 at 12 41 07 PM](https://github.com/grafana/explore-logs/assets/114438185/ce3a9fc7-b20d-42cd-8779-f7b736c8de44)

