### PR TITLE
fix: remove bug when filters were applied when going to service search scene

### DIFF
--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -4,6 +4,7 @@ import { debounce } from 'lodash';
 
 import { BusEventBase, GrafanaTheme2 } from '@grafana/data';
 import {
+  AdHocFiltersVariable,
   PanelBuilders,
   SceneComponentProps,
   SceneCSSGridLayout,
@@ -26,7 +27,7 @@ import {
   Text,
   TextLink,
 } from '@grafana/ui';
-import { explorationDS, VAR_DATASOURCE } from 'services/variables';
+import { explorationDS, VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
 import { getLokiDatasource } from 'services/scenes';
 import { getFavoriteServicesFromStorage } from 'services/store';
 import { testIds } from 'services/testIds';
@@ -78,6 +79,13 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
   }
 
   private _onActivate() {
+    // Clear all adhoc filters when the scene is activated, if there are any
+    const variable = sceneGraph.lookupVariable(VAR_FILTERS, this);
+    if (variable instanceof AdHocFiltersVariable && variable.state.filters.length > 0) {
+      variable.setState({
+        filters: [],
+      });
+    }
     this._getServicesByVolume();
     this.subscribeToState((newState, oldState) => {
       // Updates servicesToQuery when servicesByVolume is changed - should happen only once when the list of services is fetched during initialization

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -27,7 +27,7 @@ import {
   Text,
   TextLink,
 } from '@grafana/ui';
-import { explorationDS, VAR_DATASOURCE } from 'services/variables';
+import { explorationDS, VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
 import { getLokiDatasource } from 'services/scenes';
 import { getFavoriteServicesFromStorage } from 'services/store';
 import { testIds } from 'services/testIds';

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -27,7 +27,7 @@ import {
   Text,
   TextLink,
 } from '@grafana/ui';
-import { explorationDS, VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
+import { explorationDS, VAR_DATASOURCE } from 'services/variables';
 import { getLokiDatasource } from 'services/scenes';
 import { getFavoriteServicesFromStorage } from 'services/store';
 import { testIds } from 'services/testIds';


### PR DESCRIPTION
Brings back code removed in https://github.com/grafana/explore-logs/pull/266/files. But instead of just removing SERVICE_NAME filters, we want to remove all. I tried to see if I can find a way to remove it somewhere else, but I couldn't. So I just brought this back :( 

https://github.com/grafana/explore-logs/assets/30407135/b49a3ded-2c9c-4c6a-aa2f-d13891a42dfd

<img width="865" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/373148cc-d3f0-43e0-a1a8-2c00b0ad707c">
