### PR TITLE
feat(query-tracking): add `supportingQueryType` header

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -35,6 +35,7 @@ import {
   explorationDS,
   LOG_STREAM_SELECTOR_EXPR,
 } from 'services/variables';
+import { PLUGIN_ID } from 'services/routing';
 
 export interface FieldsBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -305,6 +306,7 @@ function buildQuery(tagKey: string) {
   return {
     refId: 'A',
     expr: getExpr(tagKey),
+    supportingQueryType: PLUGIN_ID,
     queryType: 'range',
     editorMode: 'code',
     maxLines: 1000,

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -36,6 +36,7 @@ import {
   LOG_STREAM_SELECTOR_EXPR,
 } from 'services/variables';
 import { getLokiDatasource, getLabelOptions } from 'services/scenes';
+import { PLUGIN_ID } from 'services/routing';
 
 export interface LabelBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -228,6 +229,7 @@ function buildLabelsLayout(options: Array<SelectableValue<string>>) {
                 {
                   refId: 'A',
                   expr: getExpr(option.value),
+                  supportingQueryType: PLUGIN_ID,
                   legendFormat: `{{${option.label}}}`,
                 },
               ],
@@ -274,6 +276,7 @@ function buildQuery(tagKey: string) {
   return {
     refId: 'A',
     expr: getExpr(tagKey),
+    supportingQueryType: PLUGIN_ID,
     queryType: 'range',
     editorMode: 'code',
     maxLines: 1000,

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -14,6 +14,7 @@ import { DrawStyle, StackingMode } from '@grafana/ui';
 import { DataFrame } from '@grafana/data';
 import { map, Observable } from 'rxjs';
 import { LOG_STREAM_SELECTOR_EXPR, explorationDS } from 'services/variables';
+import { PLUGIN_ID } from 'services/routing';
 
 export interface LogsVolumePanelState extends SceneObjectState {
   panel?: SceneFlexLayout;
@@ -123,5 +124,6 @@ function buildQuery() {
     expr: `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__ [$__auto])) by (level)`,
     queryType: 'range',
     editorMode: 'code',
+    supportingQueryType: PLUGIN_ID,
   };
 }

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -24,7 +24,7 @@ import {
 import { Box, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 import { Unsubscribable } from 'rxjs';
 import { extractParserAndFieldsFromDataFrame, DetectedLabelsResponse } from 'services/fields';
-import { EXPLORATIONS_ROUTE } from 'services/routing';
+import { EXPLORATIONS_ROUTE, PLUGIN_ID } from 'services/routing';
 import { getLokiDatasource, getExplorationFor } from 'services/scenes';
 import {
   ALL_VARIABLE_VALUE,
@@ -423,6 +423,7 @@ function buildQuery() {
   return {
     refId: 'A',
     expr: LOG_STREAM_SELECTOR_EXPR,
+    supportingQueryType: PLUGIN_ID,
     queryType: 'range',
     editorMode: 'code',
     maxLines: 1000,

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -33,6 +33,7 @@ import { testIds } from 'services/testIds';
 import { explorationDS, VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
 import { GrotError } from '../GrotError';
 import { SelectFieldButton } from './SelectFieldButton';
+import { PLUGIN_ID } from 'services/routing';
 
 export const SERVICE_NAME = 'service_name';
 
@@ -328,6 +329,7 @@ function buildVolumeQuery(service: string) {
     expr: `sum by(level) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`,
     queryType: 'range',
     legendFormat: '{{level}}',
+    supportingQueryType: PLUGIN_ID,
   };
 }
 
@@ -335,6 +337,7 @@ function buildLogQuery(service: string) {
   return {
     refId: 'A',
     expr: `{${SERVICE_NAME}=\`${service}\`}`,
+    supportingQueryType: PLUGIN_ID,
     queryType: 'range',
     maxLines: 100,
   };

--- a/src/services/routing.ts
+++ b/src/services/routing.ts
@@ -1,6 +1,7 @@
 import pluginJson from '../plugin.json';
 
-export const PLUGIN_BASE_URL = `/a/${pluginJson.id}`;
+export const PLUGIN_ID = pluginJson.id;
+export const PLUGIN_BASE_URL = `/a/${PLUGIN_ID}`;
 
 export enum ROUTES {
   Explore = 'explore',


### PR DESCRIPTION
<img width="1454" alt="image" src="https://github.com/grafana/explore-logs/assets/8092184/6a1740e5-85fa-451f-bf74-a6dffe263652">

Adds the plugin ID as `supportingQueryType` header, which translates into the `X-Query-Tags` in Grafana, and then in the `source` label in Loki (see screenshot).

NB: this does only work for "queries" not for resource calls for now.