### PR TITLE
feat: lazy load services

### DIFF
--- a/src/Components/Index/ServiceSelectionComponent.tsx
+++ b/src/Components/Index/ServiceSelectionComponent.tsx
@@ -208,7 +208,6 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
               transformations: [
                 () => (source: Observable<DataFrame[]>) => {
                   const favoriteServices = getFavoriteServicesFromStorage(ds);
-
                   return source.pipe(
                     map((data: DataFrame[]) => {
                       data.forEach((a) => reduceField({ field: a.fields[1], reducers: [ReducerID.max] }));
@@ -301,22 +300,18 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
     const logsPanel = PanelBuilders.logs().setData(logsQueryRunner).setOption('showTime', true).build();
 
     const layout = new SceneFlexItem({
-      body: new SceneFlexLayout({
-        height: '200px',
-        direction: 'row',
+      body: new SceneCSSGridLayout({
+        isLazy: true,
+        rowGap: 1,
+        columnGap: 1,
+        templateColumns: 'repeat(auto-fit, minmax(100px, 1fr) minmax(200px, 2fr))',
         children: [
           new SceneFlexItem({
-            width: '30%',
-            md: {
-              width: '100%',
-            },
+            height: '200px',
             body: volumePanel,
           }),
           new SceneFlexItem({
-            width: '70%',
-            md: {
-              width: '100%',
-            },
+            height: '200px',
             body: logsPanel,
           }),
         ],


### PR DESCRIPTION
### Description
- #248 

### Todo

- [ ] - Stack the layout in small
![Screenshot 2024-04-25 at 2 12 30 PM](https://github.com/grafana/explore-logs/assets/114438185/f56aa34c-1193-4db6-b173-9bc8d7f681fa)
- [ ] lazy load this ByLabelRepeater query `"sum by(service_name, level) (count_over_time({service_name=~\"tempo-ingester|tempo-distributor|nginx-json|httpd|mimir-ingester|mimir-querier|apache|mimir-distributor|nginx|mimir-ruler\"} | drop __error__ [$__auto]))"`
