### PR TITLE
chore: change GAR to `prod`

### DIFF
--- a/.github/workflows/build-generator.yml
+++ b/.github/workflows/build-generator.yml
@@ -36,4 +36,4 @@ jobs:
           tags: ${{ env.TAGS_CONFIG }}
           context: ./generator/
           image_name: 'fake-log-generator'
-          environment: 'dev'
+          environment: 'prod'


### PR DESCRIPTION
We won't use the `dev` environment for now. Going to destroy any allocated resources in a PR in deployment_tools.