### PR TITLE
chore: clean up index scene and refactor

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -51,7 +51,7 @@ export interface IndexSceneState extends SceneObjectState {
   // mode is the current mode of the index scene - it can be either 'start' for service selection or 'logs' for service
   mode?: LogExplorationMode;
   initialFilters?: AdHocVariableFilter[];
-
+  initialDS?: string;
   patterns?: AppliedPattern[];
 }
 
@@ -61,7 +61,8 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
   public constructor(state: Partial<IndexSceneState>) {
     super({
       $timeRange: state.$timeRange ?? new SceneTimeRange({}),
-      $variables: state.$variables ?? getVariableSet(getLastUsedDataSourceFromStorage(), state.initialFilters),
+      $variables:
+        state.$variables ?? getVariableSet(state.initialDS ?? getLastUsedDataSourceFromStorage(), state.initialFilters),
       controls: state.controls ?? [
         new VariableValueSelectors({ layout: 'vertical' }),
         new SceneControlsSpacer(),

--- a/src/Components/IndexScene/PatternControls.tsx
+++ b/src/Components/IndexScene/PatternControls.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
+import { AppliedPattern } from './IndexScene';
+import { PatternTag } from './PatternTag';
+import { css } from '@emotion/css';
+import { useStyles2, Text } from '@grafana/ui';
+
+type Props = {
+  patterns: AppliedPattern[] | undefined;
+  onRemove: (patterns: AppliedPattern[]) => void;
+};
+export const PatternControls = ({ patterns, onRemove }: Props) => {
+  const styles = useStyles2(getStyles);
+
+  if (!patterns || patterns.length === 0) {
+    return null;
+  }
+
+  const includePatterns = patterns.filter((pattern) => pattern.type === 'include');
+  const excludePatterns = patterns.filter((pattern) => pattern.type !== 'include');
+
+  return (
+    <div>
+      {includePatterns.length > 0 && (
+        <div className={styles.patternsContainer}>
+          <Text variant="bodySmall" weight="bold">
+            {excludePatterns.length > 0 ? 'Include patterns' : 'Patterns'}
+          </Text>
+          <div className={styles.patterns}>
+            {includePatterns.map((p) => (
+              <PatternTag
+                key={p.pattern}
+                pattern={p.pattern}
+                onRemove={() => onRemove(patterns.filter((pat) => pat !== p))}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+      {excludePatterns.length > 0 && (
+        <div className={styles.patternsContainer}>
+          <Text variant="bodySmall" weight="bold">
+            Exclude patterns:
+          </Text>
+          <div className={styles.patterns}>
+            {excludePatterns.map((p) => (
+              <PatternTag
+                key={p.pattern}
+                pattern={p.pattern}
+                onRemove={() => onRemove(patterns.filter((pat) => pat !== p))}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    patternsContainer: css({
+      paddingBottom: theme.spacing(1),
+      overflow: 'hidden',
+    }),
+    patterns: css({
+      display: 'flex',
+      gap: theme.spacing(1),
+      alignItems: 'center',
+      flexWrap: 'wrap',
+    }),
+  };
+}

--- a/src/Components/IndexScene/PatternTag.tsx
+++ b/src/Components/IndexScene/PatternTag.tsx
@@ -4,12 +4,11 @@ import { GrafanaTheme2 } from '@grafana/data';
 import React, { useState } from 'react';
 
 interface Props {
-  type: 'include' | 'exclude';
   onRemove(): void;
   pattern: string;
 }
 
-export const Pattern = ({ type, onRemove, pattern }: Props) => {
+export const PatternTag = ({ onRemove, pattern }: Props) => {
   const styles = useStyles2(getStyles);
   const [expanded, setExpanded] = useState(false);
   return (

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -1,6 +1,7 @@
 import pluginJson from '../plugin.json';
 
 const SERVICES_LOCALSTORAGE_KEY = `${pluginJson.id}.services.favorite`;
+const DS_LOCALSTORAGE_KEY = `${pluginJson.id}.datasource`;
 
 // This should be a string, but we'll accept anything and return an empty array if it's not a string
 export function getFavoriteServicesFromStorage(dsKey: string | unknown): string[] {
@@ -47,4 +48,12 @@ export function addToFavoriteServicesInStorage(dsKey: string | unknown, serviceN
 
 function createServicesLocalStorageKey(ds: string) {
   return `${SERVICES_LOCALSTORAGE_KEY}_${ds}`;
+}
+
+export function getLastUsedDataSourceFromStorage(): string | undefined {
+  return localStorage.getItem(DS_LOCALSTORAGE_KEY) ?? undefined;
+}
+
+export function addLastUsedDataSourceToStorage(dsKey: string) {
+  localStorage.setItem(DS_LOCALSTORAGE_KEY, dsKey);
 }


### PR DESCRIPTION
This PR:
- Adds comments
- Removes state/props that we are not using - such as  `showDetails`
- `body` is not `SplitLayout` anymore as we are not using it. And instead it is `LogExplorationScene`
- moves getting/setting initial data source from local storage to `store`
- Removes following logic, that was initially there to add live tailing controls, which were removed and this is not doing anything anymore:

```
   if (this.state.mode !== undefined && this.state.mode !== 'start') {
      this.setState({
        controls: [...this.state.controls],
      });
    }
```
- Removes additional logic for hiding of variable. More context in https://raintank-corp.slack.com/archives/C05FWM2DN07/p1714668329748469?thread_ts=1714667212.714819&cid=C05FWM2DN07, but basically there might be an issue when variables are not hidden. However, we are not able to reproduce it/have steps to reproduce it. We talked with @matyax and @adrapereira and want to keep this YAGNI, so removed for now. Also we are always hiding label now - `hideLabel`, so that part of the logic doesn't even do anything, as this never changes
- Removes logic to render patterns to a separate component `PatternControls`
- Renames `Pattern` -> `PatternTag`