### PR TITLE
chore: refactor for readability

### DIFF
--- a/src/Components/LogExplorationPage.tsx
+++ b/src/Components/LogExplorationPage.tsx
@@ -1,11 +1,15 @@
 import React, { useEffect, useState } from 'react';
 
-import { getUrlSyncManager } from '@grafana/scenes';
-import { newLogsExploration } from 'services/scenes';
+import { SceneTimeRange, getUrlSyncManager } from '@grafana/scenes';
 import { IndexScene } from './IndexScene/IndexScene';
+const DEFAULT_TIME_RANGE = { from: 'now-15m', to: 'now' };
 
 export const LogExplorationPage = () => {
-  const [exploration] = useState(newLogsExploration());
+  const [exploration] = useState(
+    new IndexScene({
+      $timeRange: new SceneTimeRange(DEFAULT_TIME_RANGE),
+    })
+  );
 
   return <LogExplorationView exploration={exploration} />;
 };

--- a/src/Components/LogExplorationPage.tsx
+++ b/src/Components/LogExplorationPage.tsx
@@ -5,6 +5,7 @@ import { IndexScene } from './IndexScene/IndexScene';
 const DEFAULT_TIME_RANGE = { from: 'now-15m', to: 'now' };
 
 export const LogExplorationPage = () => {
+  // Here we are initializing the scene in here with the default time range
   const [exploration] = useState(
     new IndexScene({
       $timeRange: new SceneTimeRange(DEFAULT_TIME_RANGE),

--- a/src/Components/LogExplorationPage.tsx
+++ b/src/Components/LogExplorationPage.tsx
@@ -5,7 +5,7 @@ import { IndexScene } from './IndexScene/IndexScene';
 const DEFAULT_TIME_RANGE = { from: 'now-15m', to: 'now' };
 
 export const LogExplorationPage = () => {
-  // Here we are initializing the scene in here with the default time range
+  // Here we are initializing the scene with the default time range
   const [exploration] = useState(
     new IndexScene({
       $timeRange: new SceneTimeRange(DEFAULT_TIME_RANGE),

--- a/src/Components/ServiceSelectionScene/SelectFieldButton.tsx
+++ b/src/Components/ServiceSelectionScene/SelectFieldButton.tsx
@@ -12,7 +12,7 @@ import { VariableHide } from '@grafana/schema';
 
 import { addToFavoriteServicesInStorage } from 'services/store';
 import { VAR_DATASOURCE } from 'services/variables';
-import { StartingPointSelectedEvent } from './ServiceSelectionScene';
+import { SERVICE_NAME, StartingPointSelectedEvent } from './ServiceSelectionScene';
 
 export interface SelectFieldButtonState extends SceneObjectState {
   value: string;
@@ -33,7 +33,7 @@ export class SelectFieldButton extends SceneObjectBase<SelectFieldButtonState> {
       filters: [
         ...variable.state.filters,
         {
-          key: 'service_name',
+          key: SERVICE_NAME,
           operator: '=',
           value: this.state.value,
         },

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -33,7 +33,7 @@ import { testIds } from 'services/testIds';
 import { SelectFieldButton } from './SelectFieldButton';
 import { GrotError } from '../GrotError';
 
-const SERVICE_NAME = 'service_name';
+export const SERVICE_NAME = 'service_name';
 
 interface ServiceSelectionComponentState extends SceneObjectState {
   // The body of the component

--- a/src/services/scenes.ts
+++ b/src/services/scenes.ts
@@ -6,7 +6,6 @@ import {
   sceneGraph,
   SceneObject,
   SceneObjectUrlValues,
-  SceneTimeRange,
 } from '@grafana/scenes';
 import { VAR_DATASOURCE_EXPR, LOG_STREAM_SELECTOR_EXPR, VAR_FILTERS, ALL_VARIABLE_VALUE } from './variables';
 import { EXPLORATIONS_ROUTE } from './routing';
@@ -15,14 +14,6 @@ import { IndexScene } from 'Components/IndexScene/IndexScene';
 export function getExplorationFor(model: SceneObject): IndexScene {
   return sceneGraph.getAncestor(model, IndexScene);
 }
-
-export function newLogsExploration(initialDS?: string): IndexScene {
-  return new IndexScene({
-    initialDS,
-    $timeRange: new SceneTimeRange({ from: 'now-15m', to: 'now' }),
-  });
-}
-
 export function getUrlForExploration(exploration: IndexScene) {
   const params = getUrlSyncManager().getUrlState(exploration);
   return getUrlForValues(params);


### PR DESCRIPTION
1. In my case, using `newLogsExploration()` in `LogExplorationPage` have made readability/understandability of code much harder. `newLogsExploration` is just a wrapper over creating a new `IndexScene` and we are not even using `initialDS` - so that can be removed. I think it should be very obvious in code where we are creating scene and not hidden in services folder. 


```

export function newLogsExploration(initialDS?: string): IndexScene {
  return new IndexScene({
    initialDS,
    $timeRange: new SceneTimeRange({ from: 'now-15m', to: 'now' }),
  });
}
```

2. Fixing keeping `SERVICE_NAME` in sync between querying for values and then creating new query when selecting service. 