### PR TITLE
fix: md layout stack

### DIFF
--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -174,6 +174,11 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
             isLazy: true,
             templateColumns: 'repeat(auto-fit, minmax(400px, 1fr) minmax(600px, 2fr))',
             autoRows: '200px',
+            md: {
+              templateColumns: '1fr',
+              rowGap: 1,
+              columnGap: 1,
+            },
           }),
         ],
       });


### PR DESCRIPTION
### Description
In an odd turn of events, probably do to @ivanahuckova refactor the md breakpoint stacks now.

### Test
![Screenshot 2024-05-01 at 9 04 30 AM](https://github.com/grafana/explore-logs/assets/114438185/b0bd44ee-0b36-449e-b400-3671c9e1a831)
