### PR TITLE
fix: fix extra padding in logs panel

### DIFF
--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -233,6 +233,8 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
   buildServiceLogsLayout(service: string) {
     return new SceneCSSGridItem({
       body: PanelBuilders.logs()
+        // Hover header set to true hides the extra padding on top saved for header that we don't use in logs panel (more logs are visible)
+        .setHoverHeader(true)
         .setData(getQueryRunner(buildLokiQuery(`{${SERVICE_NAME}=\`${service}\`}`, { maxLines: 100 })))
         .setOption('showTime', true)
         .setOption('enableLogDetails', false)

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -233,7 +233,7 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
   buildServiceLogsLayout(service: string) {
     return new SceneCSSGridItem({
       body: PanelBuilders.logs()
-        // Hover header set to true hides the extra padding on top saved for header that we don't use in logs panel (more logs are visible)
+        // Hover header set to true removes unused header padding, displaying more logs
         .setHoverHeader(true)
         .setData(getQueryRunner(buildLokiQuery(`{${SERVICE_NAME}=\`${service}\`}`, { maxLines: 100 })))
         .setOption('showTime', true)


### PR DESCRIPTION
Fixes https://github.com/grafana/explore-logs/issues/275

Now:
<img width="1455" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/5b309d1b-8fe3-470e-9068-aa0fd7110274">

Before: 
<img width="1470" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/b6f1a245-b01f-4aad-9c88-a9ee722dcf5d">
