### PR TITLE
fix: landing page wrap

### DIFF
--- a/src/Components/Index/ServiceSelectionComponent.tsx
+++ b/src/Components/Index/ServiceSelectionComponent.tsx
@@ -296,10 +296,16 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
         children: [
           new SceneFlexItem({
             width: '30%',
+            md: {
+              width: '100%',
+            },
             body: volumePanel,
           }),
           new SceneFlexItem({
             width: '70%',
+            md: {
+              width: '100%',
+            },
             body: logsPanel,
           }),
         ],


### PR DESCRIPTION
### Description
- #258 
Set the width to 100% in md breakpoint. Setting the height or minHeight did not seem to work, but it would have been nice to make them taller. 

![Screenshot 2024-04-22 at 2 54 25 PM](https://github.com/grafana/explore-logs/assets/114438185/87052671-42fb-4fa6-bf41-762c904eea1b)

- [Scenes breakpoints docs](https://github.com/grafana/scenes/pull/156/files#diff-0619e5bc001b9b055c71b89fc9f9f9638fb7373bdd5f9ceaeaa03161216f46e7)