### PR TITLE
feat(query-tracking): add `X-Query-Tags` header to `volume`,`patterns`,`detected_labels`

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -109,11 +109,19 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     const timeRange = sceneGraph.getTimeRange(this).state.value;
     const filters = sceneGraph.lookupVariable(VAR_FILTERS, this)! as AdHocFiltersVariable;
 
-    const { detectedLabels } = await ds.getResource<DetectedLabelsResponse>('detected_labels', {
-      query: filters.state.filterExpression,
-      start: timeRange.from.utc().toISOString(),
-      end: timeRange.to.utc().toISOString(),
-    });
+    const { detectedLabels } = await ds.getResource<DetectedLabelsResponse>(
+      'detected_labels',
+      {
+        query: filters.state.filterExpression,
+        start: timeRange.from.utc().toISOString(),
+        end: timeRange.to.utc().toISOString(),
+      },
+      {
+        headers: {
+          'X-Query-Tags': `Source=${PLUGIN_ID}`,
+        },
+      }
+    );
 
     if (!detectedLabels || !Array.isArray(detectedLabels)) {
       return;

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -136,11 +136,19 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
     }
 
     try {
-      const volumeResponse = await ds.getResource!('index/volume', {
-        query: `{${SERVICE_NAME}=~".+"}`,
-        from: timeRange.from.utc().toISOString(),
-        to: timeRange.to.utc().toISOString(),
-      });
+      const volumeResponse = await ds.getResource!(
+        'index/volume',
+        {
+          query: `{${SERVICE_NAME}=~".+"}`,
+          from: timeRange.from.utc().toISOString(),
+          to: timeRange.to.utc().toISOString(),
+        },
+        {
+          headers: {
+            'X-Query-Tags': `Source=${PLUGIN_ID}`,
+          },
+        }
+      );
       const serviceMetrics: { [key: string]: number } = {};
       volumeResponse.data.result.forEach((item: any) => {
         const serviceName = item['metric'][SERVICE_NAME];


### PR DESCRIPTION
Sets the `X-Query-Tags` header to also track other APIs. Followup of https://github.com/grafana/explore-logs/pull/291

