### PR TITLE
feat(unified level): move to `detected_level` and unify log level colors and sorting

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -17,7 +17,7 @@ services:
     extra_hosts:
       - 'host.docker.internal:host-gateway'
   loki:
-    image: grafana/loki:main-e9b6ce9
+    image: grafana/loki:main
     environment:
       LOG_CLUSTER_DEPTH: '8'
       LOG_SIM_TH: '0.3'

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -15,28 +15,22 @@ import {
   SceneObject,
   SceneObjectBase,
   SceneObjectState,
-  SceneQueryRunner,
   SceneReactObject,
   SceneVariableSet,
   VariableDependencyConfig,
 } from '@grafana/scenes';
 import { Button, DrawStyle, Field, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafana/ui';
+import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
+import { getLabelValueScene } from 'services/fields';
+import { getQueryRunner, levelOverrides } from 'services/panel';
+import { buildLokiQuery } from 'services/query';
+import { ALL_VARIABLE_VALUE, LOG_STREAM_SELECTOR_EXPR, VAR_FIELD_GROUP_BY, VAR_FILTERS } from 'services/variables';
+import { ServiceScene } from '../ServiceScene';
 import { AddToFiltersGraphAction } from './AddToFiltersButton';
 import { ByFrameRepeater } from './ByFrameRepeater';
+import { FieldSelector } from './FieldSelector';
 import { LayoutSwitcher } from './LayoutSwitcher';
 import { StatusWrapper } from './StatusWrapper';
-import { FieldSelector } from './FieldSelector';
-import { ServiceScene } from '../ServiceScene';
-import { getLabelValueScene } from 'services/fields';
-import {
-  VAR_FILTERS,
-  VAR_FIELD_GROUP_BY,
-  ALL_VARIABLE_VALUE,
-  explorationDS,
-  LOG_STREAM_SELECTOR_EXPR,
-} from 'services/variables';
-import { buildLokiQuery } from 'services/query';
-import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 
 export interface FieldsBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -159,22 +153,18 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
         legendFormat: `{{${optionValue}}}`,
         refId: optionValue,
       });
-      const queryRunner = new SceneQueryRunner({
-        maxDataPoints: 300,
-        datasource: explorationDS,
-        queries: [query],
-      });
+      const queryRunner = getQueryRunner(query);
       let body = PanelBuilders.timeseries().setTitle(optionValue).setData(queryRunner);
 
       if (!isAvgField(optionValue)) {
-        // TODO hack
         body = body
           .setHeaderActions(new SelectLabelAction({ labelName: String(optionValue) }))
           .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
           .setCustomFieldConfig('fillOpacity', 100)
           .setCustomFieldConfig('lineWidth', 0)
           .setCustomFieldConfig('pointSize', 0)
-          .setCustomFieldConfig('drawStyle', DrawStyle.Bars);
+          .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
+          .setOverrides(levelOverrides);
       }
       const gridItem = new SceneCSSGridItem({
         body: body.build(),
@@ -318,11 +308,7 @@ function buildNormalLayout(variable: CustomVariable) {
   const query = buildLokiQuery(getExpr(tagKey), { legendFormat: `{{${tagKey}}}` });
 
   return new LayoutSwitcher({
-    $data: new SceneQueryRunner({
-      datasource: explorationDS,
-      maxDataPoints: 300,
-      queries: [query],
-    }),
+    $data: getQueryRunner(query),
     actionView: 'fields',
     options: [
       { value: 'single', label: 'Single' },

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -16,29 +16,23 @@ import {
   SceneObject,
   SceneObjectBase,
   SceneObjectState,
-  SceneQueryRunner,
   SceneReactObject,
   SceneVariableSet,
   VariableDependencyConfig,
 } from '@grafana/scenes';
 import { Button, DrawStyle, Field, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafana/ui';
+import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
+import { DetectedLabelsResponse, getLabelValueScene } from 'services/fields';
+import { getQueryRunner, levelOverrides } from 'services/panel';
+import { buildLokiQuery } from 'services/query';
+import { PLUGIN_ID } from 'services/routing';
+import { getLabelOptions, getLokiDatasource } from 'services/scenes';
+import { ALL_VARIABLE_VALUE, LOG_STREAM_SELECTOR_EXPR, VAR_FILTERS, VAR_LABEL_GROUP_BY } from 'services/variables';
 import { AddToFiltersGraphAction } from './AddToFiltersButton';
 import { ByFrameRepeater } from './ByFrameRepeater';
+import { FieldSelector } from './FieldSelector';
 import { LayoutSwitcher } from './LayoutSwitcher';
 import { StatusWrapper } from './StatusWrapper';
-import { FieldSelector } from './FieldSelector';
-import { getLabelValueScene, DetectedLabelsResponse } from 'services/fields';
-import {
-  VAR_FILTERS,
-  VAR_LABEL_GROUP_BY,
-  ALL_VARIABLE_VALUE,
-  explorationDS,
-  LOG_STREAM_SELECTOR_EXPR,
-} from 'services/variables';
-import { getLokiDatasource, getLabelOptions } from 'services/scenes';
-import { PLUGIN_ID } from 'services/routing';
-import { buildLokiQuery } from 'services/query';
-import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 
 export interface LabelBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -241,13 +235,7 @@ function buildLabelsLayout(options: Array<SelectableValue<string>>) {
       new SceneCSSGridItem({
         body: PanelBuilders.timeseries()
           .setTitle(optionValue)
-          .setData(
-            new SceneQueryRunner({
-              maxDataPoints: 300,
-              datasource: explorationDS,
-              queries: [buildLokiQuery(getExpr(optionValue), { legendFormat: `{{${optionValue}}}` })],
-            })
-          )
+          .setData(getQueryRunner(buildLokiQuery(getExpr(optionValue), { legendFormat: `{{${optionValue}}}` })))
           .setHeaderActions(new SelectLabelAction({ labelName: String(optionValue) }))
           .setHeaderActions(new SelectLabelAction({ labelName: String(optionValue) }))
           .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
@@ -255,6 +243,7 @@ function buildLabelsLayout(options: Array<SelectableValue<string>>) {
           .setCustomFieldConfig('lineWidth', 0)
           .setCustomFieldConfig('pointSize', 0)
           .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
+          .setOverrides(levelOverrides)
           .build(),
       })
     );
@@ -299,16 +288,13 @@ function buildLabelValuesLayout(variable: CustomVariable) {
     .setCustomFieldConfig('lineWidth', 0)
     .setCustomFieldConfig('pointSize', 0)
     .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
+    .setOverrides(levelOverrides)
     .setTitle(variable.getValueText());
 
   const body = bodyOpts.build();
 
   return new LayoutSwitcher({
-    $data: new SceneQueryRunner({
-      datasource: explorationDS,
-      maxDataPoints: 300,
-      queries: [query],
-    }),
+    $data: getQueryRunner(query),
     options: [
       { value: 'single', label: 'Single' },
       { value: 'grid', label: 'Grid' },

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -1,20 +1,17 @@
 import React from 'react';
 
 import {
-  SceneObjectState,
-  SceneObjectBase,
-  SceneComponentProps,
   PanelBuilders,
+  SceneComponentProps,
   SceneFlexItem,
   SceneFlexLayout,
-  SceneQueryRunner,
-  SceneDataTransformer,
+  SceneObjectBase,
+  SceneObjectState,
 } from '@grafana/scenes';
 import { DrawStyle, StackingMode } from '@grafana/ui';
-import { DataFrame } from '@grafana/data';
-import { map, Observable } from 'rxjs';
-import { LOG_STREAM_SELECTOR_EXPR, explorationDS } from 'services/variables';
+import { getQueryRunner, levelOverrides } from 'services/panel';
 import { buildLokiQuery } from 'services/query';
+import { LOG_STREAM_SELECTOR_EXPR } from 'services/variables';
 
 export interface LogsVolumePanelState extends SceneObjectState {
   panel?: SceneFlexLayout;
@@ -44,68 +41,19 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
             .setTitle('Log volume')
             .setOption('legend', { showLegend: false })
             .setData(
-              new SceneDataTransformer({
-                $data: new SceneQueryRunner({
-                  datasource: explorationDS,
-                  queries: [
-                    buildLokiQuery(
-                      `sum by (level) (count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__ [$__auto]))`,
-                      { legendFormat: '{{level}}' }
-                    ),
-                  ],
-                }),
-                transformations: [
-                  () => (source: Observable<DataFrame[]>) => {
-                    return source.pipe(
-                      map((data: DataFrame[]) => {
-                        return data.sort((a, b) => {
-                          const aName = a.fields[1].config.displayNameFromDS;
-                          const aVal = aName?.includes('error')
-                            ? 4
-                            : aName?.includes('warn')
-                            ? 3
-                            : aName?.includes('info')
-                            ? 2
-                            : 1;
-                          const bName = b.fields[1].config.displayNameFromDS;
-                          const bVal = bName?.includes('error')
-                            ? 4
-                            : bName?.includes('warn')
-                            ? 3
-                            : bName?.includes('info')
-                            ? 2
-                            : 1;
-                          return aVal - bVal;
-                        });
-                      })
-                    );
-                  },
-                ],
-              })
+              getQueryRunner(
+                buildLokiQuery(
+                  `sum by (detected_level) (count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__ [$__auto]))`,
+                  { legendFormat: '{{detected_level}}' }
+                )
+              )
             )
             .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
             .setCustomFieldConfig('fillOpacity', 100)
             .setCustomFieldConfig('lineWidth', 0)
             .setCustomFieldConfig('pointSize', 0)
             .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
-            .setOverrides((overrides) => {
-              overrides.matchFieldsWithName('{level="info"}').overrideColor({
-                mode: 'fixed',
-                fixedColor: 'semi-dark-green',
-              });
-              overrides.matchFieldsWithName('{level="debug"}').overrideColor({
-                mode: 'fixed',
-                fixedColor: 'semi-dark-blue',
-              });
-              overrides.matchFieldsWithName('{level="error"}').overrideColor({
-                mode: 'fixed',
-                fixedColor: 'semi-dark-red',
-              });
-              overrides.matchFieldsWithName('{level="warn"}').overrideColor({
-                mode: 'fixed',
-                fixedColor: 'semi-dark-orange',
-              });
-            })
+            .setOverrides(levelOverrides)
             .build(),
         }),
       ],

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -11,7 +11,6 @@ import {
   sceneGraph,
   SceneObjectBase,
   SceneObjectState,
-  SceneQueryRunner,
   SceneVariable,
   VariableDependencyConfig,
 } from '@grafana/scenes';
@@ -29,12 +28,13 @@ import {
 import { getLokiDatasource } from 'services/scenes';
 import { getFavoriteServicesFromStorage } from 'services/store';
 import { testIds } from 'services/testIds';
-import { explorationDS, VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
+import { VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
 import { GrotError } from '../GrotError';
 import { SelectFieldButton } from './SelectFieldButton';
 import { PLUGIN_ID } from 'services/routing';
 import { buildLokiQuery } from 'services/query';
 import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
+import { getQueryRunner, levelOverrides } from 'services/panel';
 
 export const SERVICE_NAME = 'service_name';
 
@@ -210,40 +210,19 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
         // If service was previously selected, we show it in the title
         .setTitle(service)
         .setData(
-          new SceneQueryRunner({
-            datasource: explorationDS,
-            queries: [
-              // Volume of logs for service grouped by level
-              buildLokiQuery(
-                `sum by(level) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`,
-                { legendFormat: '{{level}}' }
-              ),
-            ],
-          })
+          getQueryRunner(
+            buildLokiQuery(
+              `sum by (detected_level) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`,
+              { legendFormat: '{{detected_level}}' }
+            )
+          )
         )
         .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
         .setCustomFieldConfig('fillOpacity', 100)
         .setCustomFieldConfig('lineWidth', 0)
         .setCustomFieldConfig('pointSize', 0)
         .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
-        .setOverrides((overrides) => {
-          overrides.matchFieldsWithName('info').overrideColor({
-            mode: 'fixed',
-            fixedColor: 'semi-dark-green',
-          });
-          overrides.matchFieldsWithName('debug').overrideColor({
-            mode: 'fixed',
-            fixedColor: 'semi-dark-blue',
-          });
-          overrides.matchFieldsWithName('error').overrideColor({
-            mode: 'fixed',
-            fixedColor: 'semi-dark-red',
-          });
-          overrides.matchFieldsWithName('warn').overrideColor({
-            mode: 'fixed',
-            fixedColor: 'semi-dark-orange',
-          });
-        })
+        .setOverrides(levelOverrides)
         .setOption('legend', { showLegend: false })
         .setHeaderActions(new SelectFieldButton({ value: service }))
         .build(),
@@ -254,12 +233,7 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
   buildServiceLogsLayout(service: string) {
     return new SceneCSSGridItem({
       body: PanelBuilders.logs()
-        .setData(
-          new SceneQueryRunner({
-            datasource: explorationDS,
-            queries: [buildLokiQuery(`{${SERVICE_NAME}=\`${service}\`}`, { maxLines: 100 })],
-          })
-        )
+        .setData(getQueryRunner(buildLokiQuery(`{${SERVICE_NAME}=\`${service}\`}`, { maxLines: 100 })))
         .setOption('showTime', true)
         .setOption('enableLogDetails', false)
         .build(),

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -4,6 +4,7 @@ import { PanelBuilders, SceneCSSGridItem, SceneDataNode } from '@grafana/scenes'
 import { getColorByIndex } from './scenes';
 import { AddToFiltersGraphAction } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
 import { VAR_FIELDS } from './variables';
+import { levelOverrides } from './panel';
 
 export type DetectedLabel = {
   label: string;
@@ -45,6 +46,7 @@ export function getLabelValueScene(getTitle: (df: DataFrame) => string, style: D
       .setTitle(getTitle(frame))
       .setData(new SceneDataNode({ data: { ...data, series: [frame] } }))
       .setColor({ mode: 'fixed', fixedColor: getColorByIndex(frameIndex) })
+      .setOverrides(levelOverrides)
       .setHeaderActions(new AddToFiltersGraphAction({ frame, variableName: VAR_FIELDS }));
 
     if (style === DrawStyle.Bars) {
@@ -53,6 +55,7 @@ export function getLabelValueScene(getTitle: (df: DataFrame) => string, style: D
         .setCustomFieldConfig('fillOpacity', 100)
         .setCustomFieldConfig('lineWidth', 0)
         .setCustomFieldConfig('pointSize', 0)
+        .setOverrides(levelOverrides)
         .setCustomFieldConfig('drawStyle', DrawStyle.Bars);
     }
     return new SceneCSSGridItem({

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -1,0 +1,59 @@
+import { DataFrame } from '@grafana/data';
+import { SceneDataTransformer, SceneQueryRunner } from '@grafana/scenes';
+import { map, Observable } from 'rxjs';
+import { LokiQuery } from './query';
+import { explorationDS } from './variables';
+
+// TODO: `FieldConfigOverridesBuilder` is not exported, so it can not be used here.
+export function levelOverrides(overrides: any) {
+  overrides.matchFieldsWithName('info').overrideColor({
+    mode: 'fixed',
+    fixedColor: 'semi-dark-green',
+  });
+  overrides.matchFieldsWithName('debug').overrideColor({
+    mode: 'fixed',
+    fixedColor: 'semi-dark-blue',
+  });
+  overrides.matchFieldsWithName('error').overrideColor({
+    mode: 'fixed',
+    fixedColor: 'semi-dark-red',
+  });
+  overrides.matchFieldsWithName('warn').overrideColor({
+    mode: 'fixed',
+    fixedColor: 'semi-dark-orange',
+  });
+}
+
+export function sortLevelTransformation() {
+  return (source: Observable<DataFrame[]>) => {
+    return source.pipe(
+      map((data: DataFrame[]) => {
+        return data.sort((a, b) => {
+          const aName: string | undefined = a.fields[1].config.displayNameFromDS;
+          const aVal = aName?.includes('error') ? 4 : aName?.includes('warn') ? 3 : aName?.includes('info') ? 2 : 1;
+          const bName: string | undefined = b.fields[1].config.displayNameFromDS;
+          const bVal = bName?.includes('error') ? 4 : bName?.includes('warn') ? 3 : bName?.includes('info') ? 2 : 1;
+          return aVal - bVal;
+        });
+      })
+    );
+  };
+}
+
+export function getQueryRunner(query: LokiQuery) {
+  // if there's anything related to `level`, we want to sort the output equally
+  if (query.expr.includes('level')) {
+    return new SceneDataTransformer({
+      $data: new SceneQueryRunner({
+        datasource: explorationDS,
+        queries: [query],
+      }),
+      transformations: [sortLevelTransformation],
+    });
+  }
+
+  return new SceneQueryRunner({
+    datasource: explorationDS,
+    queries: [query],
+  });
+}

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -1,6 +1,14 @@
 import { PLUGIN_ID } from './routing';
 
-export const buildLokiQuery = (expr: string, queryParamsOverrides?: Record<string, unknown>) => {
+export type LokiQuery = {
+  refId: string;
+  queryType: string;
+  editorMode: string;
+  supportingQueryType: string;
+  expr: string;
+  legendFormat?: string;
+};
+export const buildLokiQuery = (expr: string, queryParamsOverrides?: Record<string, unknown>): LokiQuery => {
   return {
     ...defaultQueryParams,
     ...queryParamsOverrides,

--- a/src/services/scenes.ts
+++ b/src/services/scenes.ts
@@ -7,7 +7,13 @@ import {
   SceneObject,
   SceneObjectUrlValues,
 } from '@grafana/scenes';
-import { VAR_DATASOURCE_EXPR, LOG_STREAM_SELECTOR_EXPR, VAR_FILTERS, ALL_VARIABLE_VALUE } from './variables';
+import {
+  VAR_DATASOURCE_EXPR,
+  LOG_STREAM_SELECTOR_EXPR,
+  VAR_FILTERS,
+  ALL_VARIABLE_VALUE,
+  LEVEL_VARIABLE_VALUE,
+} from './variables';
 import { EXPLORATIONS_ROUTE } from './routing';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
 
@@ -54,8 +60,8 @@ export function getLabelOptions(scenObject: SceneObject, allOptions: string[]) {
   }
 
   const levelOption = [];
-  if (!allOptions.includes('level')) {
-    levelOption.push({ label: 'level', value: 'level' });
+  if (!allOptions.includes(LEVEL_VARIABLE_VALUE)) {
+    levelOption.push({ label: LEVEL_VARIABLE_VALUE, value: LEVEL_VARIABLE_VALUE });
   }
 
   return [{ label: 'All', value: ALL_VARIABLE_VALUE }, ...levelOption, ...labelOptions];

--- a/src/services/variables.ts
+++ b/src/services/variables.ts
@@ -17,3 +17,4 @@ export const LOG_STREAM_SELECTOR_EXPR = `${VAR_FILTERS_EXPR} ${VAR_PATTERNS_EXPR
 export const explorationDS = { uid: VAR_DATASOURCE_EXPR };
 
 export const ALL_VARIABLE_VALUE = '$__all';
+export const LEVEL_VARIABLE_VALUE = 'detected_level';


### PR DESCRIPTION
This is quite a big change. I just wanted to change the `level` to `detected_level`. I ended up also unifying the colouring of all labels and feats that are like a `level` additionally for the colouring. I also added sorting of all those labels and fields.

Unified levels:
<img width="1440" alt="image" src="https://github.com/grafana/explore-logs/assets/8092184/07e3f51d-f127-470a-ac13-2104e45b282b">

Before:
<img width="1446" alt="image" src="https://github.com/grafana/explore-logs/assets/8092184/41f455a5-289d-4919-9fdf-837893d93dbb">

Fixes #299
Fixes #202
