### PR TITLE
Filters: hide labels and fields if already used (and not actually interactive)

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -37,6 +37,7 @@ import {
 } from 'services/variables';
 import { buildLokiQuery } from 'services/query';
 import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
+import { filterUsedLabelNames } from 'services/scenes';
 
 export interface FieldsBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -101,10 +102,10 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     this.setState({
       fields: [
         { label: 'All', value: ALL_VARIABLE_VALUE },
-        ...(logsScene.state.detectedFields?.map((f) => ({
+        ...filterUsedLabelNames(logsScene, logsScene.state.detectedFields || []).map((f) => ({
           label: f,
           value: f,
-        })) || []),
+        })),
       ],
     });
 

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -249,7 +249,6 @@ function buildLabelsLayout(options: Array<SelectableValue<string>>) {
             })
           )
           .setHeaderActions(new SelectLabelAction({ labelName: String(optionValue) }))
-          .setHeaderActions(new SelectLabelAction({ labelName: String(optionValue) }))
           .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
           .setCustomFieldConfig('fillOpacity', 100)
           .setCustomFieldConfig('lineWidth', 0)

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -25,7 +25,7 @@ import { Box, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 import { Unsubscribable } from 'rxjs';
 import { extractParserAndFieldsFromDataFrame, DetectedLabelsResponse } from 'services/fields';
 import { EXPLORATIONS_ROUTE, PLUGIN_ID } from 'services/routing';
-import { getLokiDatasource, getExplorationFor } from 'services/scenes';
+import { getLokiDatasource, getExplorationFor, filterUsedLabelNames } from 'services/scenes';
 import {
   ALL_VARIABLE_VALUE,
   LOG_STREAM_SELECTOR_EXPR,
@@ -379,11 +379,15 @@ export class LogsActionBar extends SceneObjectBase<LogsActionBarState> {
     const getCounter = (tab: ActionViewDefinition) => {
       switch (tab.value) {
         case 'fields':
-          return logsScene.state.detectedFieldsCount ?? logsScene.state.detectedFields?.length;
+          return (
+            logsScene.state.detectedFieldsCount ??
+            filterUsedLabelNames(logsScene, logsScene.state.detectedFields || []).length
+          );
         case 'patterns':
           return logsScene.state.patterns?.length;
         case 'labels':
-          return (logsScene.state.labels?.filter((l) => l !== ALL_VARIABLE_VALUE) ?? []).length;
+          return filterUsedLabelNames(logsScene, logsScene.state.labels?.filter((l) => l !== ALL_VARIABLE_VALUE) ?? [])
+            .length;
         default:
           return undefined;
       }


### PR DESCRIPTION
Currently we display labels and fields as filters, even when already used, which causes them to be visible bot not interactive, i.e, clicking does nothing.

In this PR we're removing them from being listed and updating the displayed amount to match the available filters.

Before:

https://github.com/grafana/explore-logs/assets/1069378/e48ba843-9fcc-42a1-b4c6-d7fd347fb334

After:

https://github.com/grafana/explore-logs/assets/1069378/3e09f973-00a6-44ad-99d3-cd11ca0d7f48

Fixes https://github.com/grafana/explore-logs/issues/300