### PR TITLE
chore: change to grafana's generator image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,5 +27,5 @@ services:
     command: -config.file=/etc/loki/local-config.yaml
     restart: on-failure
   generator:
-    image: svennergr/fake-logs-generator:main-c8d21cc
+    image: us-docker.pkg.dev/grafanalabs-global/docker-explore-logs-prod/fake-log-generator:latest
     command: -url http://loki:3100/loki/api/v1/push


### PR DESCRIPTION
We added CI to build and push the fake log generator. This PR updates the reference in the docker compose setup.

Fixes #215

How to test:

1. `docker compose pull`
2. `docker compose up`
3. Should still result in visible logs in the app.