### PR TITLE
feat: add analytics

### DIFF
--- a/src/Components/IndexScene/PatternControls.tsx
+++ b/src/Components/IndexScene/PatternControls.tsx
@@ -4,6 +4,7 @@ import { AppliedPattern } from './IndexScene';
 import { PatternTag } from './PatternTag';
 import { css } from '@emotion/css';
 import { useStyles2, Text } from '@grafana/ui';
+import { reportAppInteraction } from 'services/analytics';
 
 type Props = {
   patterns: AppliedPattern[] | undefined;
@@ -19,6 +20,15 @@ export const PatternControls = ({ patterns, onRemove }: Props) => {
   const includePatterns = patterns.filter((pattern) => pattern.type === 'include');
   const excludePatterns = patterns.filter((pattern) => pattern.type !== 'include');
 
+  const onRemovePattern = (pattern: AppliedPattern) => {
+    onRemove(patterns.filter((pat) => pat !== pattern));
+    reportAppInteraction('service_selection', 'pattern_removed', {
+      includePatternsLength: includePatterns.length - (pattern?.type === 'include' ? 1 : 0),
+      excludePatternsLength: excludePatterns.length - (pattern?.type !== 'include' ? 1 : 0),
+      type: pattern.type,
+    });
+  };
+
   return (
     <div>
       {includePatterns.length > 0 && (
@@ -28,11 +38,7 @@ export const PatternControls = ({ patterns, onRemove }: Props) => {
           </Text>
           <div className={styles.patterns}>
             {includePatterns.map((p) => (
-              <PatternTag
-                key={p.pattern}
-                pattern={p.pattern}
-                onRemove={() => onRemove(patterns.filter((pat) => pat !== p))}
-              />
+              <PatternTag key={p.pattern} pattern={p.pattern} onRemove={() => onRemovePattern(p)} />
             ))}
           </div>
         </div>
@@ -44,11 +50,7 @@ export const PatternControls = ({ patterns, onRemove }: Props) => {
           </Text>
           <div className={styles.patterns}>
             {excludePatterns.map((p) => (
-              <PatternTag
-                key={p.pattern}
-                pattern={p.pattern}
-                onRemove={() => onRemove(patterns.filter((pat) => pat !== p))}
-              />
+              <PatternTag key={p.pattern} pattern={p.pattern} onRemove={() => onRemovePattern(p)} />
             ))}
           </div>
         </div>

--- a/src/Components/IndexScene/PatternControls.tsx
+++ b/src/Components/IndexScene/PatternControls.tsx
@@ -4,7 +4,7 @@ import { AppliedPattern } from './IndexScene';
 import { PatternTag } from './PatternTag';
 import { css } from '@emotion/css';
 import { useStyles2, Text } from '@grafana/ui';
-import { reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
 
 type Props = {
   patterns: AppliedPattern[] | undefined;
@@ -22,7 +22,7 @@ export const PatternControls = ({ patterns, onRemove }: Props) => {
 
   const onRemovePattern = (pattern: AppliedPattern) => {
     onRemove(patterns.filter((pat) => pat !== pattern));
-    reportAppInteraction('service_selection', 'pattern_removed', {
+    reportAppInteraction(USER_EVENTS.pages.service_details, USER_EVENTS.actions.service_details.pattern_removed, {
       includePatternsLength: includePatterns.length - (pattern?.type === 'include' ? 1 : 0),
       excludePatternsLength: excludePatterns.length - (pattern?.type !== 'include' ? 1 : 0),
       type: pattern.type,

--- a/src/Components/IndexScene/PatternControls.tsx
+++ b/src/Components/IndexScene/PatternControls.tsx
@@ -4,7 +4,7 @@ import { AppliedPattern } from './IndexScene';
 import { PatternTag } from './PatternTag';
 import { css } from '@emotion/css';
 import { useStyles2, Text } from '@grafana/ui';
-import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 
 type Props = {
   patterns: AppliedPattern[] | undefined;
@@ -22,7 +22,7 @@ export const PatternControls = ({ patterns, onRemove }: Props) => {
 
   const onRemovePattern = (pattern: AppliedPattern) => {
     onRemove(patterns.filter((pat) => pat !== pattern));
-    reportAppInteraction(USER_EVENTS.pages.service_details, USER_EVENTS.actions.service_details.pattern_removed, {
+    reportAppInteraction(USER_EVENTS_PAGES.service_details, USER_EVENTS_ACTIONS.service_details.pattern_removed, {
       includePatternsLength: includePatterns.length - (pattern?.type === 'include' ? 1 : 0),
       excludePatternsLength: excludePatterns.length - (pattern?.type !== 'include' ? 1 : 0),
       type: pattern.type,

--- a/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
@@ -10,7 +10,7 @@ import {
 } from '@grafana/scenes';
 import { Button } from '@grafana/ui';
 import { VariableHide } from '@grafana/schema';
-import { reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
 
 export interface AddToFiltersGraphActionState extends SceneObjectState {
   frame: DataFrame;
@@ -50,12 +50,16 @@ export class AddToFiltersGraphAction extends SceneObjectBase<AddToFiltersGraphAc
       });
     }
 
-    reportAppInteraction('service_selection', 'add_to_filters', {
-      filterType: this.state.variableName,
-      key: labelName,
-      isFilterDuplicate,
-      filtersLength: variable.state.filters.length,
-    });
+    reportAppInteraction(
+      USER_EVENTS.pages.service_details,
+      USER_EVENTS.actions.service_details.add_to_filters_in_breakdown_clicked,
+      {
+        filterType: this.state.variableName,
+        key: labelName,
+        isFilterDuplicate,
+        filtersLength: variable.state.filters.length,
+      }
+    );
   };
 
   public static Component = ({ model }: SceneComponentProps<AddToFiltersGraphAction>) => {

--- a/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
@@ -10,7 +10,7 @@ import {
 } from '@grafana/scenes';
 import { Button } from '@grafana/ui';
 import { VariableHide } from '@grafana/schema';
-import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 
 export interface AddToFiltersGraphActionState extends SceneObjectState {
   frame: DataFrame;
@@ -51,8 +51,8 @@ export class AddToFiltersGraphAction extends SceneObjectBase<AddToFiltersGraphAc
     }
 
     reportAppInteraction(
-      USER_EVENTS.pages.service_details,
-      USER_EVENTS.actions.service_details.add_to_filters_in_breakdown_clicked,
+      USER_EVENTS_PAGES.service_details,
+      USER_EVENTS_ACTIONS.service_details.add_to_filters_in_breakdown_clicked,
       {
         filterType: this.state.variableName,
         key: labelName,

--- a/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
@@ -10,6 +10,7 @@ import {
 } from '@grafana/scenes';
 import { Button } from '@grafana/ui';
 import { VariableHide } from '@grafana/schema';
+import { reportAppInteraction } from 'services/analytics';
 
 export interface AddToFiltersGraphActionState extends SceneObjectState {
   frame: DataFrame;
@@ -48,6 +49,13 @@ export class AddToFiltersGraphAction extends SceneObjectBase<AddToFiltersGraphAc
         hide: VariableHide.hideLabel,
       });
     }
+
+    reportAppInteraction('service_selection', 'add_to_filters', {
+      filterType: this.state.variableName,
+      key: labelName,
+      isFilterDuplicate,
+      filtersLength: variable.state.filters.length,
+    });
   };
 
   public static Component = ({ model }: SceneComponentProps<AddToFiltersGraphAction>) => {

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -198,7 +198,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
         { value: 'grid', label: 'Grid' },
         { value: 'rows', label: 'Rows' },
       ],
-      viewName: 'fields',
+      actionView: 'fields',
       active: 'grid',
       layouts: [
         new SceneCSSGridLayout({
@@ -337,7 +337,7 @@ function buildNormalLayout(variable: CustomVariable) {
       maxDataPoints: 300,
       queries: [query],
     }),
-    viewName: 'fields',
+    actionView: 'fields',
     options: [
       { value: 'single', label: 'Single' },
       { value: 'grid', label: 'Grid' },

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -36,7 +36,7 @@ import {
   LOG_STREAM_SELECTOR_EXPR,
 } from 'services/variables';
 import { PLUGIN_ID } from 'services/routing';
-import { reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
 
 export interface FieldsBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -221,10 +221,15 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     }
 
     const variable = this.getVariable();
-    reportAppInteraction('service_selection', 'fields_view_field_selected', {
-      field: value,
-      previousField: variable.getValueText(),
-    });
+    reportAppInteraction(
+      USER_EVENTS.pages.service_details,
+      USER_EVENTS.actions.service_details.select_field_in_breakdown_clicked,
+      {
+        field: value,
+        previousField: variable.getValueText(),
+        view: 'fields',
+      }
+    );
 
     variable.changeValueTo(value);
   };

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -36,6 +36,7 @@ import {
   LOG_STREAM_SELECTOR_EXPR,
 } from 'services/variables';
 import { PLUGIN_ID } from 'services/routing';
+import { reportAppInteraction } from 'services/analytics';
 
 export interface FieldsBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -197,6 +198,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
         { value: 'grid', label: 'Grid' },
         { value: 'rows', label: 'Rows' },
       ],
+      viewName: 'fields',
       active: 'grid',
       layouts: [
         new SceneCSSGridLayout({
@@ -219,6 +221,10 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     }
 
     const variable = this.getVariable();
+    reportAppInteraction('service_selection', 'fields_view_field_selected', {
+      field: value,
+      previousField: variable.getValueText(),
+    });
 
     variable.changeValueTo(value);
   };
@@ -326,6 +332,7 @@ function buildNormalLayout(variable: CustomVariable) {
       maxDataPoints: 300,
       queries: [query],
     }),
+    viewName: 'fields',
     options: [
       { value: 'single', label: 'Single' },
       { value: 'grid', label: 'Grid' },

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -36,7 +36,7 @@ import {
   LOG_STREAM_SELECTOR_EXPR,
 } from 'services/variables';
 import { PLUGIN_ID } from 'services/routing';
-import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 
 export interface FieldsBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -222,8 +222,8 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
 
     const variable = this.getVariable();
     reportAppInteraction(
-      USER_EVENTS.pages.service_details,
-      USER_EVENTS.actions.service_details.select_field_in_breakdown_clicked,
+      USER_EVENTS_PAGES.service_details,
+      USER_EVENTS_ACTIONS.service_details.select_field_in_breakdown_clicked,
       {
         field: value,
         previousField: variable.getValueText(),

--- a/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { SceneObjectState, SceneObjectBase, SceneComponentProps, sceneGraph } from '@grafana/scenes';
 import { Button } from '@grafana/ui';
 import { IndexScene } from '../../IndexScene/IndexScene';
-import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 
 export interface FilterByPatternsButtonState extends SceneObjectState {
   pattern: string;
@@ -26,7 +26,7 @@ export class FilterByPatternsButton extends SceneObjectBase<FilterByPatternsButt
     // Analytics
     const includePatternsLength = filteredPatterns.filter((p) => p.type === 'include')?.length ?? 0;
     const excludePatternsLength = filteredPatterns.filter((p) => p.type === 'exclude')?.length ?? 0;
-    reportAppInteraction(USER_EVENTS.pages.service_details, USER_EVENTS.actions.service_details.pattern_selected, {
+    reportAppInteraction(USER_EVENTS_PAGES.service_details, USER_EVENTS_ACTIONS.service_details.pattern_selected, {
       type: this.state.type,
       includePatternsLength: includePatternsLength + (this.state.type === 'include' ? 1 : 0),
       excludePatternsLength: excludePatternsLength + (this.state.type === 'exclude' ? 1 : 0),

--- a/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { SceneObjectState, SceneObjectBase, SceneComponentProps, sceneGraph } from '@grafana/scenes';
 import { Button } from '@grafana/ui';
 import { IndexScene } from '../../IndexScene/IndexScene';
-import { reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
 
 export interface FilterByPatternsButtonState extends SceneObjectState {
   pattern: string;
@@ -26,7 +26,7 @@ export class FilterByPatternsButton extends SceneObjectBase<FilterByPatternsButt
     // Analytics
     const includePatternsLength = filteredPatterns.filter((p) => p.type === 'include')?.length ?? 0;
     const excludePatternsLength = filteredPatterns.filter((p) => p.type === 'exclude')?.length ?? 0;
-    reportAppInteraction('service_selection', 'patterns_filtered', {
+    reportAppInteraction(USER_EVENTS.pages.service_details, USER_EVENTS.actions.service_details.pattern_selected, {
       type: this.state.type,
       includePatternsLength: includePatternsLength + (this.state.type === 'include' ? 1 : 0),
       excludePatternsLength: excludePatternsLength + (this.state.type === 'exclude' ? 1 : 0),

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -37,7 +37,7 @@ import {
 } from 'services/variables';
 import { getLokiDatasource, getLabelOptions } from 'services/scenes';
 import { PLUGIN_ID } from 'services/routing';
-import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 
 export interface LabelBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -153,8 +153,8 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
 
     const variable = this.getVariable();
     reportAppInteraction(
-      USER_EVENTS.pages.service_details,
-      USER_EVENTS.actions.service_details.select_field_in_breakdown_clicked,
+      USER_EVENTS_PAGES.service_details,
+      USER_EVENTS_ACTIONS.service_details.select_field_in_breakdown_clicked,
       {
         label: value,
         previousLabel: variable.getValueText(),

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -37,6 +37,7 @@ import {
 } from 'services/variables';
 import { getLokiDatasource, getLabelOptions } from 'services/scenes';
 import { PLUGIN_ID } from 'services/routing';
+import { reportAppInteraction } from 'services/analytics';
 
 export interface LabelBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -143,6 +144,10 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     }
 
     const variable = this.getVariable();
+    reportAppInteraction('service_selection', 'labels_view_label_selected', {
+      label: value,
+      previousLabel: variable.getValueText(),
+    });
 
     variable.changeValueTo(value);
   };
@@ -253,6 +258,7 @@ function buildLabelsLayout(options: Array<SelectableValue<string>>) {
       { value: 'rows', label: 'Rows' },
     ],
     active: 'grid',
+    viewName: 'labels',
     layouts: [
       new SceneCSSGridLayout({
         templateColumns: GRID_TEMPLATE_COLUMNS,
@@ -313,6 +319,7 @@ function buildLabelValuesLayout(variable: CustomVariable) {
       { value: 'rows', label: 'Rows' },
     ],
     active: 'grid',
+    viewName: 'labels',
     layouts: [
       new SceneFlexLayout({
         direction: 'column',

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -37,7 +37,7 @@ import {
 } from 'services/variables';
 import { getLokiDatasource, getLabelOptions } from 'services/scenes';
 import { PLUGIN_ID } from 'services/routing';
-import { reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
 
 export interface LabelBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -152,10 +152,15 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     }
 
     const variable = this.getVariable();
-    reportAppInteraction('service_selection', 'labels_view_label_selected', {
-      label: value,
-      previousLabel: variable.getValueText(),
-    });
+    reportAppInteraction(
+      USER_EVENTS.pages.service_details,
+      USER_EVENTS.actions.service_details.select_field_in_breakdown_clicked,
+      {
+        label: value,
+        previousLabel: variable.getValueText(),
+        view: 'labels',
+      }
+    );
 
     variable.changeValueTo(value);
   };

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -271,7 +271,7 @@ function buildLabelsLayout(options: Array<SelectableValue<string>>) {
       { value: 'rows', label: 'Rows' },
     ],
     active: 'grid',
-    viewName: 'labels',
+    actionView: 'labels',
     layouts: [
       new SceneCSSGridLayout({
         templateColumns: GRID_TEMPLATE_COLUMNS,
@@ -332,7 +332,7 @@ function buildLabelValuesLayout(variable: CustomVariable) {
       { value: 'rows', label: 'Rows' },
     ],
     active: 'grid',
-    viewName: 'labels',
+    actionView: 'labels',
     layouts: [
       new SceneFlexLayout({
         direction: 'column',

--- a/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { SelectableValue } from '@grafana/data';
 import { SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Field, RadioButtonGroup } from '@grafana/ui';
-import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 
 export interface LayoutSwitcherState extends SceneObjectState {
   active: LayoutType;
@@ -27,7 +27,7 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> {
   }
 
   public onLayoutChange = (active: LayoutType) => {
-    reportAppInteraction(USER_EVENTS.pages.service_details, USER_EVENTS.actions.service_details.layout_type_changed, {
+    reportAppInteraction(USER_EVENTS_PAGES.service_details, USER_EVENTS_ACTIONS.service_details.layout_type_changed, {
       layout: active,
       view: this.state.viewName,
     });

--- a/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
@@ -3,11 +3,14 @@ import React from 'react';
 import { SelectableValue } from '@grafana/data';
 import { SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Field, RadioButtonGroup } from '@grafana/ui';
+import { reportAppInteraction } from 'services/analytics';
 
 export interface LayoutSwitcherState extends SceneObjectState {
   active: LayoutType;
   layouts: SceneObject[];
   options: Array<SelectableValue<LayoutType>>;
+  // used for analytics
+  viewName: 'labels' | 'fields' | 'logs' | 'patterns';
 }
 
 export type LayoutType = 'single' | 'grid' | 'rows';
@@ -24,6 +27,10 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> {
   }
 
   public onLayoutChange = (active: LayoutType) => {
+    reportAppInteraction('service_selection', 'layout_changed', {
+      layout: active,
+      view: this.state.viewName,
+    });
     this.setState({ active });
   };
 

--- a/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { SelectableValue } from '@grafana/data';
 import { SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Field, RadioButtonGroup } from '@grafana/ui';
-import { reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
 
 export interface LayoutSwitcherState extends SceneObjectState {
   active: LayoutType;
@@ -27,7 +27,7 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> {
   }
 
   public onLayoutChange = (active: LayoutType) => {
-    reportAppInteraction('service_selection', 'layout_changed', {
+    reportAppInteraction(USER_EVENTS.pages.service_details, USER_EVENTS.actions.service_details.layout_type_changed, {
       layout: active,
       view: this.state.viewName,
     });

--- a/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
@@ -4,13 +4,14 @@ import { SelectableValue } from '@grafana/data';
 import { SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Field, RadioButtonGroup } from '@grafana/ui';
 import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
+import { ActionViewType } from '../ServiceScene';
 
 export interface LayoutSwitcherState extends SceneObjectState {
   active: LayoutType;
   layouts: SceneObject[];
   options: Array<SelectableValue<LayoutType>>;
-  // used for analytics
-  viewName: 'labels' | 'fields' | 'logs' | 'patterns';
+  // actionView is used mainly for analytics
+  actionView: ActionViewType;
 }
 
 export type LayoutType = 'single' | 'grid' | 'rows';
@@ -29,7 +30,7 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> {
   public onLayoutChange = (active: LayoutType) => {
     reportAppInteraction(USER_EVENTS_PAGES.service_details, USER_EVENTS_ACTIONS.service_details.layout_type_changed, {
       layout: active,
-      view: this.state.viewName,
+      view: this.state.actionView,
     });
     this.setState({ active });
   };

--- a/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
@@ -174,7 +174,7 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
           { value: 'grid', label: 'Grid' },
           { value: 'rows', label: 'Rows' },
         ],
-        viewName: 'patterns',
+        actionView: 'patterns',
         active: 'grid',
         layouts: [
           new SceneCSSGridLayout({

--- a/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
@@ -174,6 +174,7 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
           { value: 'grid', label: 'Grid' },
           { value: 'rows', label: 'Rows' },
         ],
+        viewName: 'patterns',
         active: 'grid',
         layouts: [
           new SceneCSSGridLayout({

--- a/src/Components/ServiceScene/GoToExploreButton.tsx
+++ b/src/Components/ServiceScene/GoToExploreButton.tsx
@@ -9,14 +9,17 @@ import { VAR_LOGS_FORMAT_EXPR } from 'services/variables';
 import { getDataSource, getQueryExpr } from 'services/scenes';
 import { testIds } from 'services/testIds';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
-import { reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
 interface ShareExplorationButtonState {
   exploration: IndexScene;
 }
 
 export const GoToExploreButton = ({ exploration }: ShareExplorationButtonState) => {
   const onClick = () => {
-    reportAppInteraction('service_selection', 'open_in_explore_clicked');
+    reportAppInteraction(
+      USER_EVENTS.pages.service_details,
+      USER_EVENTS.actions.service_details.open_in_explore_clicked
+    );
     const datasource = getDataSource(exploration);
     const expr = getQueryExpr(exploration).replace(VAR_LOGS_FORMAT_EXPR, '').replace(/\s+/g, ' ').trimEnd();
     const timeRange = sceneGraph.getTimeRange(exploration).state.value;

--- a/src/Components/ServiceScene/GoToExploreButton.tsx
+++ b/src/Components/ServiceScene/GoToExploreButton.tsx
@@ -9,12 +9,14 @@ import { VAR_LOGS_FORMAT_EXPR } from 'services/variables';
 import { getDataSource, getQueryExpr } from 'services/scenes';
 import { testIds } from 'services/testIds';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
+import { reportAppInteraction } from 'services/analytics';
 interface ShareExplorationButtonState {
   exploration: IndexScene;
 }
 
 export const GoToExploreButton = ({ exploration }: ShareExplorationButtonState) => {
   const onClick = () => {
+    reportAppInteraction('service_selection', 'open_in_explore_clicked');
     const datasource = getDataSource(exploration);
     const expr = getQueryExpr(exploration).replace(VAR_LOGS_FORMAT_EXPR, '').replace(/\s+/g, ' ').trimEnd();
     const timeRange = sceneGraph.getTimeRange(exploration).state.value;

--- a/src/Components/ServiceScene/GoToExploreButton.tsx
+++ b/src/Components/ServiceScene/GoToExploreButton.tsx
@@ -9,7 +9,7 @@ import { VAR_LOGS_FORMAT_EXPR } from 'services/variables';
 import { getDataSource, getQueryExpr } from 'services/scenes';
 import { testIds } from 'services/testIds';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
-import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 interface ShareExplorationButtonState {
   exploration: IndexScene;
 }
@@ -17,8 +17,8 @@ interface ShareExplorationButtonState {
 export const GoToExploreButton = ({ exploration }: ShareExplorationButtonState) => {
   const onClick = () => {
     reportAppInteraction(
-      USER_EVENTS.pages.service_details,
-      USER_EVENTS.actions.service_details.open_in_explore_clicked
+      USER_EVENTS_PAGES.service_details,
+      USER_EVENTS_ACTIONS.service_details.open_in_explore_clicked
     );
     const datasource = getDataSource(exploration);
     const expr = getQueryExpr(exploration).replace(VAR_LOGS_FORMAT_EXPR, '').replace(/\s+/g, ' ').trimEnd();

--- a/src/Components/ServiceScene/LineFilter.tsx
+++ b/src/Components/ServiceScene/LineFilter.tsx
@@ -5,6 +5,7 @@ import { debounce } from 'lodash';
 import React, { ChangeEvent } from 'react';
 import { VAR_LINE_FILTER } from 'services/variables';
 import { testIds } from 'services/testIds';
+import { reportAppInteraction } from 'services/analytics';
 
 interface LineFilterState extends SceneObjectState {
   lineFilter: string;
@@ -50,6 +51,9 @@ export class LineFilter extends SceneObjectBase<LineFilterState> {
   updateVariable = debounce((search: string) => {
     const variable = this.getVariable();
     variable.changeValueTo(`|= \`${search}\``);
+    reportAppInteraction('service_selection', 'logs_view_search_changed', {
+      searchQuery: search,
+    });
   }, 350);
 }
 

--- a/src/Components/ServiceScene/LineFilter.tsx
+++ b/src/Components/ServiceScene/LineFilter.tsx
@@ -5,7 +5,7 @@ import { debounce } from 'lodash';
 import React, { ChangeEvent } from 'react';
 import { VAR_LINE_FILTER } from 'services/variables';
 import { testIds } from 'services/testIds';
-import { reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
 
 interface LineFilterState extends SceneObjectState {
   lineFilter: string;
@@ -51,9 +51,13 @@ export class LineFilter extends SceneObjectBase<LineFilterState> {
   updateVariable = debounce((search: string) => {
     const variable = this.getVariable();
     variable.changeValueTo(`|= \`${search}\``);
-    reportAppInteraction('service_selection', 'logs_view_search_changed', {
-      searchQuery: search,
-    });
+    reportAppInteraction(
+      USER_EVENTS.pages.service_details,
+      USER_EVENTS.actions.service_details.search_string_in_logs_changed,
+      {
+        searchQuery: search,
+      }
+    );
   }, 350);
 }
 

--- a/src/Components/ServiceScene/LineFilter.tsx
+++ b/src/Components/ServiceScene/LineFilter.tsx
@@ -5,7 +5,7 @@ import { debounce } from 'lodash';
 import React, { ChangeEvent } from 'react';
 import { VAR_LINE_FILTER } from 'services/variables';
 import { testIds } from 'services/testIds';
-import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 
 interface LineFilterState extends SceneObjectState {
   lineFilter: string;
@@ -52,8 +52,8 @@ export class LineFilter extends SceneObjectBase<LineFilterState> {
     const variable = this.getVariable();
     variable.changeValueTo(`|= \`${search}\``);
     reportAppInteraction(
-      USER_EVENTS.pages.service_details,
-      USER_EVENTS.actions.service_details.search_string_in_logs_changed,
+      USER_EVENTS_PAGES.service_details,
+      USER_EVENTS_ACTIONS.service_details.search_string_in_logs_changed,
       {
         searchQuery: search,
       }

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -46,14 +46,14 @@ import { buildLogsListScene } from './LogsListScene';
 import { buildLabelBreakdownActionScene } from './Breakdowns/LabelBreakdownScene';
 import { buildFieldsBreakdownActionScene } from './Breakdowns/FieldsBreakdownScene';
 import { buildPatternsScene } from './Breakdowns/PatternsBreakdownScene';
-import { reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
 
 interface LokiPattern {
   pattern: string;
   samples: Array<[number, string]>;
 }
 
-type ActionViewType = 'logs' | 'labels' | 'patterns' | 'fields' | 'traces' | 'relatedMetrics';
+type ActionViewType = 'logs' | 'labels' | 'patterns' | 'fields';
 
 interface ActionViewDefinition {
   displayName: string;
@@ -408,10 +408,14 @@ export class LogsActionBar extends SceneObjectBase<LogsActionBarState> {
                 counter={getCounter(tab)}
                 onChangeTab={() => {
                   if (tab.value !== logsScene.state.actionView) {
-                    reportAppInteraction('service_selection', 'action_view_changed', {
-                      newActionView: tab.value,
-                      previousActionView: logsScene.state.actionView,
-                    });
+                    reportAppInteraction(
+                      USER_EVENTS.pages.service_details,
+                      USER_EVENTS.actions.service_details.action_view_changed,
+                      {
+                        newActionView: tab.value,
+                        previousActionView: logsScene.state.actionView,
+                      }
+                    );
                     logsScene.setActionView(tab.value);
                   }
                 }}

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -53,7 +53,7 @@ interface LokiPattern {
   samples: Array<[number, string]>;
 }
 
-type ActionViewType = 'logs' | 'labels' | 'patterns' | 'fields';
+export type ActionViewType = 'logs' | 'labels' | 'patterns' | 'fields';
 
 interface ActionViewDefinition {
   displayName: string;

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -46,7 +46,7 @@ import { buildLogsListScene } from './LogsListScene';
 import { buildLabelBreakdownActionScene } from './Breakdowns/LabelBreakdownScene';
 import { buildFieldsBreakdownActionScene } from './Breakdowns/FieldsBreakdownScene';
 import { buildPatternsScene } from './Breakdowns/PatternsBreakdownScene';
-import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 
 interface LokiPattern {
   pattern: string;
@@ -409,8 +409,8 @@ export class LogsActionBar extends SceneObjectBase<LogsActionBarState> {
                 onChangeTab={() => {
                   if (tab.value !== logsScene.state.actionView) {
                     reportAppInteraction(
-                      USER_EVENTS.pages.service_details,
-                      USER_EVENTS.actions.service_details.action_view_changed,
+                      USER_EVENTS_PAGES.service_details,
+                      USER_EVENTS_ACTIONS.service_details.action_view_changed,
                       {
                         newActionView: tab.value,
                         previousActionView: logsScene.state.actionView,

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -46,6 +46,7 @@ import { buildLogsListScene } from './LogsListScene';
 import { buildLabelBreakdownActionScene } from './Breakdowns/LabelBreakdownScene';
 import { buildFieldsBreakdownActionScene } from './Breakdowns/FieldsBreakdownScene';
 import { buildPatternsScene } from './Breakdowns/PatternsBreakdownScene';
+import { reportAppInteraction } from 'services/analytics';
 
 interface LokiPattern {
   pattern: string;
@@ -392,6 +393,10 @@ export class LogsActionBar extends SceneObjectBase<LogsActionBarState> {
                 counter={getCounter(tab)}
                 onChangeTab={() => {
                   if (tab.value !== logsScene.state.actionView) {
+                    reportAppInteraction('service_selection', 'action_view_changed', {
+                      newActionView: tab.value,
+                      previousActionView: logsScene.state.actionView,
+                    });
                     logsScene.setActionView(tab.value);
                   }
                 }}

--- a/src/Components/ServiceScene/ShareExplorationButton.tsx
+++ b/src/Components/ServiceScene/ShareExplorationButton.tsx
@@ -7,7 +7,7 @@ import { config } from '@grafana/runtime';
 import { getUrlForExploration } from 'services/scenes';
 import { copyText } from 'services/text';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
-import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 
 interface ShareExplorationButtonState {
   exploration: IndexScene;
@@ -27,8 +27,8 @@ export const ShareExplorationButton = ({ exploration }: ShareExplorationButtonSt
     copyText(`${origin}${subUrl}${getUrlForExploration(exploration)}`, buttonRef);
     setTooltip('Copied!');
     reportAppInteraction(
-      USER_EVENTS.pages.service_details,
-      USER_EVENTS.actions.service_details.share_exploration_clicked
+      USER_EVENTS_PAGES.service_details,
+      USER_EVENTS_ACTIONS.service_details.share_exploration_clicked
     );
     setTimeout(() => {
       setTooltip('Copy url');

--- a/src/Components/ServiceScene/ShareExplorationButton.tsx
+++ b/src/Components/ServiceScene/ShareExplorationButton.tsx
@@ -7,6 +7,7 @@ import { config } from '@grafana/runtime';
 import { getUrlForExploration } from 'services/scenes';
 import { copyText } from 'services/text';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
+import { reportAppInteraction } from 'services/analytics';
 
 interface ShareExplorationButtonState {
   exploration: IndexScene;
@@ -25,6 +26,7 @@ export const ShareExplorationButton = ({ exploration }: ShareExplorationButtonSt
     const subUrl = config.appSubUrl ?? '';
     copyText(`${origin}${subUrl}${getUrlForExploration(exploration)}`, buttonRef);
     setTooltip('Copied!');
+    reportAppInteraction('service_selection', 'share_exploration_clicked');
     setTimeout(() => {
       setTooltip('Copy url');
     }, 2000);

--- a/src/Components/ServiceScene/ShareExplorationButton.tsx
+++ b/src/Components/ServiceScene/ShareExplorationButton.tsx
@@ -7,7 +7,7 @@ import { config } from '@grafana/runtime';
 import { getUrlForExploration } from 'services/scenes';
 import { copyText } from 'services/text';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
-import { reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
 
 interface ShareExplorationButtonState {
   exploration: IndexScene;
@@ -26,7 +26,10 @@ export const ShareExplorationButton = ({ exploration }: ShareExplorationButtonSt
     const subUrl = config.appSubUrl ?? '';
     copyText(`${origin}${subUrl}${getUrlForExploration(exploration)}`, buttonRef);
     setTooltip('Copied!');
-    reportAppInteraction('service_selection', 'share_exploration_clicked');
+    reportAppInteraction(
+      USER_EVENTS.pages.service_details,
+      USER_EVENTS.actions.service_details.share_exploration_clicked
+    );
     setTimeout(() => {
       setTooltip('Copy url');
     }, 2000);

--- a/src/Components/ServiceSelectionScene/SelectFieldButton.tsx
+++ b/src/Components/ServiceSelectionScene/SelectFieldButton.tsx
@@ -12,7 +12,7 @@ import { VariableHide } from '@grafana/schema';
 import { addToFavoriteServicesInStorage } from 'services/store';
 import { VAR_DATASOURCE } from 'services/variables';
 import { SERVICE_NAME, StartingPointSelectedEvent } from './ServiceSelectionScene';
-import { reportAppInteraction, USER_EVENTS } from 'services/analytics';
+import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 
 export interface SelectFieldButtonState extends SceneObjectState {
   value: string;
@@ -29,7 +29,7 @@ export class SelectFieldButton extends SceneObjectBase<SelectFieldButtonState> {
       return;
     }
 
-    reportAppInteraction(USER_EVENTS.pages.service_selection, USER_EVENTS.actions.service_selection.service_selected, {
+    reportAppInteraction(USER_EVENTS_PAGES.service_selection, USER_EVENTS_ACTIONS.service_selection.service_selected, {
       service: this.state.value,
     });
 

--- a/src/Components/ServiceSelectionScene/SelectFieldButton.tsx
+++ b/src/Components/ServiceSelectionScene/SelectFieldButton.tsx
@@ -9,10 +9,10 @@ import {
 } from '@grafana/scenes';
 import { Button } from '@grafana/ui';
 import { VariableHide } from '@grafana/schema';
-
 import { addToFavoriteServicesInStorage } from 'services/store';
 import { VAR_DATASOURCE } from 'services/variables';
 import { SERVICE_NAME, StartingPointSelectedEvent } from './ServiceSelectionScene';
+import { reportAppInteraction } from 'services/analytics';
 
 export interface SelectFieldButtonState extends SceneObjectState {
   value: string;
@@ -28,6 +28,10 @@ export class SelectFieldButton extends SceneObjectBase<SelectFieldButtonState> {
     if (!this.state.value) {
       return;
     }
+
+    reportAppInteraction('service_selection', 'service_selected', {
+      service: this.state.value,
+    });
 
     variable.setState({
       filters: [

--- a/src/Components/ServiceSelectionScene/SelectFieldButton.tsx
+++ b/src/Components/ServiceSelectionScene/SelectFieldButton.tsx
@@ -12,7 +12,7 @@ import { VariableHide } from '@grafana/schema';
 import { addToFavoriteServicesInStorage } from 'services/store';
 import { VAR_DATASOURCE } from 'services/variables';
 import { SERVICE_NAME, StartingPointSelectedEvent } from './ServiceSelectionScene';
-import { reportAppInteraction } from 'services/analytics';
+import { reportAppInteraction, USER_EVENTS } from 'services/analytics';
 
 export interface SelectFieldButtonState extends SceneObjectState {
   value: string;
@@ -29,7 +29,7 @@ export class SelectFieldButton extends SceneObjectBase<SelectFieldButtonState> {
       return;
     }
 
-    reportAppInteraction('service_selection', 'service_selected', {
+    reportAppInteraction(USER_EVENTS.pages.service_selection, USER_EVENTS.actions.service_selection.service_selected, {
       service: this.state.value,
     });
 

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/css';
 import { debounce } from 'lodash';
 import React, { useCallback, useState } from 'react';
-
 import { BusEventBase, GrafanaTheme2 } from '@grafana/data';
 import {
   AdHocFiltersVariable,
@@ -34,6 +33,7 @@ import { explorationDS, VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
 import { GrotError } from '../GrotError';
 import { SelectFieldButton } from './SelectFieldButton';
 import { PLUGIN_ID } from 'services/routing';
+import { reportAppInteraction } from 'services/analytics';
 
 export const SERVICE_NAME = 'service_name';
 
@@ -258,6 +258,9 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
   public onSearchServicesChange = debounce((serviceString: string) => {
     this.setState({
       searchServicesString: serviceString,
+    });
+    reportAppInteraction('service_selection', 'search_services_changed', {
+      searchQuery: serviceString,
     });
   }, 500);
 

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -33,7 +33,7 @@ import { explorationDS, VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
 import { GrotError } from '../GrotError';
 import { SelectFieldButton } from './SelectFieldButton';
 import { PLUGIN_ID } from 'services/routing';
-import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 
 export const SERVICE_NAME = 'service_name';
 
@@ -268,8 +268,8 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
       searchServicesString: serviceString,
     });
     reportAppInteraction(
-      USER_EVENTS.pages.service_selection,
-      USER_EVENTS.actions.service_selection.search_services_changed,
+      USER_EVENTS_PAGES.service_selection,
+      USER_EVENTS_ACTIONS.service_selection.search_services_changed,
       {
         searchQuery: serviceString,
       }

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -33,7 +33,7 @@ import { explorationDS, VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
 import { GrotError } from '../GrotError';
 import { SelectFieldButton } from './SelectFieldButton';
 import { PLUGIN_ID } from 'services/routing';
-import { reportAppInteraction } from 'services/analytics';
+import { USER_EVENTS, reportAppInteraction } from 'services/analytics';
 
 export const SERVICE_NAME = 'service_name';
 
@@ -267,9 +267,13 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
     this.setState({
       searchServicesString: serviceString,
     });
-    reportAppInteraction('service_selection', 'search_services_changed', {
-      searchQuery: serviceString,
-    });
+    reportAppInteraction(
+      USER_EVENTS.pages.service_selection,
+      USER_EVENTS.actions.service_selection.search_services_changed,
+      {
+        searchQuery: serviceString,
+      }
+    );
   }, 500);
 
   public static Component = ({ model }: SceneComponentProps<ServiceSelectionComponent>) => {

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,0 +1,16 @@
+import { reportInteraction } from '@grafana/runtime';
+import pluginJson from '../plugin.json';
+
+// Helper function to create a unique interaction name for analytics
+const createInteractionName = (page: 'service_selection' | 'service_details', action: string) => {
+  return `grafana_${pluginJson.id}_${page}_${action}`;
+};
+
+// Runs reportInteraction with a standardized interaction name
+export const reportAppInteraction = (
+  page: 'service_selection' | 'service_details',
+  action: string,
+  properties?: Record<string, unknown>
+) => {
+  reportInteraction(createInteractionName(page, action), properties);
+};

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -2,13 +2,12 @@ import { reportInteraction } from '@grafana/runtime';
 import pluginJson from '../plugin.json';
 
 // Helper function to create a unique interaction name for analytics
-// TODO: Type action parameter
 const createInteractionName = (page: UserEventPagesType, action: string) => {
   return `grafana_${pluginJson.id}_${page}_${action}`;
 };
 
 // Runs reportInteraction with a standardized interaction name
-// TODO: Type action parameter
+// TODO: Add better types for "action" to ensure that only USER_EVENTS_ACTIONS.page.action are used
 export const reportAppInteraction = (
   page: UserEventPagesType,
   action: string,

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -2,15 +2,45 @@ import { reportInteraction } from '@grafana/runtime';
 import pluginJson from '../plugin.json';
 
 // Helper function to create a unique interaction name for analytics
-const createInteractionName = (page: 'service_selection' | 'service_details', action: string) => {
+const createInteractionName = (page: string, action: string) => {
   return `grafana_${pluginJson.id}_${page}_${action}`;
 };
 
 // Runs reportInteraction with a standardized interaction name
-export const reportAppInteraction = (
-  page: 'service_selection' | 'service_details',
-  action: string,
-  properties?: Record<string, unknown>
-) => {
+export const reportAppInteraction = (page: string, action: string, properties?: Record<string, unknown>) => {
   reportInteraction(createInteractionName(page, action), properties);
+};
+
+export const USER_EVENTS = {
+  pages: {
+    service_selection: 'service_selection',
+    service_details: 'service_details',
+  },
+  // Actions per page
+  actions: {
+    service_selection: {
+      // Updating input field in search bar
+      search_services_changed: 'search_services_changed',
+      // Selecting a service from the list
+      service_selected: 'service_selected',
+    },
+    service_details: {
+      open_in_explore_clicked: 'open_in_explore_clicked',
+      share_exploration_clicked: 'share_exploration_clicked',
+      // Selecting action view tab (logs/labels/fields/patterns)
+      action_view_changed: 'action_view_changed',
+      // Clicking on "Add to filters" button in time series panels. Used in multiple views. The view type is passed as a parameter.
+      add_to_filters_in_breakdown_clicked: 'add_to_filters_in_breakdown_clicked',
+      // Clicking on "Select" button button in time series panels. Used in multiple views.The view type is passed as a parameter.
+      select_field_in_breakdown_clicked: 'select_field_in_breakdown_clicked',
+      // Changing layout type (e.g. single/grid/rows). Used in multiple views. The view type is passed as a parameter.
+      layout_type_changed: 'layout_type_changed',
+      // Changing search string in logs
+      search_string_in_logs_changed: 'search_string_changed',
+      // Removing pattern from selected pattern list
+      pattern_removed: 'pattern_removed',
+      // Selecting a pattern (e.g. include/exclude) from the list
+      pattern_selected: 'pattern_selected',
+    },
+  },
 };

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -2,45 +2,49 @@ import { reportInteraction } from '@grafana/runtime';
 import pluginJson from '../plugin.json';
 
 // Helper function to create a unique interaction name for analytics
-const createInteractionName = (page: string, action: string) => {
+// TODO: Type action parameter
+const createInteractionName = (page: UserEventPagesType, action: string) => {
   return `grafana_${pluginJson.id}_${page}_${action}`;
 };
 
 // Runs reportInteraction with a standardized interaction name
-export const reportAppInteraction = (page: string, action: string, properties?: Record<string, unknown>) => {
+// TODO: Type action parameter
+export const reportAppInteraction = (
+  page: UserEventPagesType,
+  action: string,
+  properties?: Record<string, unknown>
+) => {
   reportInteraction(createInteractionName(page, action), properties);
 };
 
-export const USER_EVENTS = {
-  pages: {
-    service_selection: 'service_selection',
-    service_details: 'service_details',
+export const USER_EVENTS_PAGES = {
+  service_selection: 'service_selection',
+  service_details: 'service_details',
+} as const;
+
+type UserEventPagesType = (typeof USER_EVENTS_PAGES)[keyof typeof USER_EVENTS_PAGES];
+
+export const USER_EVENTS_ACTIONS = {
+  [USER_EVENTS_PAGES.service_selection]: {
+    search_services_changed: 'search_services_changed',
+    service_selected: 'service_selected',
   },
-  // Actions per page
-  actions: {
-    service_selection: {
-      // Updating input field in search bar
-      search_services_changed: 'search_services_changed',
-      // Selecting a service from the list
-      service_selected: 'service_selected',
-    },
-    service_details: {
-      open_in_explore_clicked: 'open_in_explore_clicked',
-      share_exploration_clicked: 'share_exploration_clicked',
-      // Selecting action view tab (logs/labels/fields/patterns)
-      action_view_changed: 'action_view_changed',
-      // Clicking on "Add to filters" button in time series panels. Used in multiple views. The view type is passed as a parameter.
-      add_to_filters_in_breakdown_clicked: 'add_to_filters_in_breakdown_clicked',
-      // Clicking on "Select" button button in time series panels. Used in multiple views.The view type is passed as a parameter.
-      select_field_in_breakdown_clicked: 'select_field_in_breakdown_clicked',
-      // Changing layout type (e.g. single/grid/rows). Used in multiple views. The view type is passed as a parameter.
-      layout_type_changed: 'layout_type_changed',
-      // Changing search string in logs
-      search_string_in_logs_changed: 'search_string_changed',
-      // Removing pattern from selected pattern list
-      pattern_removed: 'pattern_removed',
-      // Selecting a pattern (e.g. include/exclude) from the list
-      pattern_selected: 'pattern_selected',
-    },
+  [USER_EVENTS_PAGES.service_details]: {
+    open_in_explore_clicked: 'open_in_explore_clicked',
+    share_exploration_clicked: 'share_exploration_clicked',
+    // Selecting action view tab (logs/labels/fields/patterns)
+    action_view_changed: 'action_view_changed',
+    // Clicking on "Add to filters" button in time series panels. Used in multiple views. The view type is passed as a parameter.
+    add_to_filters_in_breakdown_clicked: 'add_to_filters_in_breakdown_clicked',
+    // Clicking on "Select" button button in time series panels. Used in multiple views.The view type is passed as a parameter.
+    select_field_in_breakdown_clicked: 'select_field_in_breakdown_clicked',
+    // Changing layout type (e.g. single/grid/rows). Used in multiple views. The view type is passed as a parameter.
+    layout_type_changed: 'layout_type_changed',
+    // Changing search string in logs
+    search_string_in_logs_changed: 'search_string_in_logs_changed',
+    // Removing a pattern (e.g. include/exclude) from the list
+    pattern_removed: 'pattern_removed',
+    // Selecting a pattern (e.g. include/exclude) from the list
+    pattern_selected: 'pattern_selected',
   },
-};
+} as const;


### PR DESCRIPTION
This PR adds simple analytics for interactive elements - buttons, inputs.

I have created `reportAppInteraction = (page: 'service_selection' | 'service_details', action: string, properties?: Record<string, unknown>) => { reportInteraction(createInteractionName(page, action), properties);};` so we are aligned with events naming and also it makes it easier to test in the future (just adding console.log above `reportInteraction`). 

Fixes: https://github.com/grafana/explore-logs/issues/256
