### PR TITLE
chore: refactor query creation and have a single place where we create it

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -35,7 +35,7 @@ import {
   explorationDS,
   LOG_STREAM_SELECTOR_EXPR,
 } from 'services/variables';
-import { buildLogVolumeQuery } from 'services/query';
+import { buildLokiQuery } from 'services/query';
 
 export interface FieldsBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -154,7 +154,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
         continue;
       }
 
-      const query = buildLogVolumeQuery(getExpr(optionValue), {
+      const query = buildLokiQuery(getExpr(optionValue), {
         legendFormat: `{{${optionValue}}}`,
         refId: optionValue,
       });
@@ -304,7 +304,7 @@ const GRID_TEMPLATE_COLUMNS = 'repeat(auto-fit, minmax(400px, 1fr))';
 
 function buildNormalLayout(variable: CustomVariable) {
   const tagKey = variable.getValueText();
-  const query = buildLogVolumeQuery(getExpr(tagKey), { legendFormat: `{{${tagKey}}}` });
+  const query = buildLokiQuery(getExpr(tagKey), { legendFormat: `{{${tagKey}}}` });
 
   return new LayoutSwitcher({
     $data: new SceneQueryRunner({

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -149,25 +149,26 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     const children: SceneFlexItemLike[] = [];
 
     for (const option of options) {
-      if (option.value === ALL_VARIABLE_VALUE) {
+      const { value: optionValue } = option;
+      if (optionValue === ALL_VARIABLE_VALUE || !optionValue) {
         continue;
       }
 
-      const query = buildLogVolumeQuery(getExpr(option.value!), {
-        legendFormat: `{{${option.label}}}`,
-        refId: option.value!,
+      const query = buildLogVolumeQuery(getExpr(optionValue), {
+        legendFormat: `{{${optionValue}}}`,
+        refId: optionValue,
       });
       const queryRunner = new SceneQueryRunner({
         maxDataPoints: 300,
         datasource: explorationDS,
         queries: [query],
       });
-      let body = PanelBuilders.timeseries().setTitle(option.label!).setData(queryRunner);
+      let body = PanelBuilders.timeseries().setTitle(optionValue).setData(queryRunner);
 
-      if (!isAvgField(option.label ?? '')) {
+      if (!isAvgField(optionValue)) {
         // TODO hack
         body = body
-          .setHeaderActions(new SelectLabelAction({ labelName: String(option.value) }))
+          .setHeaderActions(new SelectLabelAction({ labelName: String(optionValue) }))
           .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
           .setCustomFieldConfig('fillOpacity', 100)
           .setCustomFieldConfig('lineWidth', 0)

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -222,23 +222,24 @@ function buildLabelsLayout(options: Array<SelectableValue<string>>) {
   const children: SceneFlexItemLike[] = [];
 
   for (const option of options) {
-    if (option.value === ALL_VARIABLE_VALUE || !option.value) {
+    const { value: optionValue } = option;
+    if (optionValue === ALL_VARIABLE_VALUE || !optionValue) {
       continue;
     }
 
     children.push(
       new SceneCSSGridItem({
         body: PanelBuilders.timeseries()
-          .setTitle(option.label!)
+          .setTitle(optionValue)
           .setData(
             new SceneQueryRunner({
               maxDataPoints: 300,
               datasource: explorationDS,
-              queries: [buildLogVolumeQuery(getExpr(option.value), { legendFormat: `{{${option.label}}}` })],
+              queries: [buildLogVolumeQuery(getExpr(optionValue), { legendFormat: `{{${optionValue}}}` })],
             })
           )
-          .setHeaderActions(new SelectLabelAction({ labelName: String(option.value) }))
-          .setHeaderActions(new SelectLabelAction({ labelName: String(option.value) }))
+          .setHeaderActions(new SelectLabelAction({ labelName: String(optionValue) }))
+          .setHeaderActions(new SelectLabelAction({ labelName: String(optionValue) }))
           .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
           .setCustomFieldConfig('fillOpacity', 100)
           .setCustomFieldConfig('lineWidth', 0)

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -37,7 +37,7 @@ import {
 } from 'services/variables';
 import { getLokiDatasource, getLabelOptions } from 'services/scenes';
 import { PLUGIN_ID } from 'services/routing';
-import { buildLogVolumeQuery } from 'services/query';
+import { buildLokiQuery } from 'services/query';
 
 export interface LabelBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -235,7 +235,7 @@ function buildLabelsLayout(options: Array<SelectableValue<string>>) {
             new SceneQueryRunner({
               maxDataPoints: 300,
               datasource: explorationDS,
-              queries: [buildLogVolumeQuery(getExpr(optionValue), { legendFormat: `{{${optionValue}}}` })],
+              queries: [buildLokiQuery(getExpr(optionValue), { legendFormat: `{{${optionValue}}}` })],
             })
           )
           .setHeaderActions(new SelectLabelAction({ labelName: String(optionValue) }))
@@ -279,7 +279,7 @@ const GRID_TEMPLATE_COLUMNS = 'repeat(auto-fit, minmax(400px, 1fr))';
 
 function buildLabelValuesLayout(variable: CustomVariable) {
   const tagKey = variable.getValueText();
-  const query = buildLogVolumeQuery(getExpr(tagKey), { legendFormat: `{{${tagKey}}}` });
+  const query = buildLokiQuery(getExpr(tagKey), { legendFormat: `{{${tagKey}}}` });
 
   let bodyOpts = PanelBuilders.timeseries();
   bodyOpts = bodyOpts

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -14,7 +14,7 @@ import { DrawStyle, StackingMode } from '@grafana/ui';
 import { DataFrame } from '@grafana/data';
 import { map, Observable } from 'rxjs';
 import { LOG_STREAM_SELECTOR_EXPR, explorationDS } from 'services/variables';
-import { buildLogVolumeQuery } from 'services/query';
+import { buildLokiQuery } from 'services/query';
 
 export interface LogsVolumePanelState extends SceneObjectState {
   panel?: SceneFlexLayout;
@@ -48,8 +48,9 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
                 $data: new SceneQueryRunner({
                   datasource: explorationDS,
                   queries: [
-                    buildLogVolumeQuery(
-                      `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__ [$__auto])) by (level)`
+                    buildLokiQuery(
+                      `sum by (level) (count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__ [$__auto]))`,
+                      { legendFormat: '{{level}}' }
                     ),
                   ],
                 }),

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -46,6 +46,7 @@ import { buildLogsListScene } from './LogsListScene';
 import { buildLabelBreakdownActionScene } from './Breakdowns/LabelBreakdownScene';
 import { buildFieldsBreakdownActionScene } from './Breakdowns/FieldsBreakdownScene';
 import { buildPatternsScene } from './Breakdowns/PatternsBreakdownScene';
+import { buildLogQuery } from 'services/query';
 
 interface LokiPattern {
   pattern: string;
@@ -88,7 +89,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
         new SceneVariableSet({ variables: [new CustomVariable({ name: VAR_LOGS_FORMAT, value: '' })] }),
       $data: new SceneQueryRunner({
         datasource: explorationDS,
-        queries: [buildQuery()],
+        queries: [buildLogQuery(LOG_STREAM_SELECTOR_EXPR)],
       }),
       ...state,
     });
@@ -433,17 +434,6 @@ function getStyles(theme: GrafanaTheme2) {
 
 const MAIN_PANEL_MIN_HEIGHT = 200;
 const MAIN_PANEL_MAX_HEIGHT = '30%';
-
-function buildQuery() {
-  return {
-    refId: 'A',
-    expr: LOG_STREAM_SELECTOR_EXPR,
-    supportingQueryType: PLUGIN_ID,
-    queryType: 'range',
-    editorMode: 'code',
-    maxLines: 1000,
-  };
-}
 
 function buildGraphScene() {
   return new SceneFlexLayout({

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -46,7 +46,7 @@ import { buildLogsListScene } from './LogsListScene';
 import { buildLabelBreakdownActionScene } from './Breakdowns/LabelBreakdownScene';
 import { buildFieldsBreakdownActionScene } from './Breakdowns/FieldsBreakdownScene';
 import { buildPatternsScene } from './Breakdowns/PatternsBreakdownScene';
-import { buildLogQuery } from 'services/query';
+import { buildLokiQuery } from 'services/query';
 
 interface LokiPattern {
   pattern: string;
@@ -89,7 +89,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
         new SceneVariableSet({ variables: [new CustomVariable({ name: VAR_LOGS_FORMAT, value: '' })] }),
       $data: new SceneQueryRunner({
         datasource: explorationDS,
-        queries: [buildLogQuery(LOG_STREAM_SELECTOR_EXPR)],
+        queries: [buildLokiQuery(LOG_STREAM_SELECTOR_EXPR)],
       }),
       ...state,
     });

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -34,7 +34,7 @@ import { explorationDS, VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
 import { GrotError } from '../GrotError';
 import { SelectFieldButton } from './SelectFieldButton';
 import { PLUGIN_ID } from 'services/routing';
-import { buildLogQuery, buildLogVolumeQuery } from 'services/query';
+import { buildLokiQuery } from 'services/query';
 
 export const SERVICE_NAME = 'service_name';
 
@@ -214,8 +214,9 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
             datasource: explorationDS,
             queries: [
               // Volume of logs for service grouped by level
-              buildLogVolumeQuery(
-                `sum by(level) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`
+              buildLokiQuery(
+                `sum by(level) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`,
+                { legendFormat: '{{level}}' }
               ),
             ],
           })
@@ -256,7 +257,7 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
         .setData(
           new SceneQueryRunner({
             datasource: explorationDS,
-            queries: [buildLogQuery(`{${SERVICE_NAME}=\`${service}\`}`, { maxLines: 100 })],
+            queries: [buildLokiQuery(`{${SERVICE_NAME}=\`${service}\`}`, { maxLines: 100 })],
           })
         )
         .setOption('showTime', true)

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -34,6 +34,7 @@ import { explorationDS, VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
 import { GrotError } from '../GrotError';
 import { SelectFieldButton } from './SelectFieldButton';
 import { PLUGIN_ID } from 'services/routing';
+import { buildLogQuery, buildLogVolumeQuery } from 'services/query';
 
 export const SERVICE_NAME = 'service_name';
 
@@ -213,7 +214,9 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
             datasource: explorationDS,
             queries: [
               // Volume of logs for service grouped by level
-              buildVolumeQuery(service),
+              buildLogVolumeQuery(
+                `sum by(level) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`
+              ),
             ],
           })
         )
@@ -253,7 +256,7 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
         .setData(
           new SceneQueryRunner({
             datasource: explorationDS,
-            queries: [buildLogQuery(service)],
+            queries: [buildLogQuery(`{${SERVICE_NAME}=\`${service}\`}`, { maxLines: 100 })],
           })
         )
         .setOption('showTime', true)
@@ -328,26 +331,6 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
         </div>
       </div>
     );
-  };
-}
-
-function buildVolumeQuery(service: string) {
-  return {
-    refId: 'A',
-    expr: `sum by(level) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`,
-    queryType: 'range',
-    legendFormat: '{{level}}',
-    supportingQueryType: PLUGIN_ID,
-  };
-}
-
-function buildLogQuery(service: string) {
-  return {
-    refId: 'A',
-    expr: `{${SERVICE_NAME}=\`${service}\`}`,
-    supportingQueryType: PLUGIN_ID,
-    queryType: 'range',
-    maxLines: 100,
   };
 }
 

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -1,20 +1,10 @@
 import { PLUGIN_ID } from './routing';
 
-export const buildLogVolumeQuery = (expr: string, overrides?: Record<string, unknown>) => {
+export const buildLokiQuery = (expr: string, queryParamsOverrides?: Record<string, unknown>) => {
   return {
-    legendFormat: '{{level}}',
-    expr,
     ...defaultQueryParams,
-    ...overrides,
-  };
-};
-
-export const buildLogQuery = (expr: string, overrides?: Record<string, unknown>) => {
-  return {
-    maxLines: 1000,
+    ...queryParamsOverrides,
     expr,
-    ...defaultQueryParams,
-    ...overrides,
   };
 };
 

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -1,0 +1,26 @@
+import { PLUGIN_ID } from './routing';
+
+export const buildLogVolumeQuery = (expr: string, overrides?: Record<string, unknown>) => {
+  return {
+    legendFormat: '{{level}}',
+    expr,
+    ...defaultQueryParams,
+    ...overrides,
+  };
+};
+
+export const buildLogQuery = (expr: string, overrides?: Record<string, unknown>) => {
+  return {
+    maxLines: 1000,
+    expr,
+    ...defaultQueryParams,
+    ...overrides,
+  };
+};
+
+const defaultQueryParams = {
+  refId: 'A',
+  queryType: 'range',
+  editorMode: 'code',
+  supportingQueryType: PLUGIN_ID,
+};


### PR DESCRIPTION
Unifies log and volume query creation - so instead of creating the same thing in many files, we have one place with default logic that can be overridden. 

Side task - in the label and fields tabs during layout creation, we were sometimes using 'option label' and sometimes 'option value.' I have unified it.