### PR TITLE
feat(queryExpressions): add `buildBaseQueryExpression` to create the base LogQL expression

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -24,7 +24,7 @@ import {
   explorationDS,
   VAR_DATASOURCE,
   VAR_FIELDS,
-  VAR_FILTERS,
+  VAR_LABELS,
   VAR_LINE_FILTER,
   VAR_LOGS_FORMAT,
   VAR_PATTERNS,
@@ -150,8 +150,8 @@ function getVariableSet(initialDS?: string, initialFilters?: AdHocVariableFilter
     value,
   }));
 
-  const filterVariable = new AdHocFiltersVariable({
-    name: VAR_FILTERS,
+  const labelsVariable = new AdHocFiltersVariable({
+    name: VAR_LABELS,
     datasource: explorationDS,
     layout: 'vertical',
     label: 'Service',
@@ -161,7 +161,7 @@ function getVariableSet(initialDS?: string, initialFilters?: AdHocVariableFilter
     key: 'adhoc_service_filter',
   });
 
-  filterVariable._getOperators = function () {
+  labelsVariable._getOperators = function () {
     return operators;
   };
 
@@ -193,7 +193,7 @@ function getVariableSet(initialDS?: string, initialFilters?: AdHocVariableFilter
   return new SceneVariableSet({
     variables: [
       dsVariable,
-      filterVariable,
+      labelsVariable,
       fieldsVariable,
       new CustomVariable({
         name: VAR_PATTERNS,

--- a/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.test.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.test.tsx
@@ -4,7 +4,7 @@ import { AddToFiltersButton, FilterType, addAdHocFilter, addToFilters } from './
 import { FieldType, createDataFrame } from '@grafana/data';
 import userEvent from '@testing-library/user-event';
 import { AdHocFiltersVariable, SceneObject, sceneGraph } from '@grafana/scenes';
-import { LEVEL_VARIABLE_VALUE, VAR_FIELDS, VAR_FILTERS } from 'services/variables';
+import { LEVEL_VARIABLE_VALUE, VAR_FIELDS, VAR_LABELS } from 'services/variables';
 
 describe('AddToFiltersButton', () => {
   it('updates correct variable passed to AddToFiltersButton', async () => {
@@ -131,7 +131,7 @@ describe('addToFilters and addAdHocFilter', () => {
       const lookupVariable = jest.spyOn(sceneGraph, 'lookupVariable').mockReturnValue(adHocVariable);
       addToFilters('indexed', 'value', 'include', {} as SceneObject);
 
-      expect(lookupVariable).toHaveBeenCalledWith(VAR_FILTERS, expect.anything());
+      expect(lookupVariable).toHaveBeenCalledWith(VAR_LABELS, expect.anything());
       expect(adHocVariable.state.filters).toEqual([
         {
           key: 'existing',
@@ -150,7 +150,7 @@ describe('addToFilters and addAdHocFilter', () => {
       const lookupVariable = jest.spyOn(sceneGraph, 'lookupVariable').mockReturnValue(adHocVariable);
       addToFilters(LEVEL_VARIABLE_VALUE, 'info', 'include', {} as SceneObject, VAR_FIELDS);
 
-      expect(lookupVariable).toHaveBeenCalledWith(VAR_FILTERS, expect.anything());
+      expect(lookupVariable).toHaveBeenCalledWith(VAR_LABELS, expect.anything());
     });
   });
 
@@ -186,7 +186,7 @@ describe('addToFilters and addAdHocFilter', () => {
       const lookupVariable = jest.spyOn(sceneGraph, 'lookupVariable').mockReturnValue(adHocVariable);
       addAdHocFilter({ key: 'indexed', value: 'value', operator: '=' }, {} as SceneObject);
 
-      expect(lookupVariable).toHaveBeenCalledWith(VAR_FILTERS, expect.anything());
+      expect(lookupVariable).toHaveBeenCalledWith(VAR_LABELS, expect.anything());
       expect(adHocVariable.state.filters).toEqual([
         {
           key: 'existing',
@@ -205,7 +205,7 @@ describe('addToFilters and addAdHocFilter', () => {
       const lookupVariable = jest.spyOn(sceneGraph, 'lookupVariable').mockReturnValue(adHocVariable);
       addAdHocFilter({ key: LEVEL_VARIABLE_VALUE, value: 'info', operator: '=' }, {} as SceneObject, VAR_FIELDS);
 
-      expect(lookupVariable).toHaveBeenCalledWith(VAR_FILTERS, expect.anything());
+      expect(lookupVariable).toHaveBeenCalledWith(VAR_LABELS, expect.anything());
     });
   });
 });

--- a/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
@@ -4,7 +4,7 @@ import { AdHocVariableFilter, DataFrame } from '@grafana/data';
 import { SceneObjectState, SceneObjectBase, SceneComponentProps, SceneObject, sceneGraph } from '@grafana/scenes';
 import { VariableHide } from '@grafana/schema';
 import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
-import { LEVEL_VARIABLE_VALUE, VAR_FIELDS, VAR_FILTERS } from 'services/variables';
+import { LEVEL_VARIABLE_VALUE, VAR_FIELDS, VAR_LABELS } from 'services/variables';
 import { FilterButton } from 'Components/FilterButton';
 import { getAdHocFiltersVariable } from 'services/scenes';
 import { FilterOp } from 'services/filters';
@@ -79,7 +79,7 @@ function validateVariableNameForField(field: string, variableName: string) {
 function resolveVariableNameForField(field: string, scene: SceneObject) {
   const serviceScene = sceneGraph.getAncestor(scene, ServiceScene);
   const indexedLabel = serviceScene.state.labels?.find((label) => label === field);
-  return indexedLabel ? VAR_FILTERS : VAR_FIELDS;
+  return indexedLabel ? VAR_LABELS : VAR_FIELDS;
 }
 
 export class AddToFiltersButton extends SceneObjectBase<AddToFiltersButtonState> {

--- a/src/Components/ServiceScene/GoToExploreButton.tsx
+++ b/src/Components/ServiceScene/GoToExploreButton.tsx
@@ -5,10 +5,12 @@ import { config } from '@grafana/runtime';
 import { sceneGraph } from '@grafana/scenes';
 import { ToolbarButton } from '@grafana/ui';
 
-import { getDataSource, getQueryExpr } from 'services/scenes';
+import { getDataSource } from 'services/scenes';
 import { testIds } from 'services/testIds';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
 import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
+import { buildBaseQueryExpression } from 'services/query';
+
 interface GoToExploreButtonState {
   exploration: IndexScene;
 }
@@ -20,7 +22,7 @@ export const GoToExploreButton = ({ exploration }: GoToExploreButtonState) => {
       USER_EVENTS_ACTIONS.service_details.open_in_explore_clicked
     );
     const datasource = getDataSource(exploration);
-    const expr = getQueryExpr(exploration).replace(/\s+/g, ' ').trimEnd();
+    const expr = buildBaseQueryExpression(exploration).replace(/\s+/g, ' ').trimEnd();
     const timeRange = sceneGraph.getTimeRange(exploration).state.value;
     const exploreState = JSON.stringify({
       ['loki-explore']: {

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -21,7 +21,7 @@ import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '..
 import { DataFrame } from '@grafana/data';
 import { FilterType, addToFilters } from './Breakdowns/AddToFiltersButton';
 import { LabelType, getLabelTypeFromFrame } from 'services/fields';
-import { VAR_FIELDS, VAR_FILTERS } from 'services/variables';
+import { VAR_FIELDS, VAR_LABELS } from 'services/variables';
 import { getAdHocFiltersVariable } from 'services/scenes';
 
 export interface LogsListSceneState extends SceneObjectState {
@@ -111,7 +111,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
       return;
     }
     const type = frame ? getLabelTypeFromFrame(key, frame) : LabelType.Parsed;
-    const variableName = type === LabelType.Indexed ? VAR_FILTERS : VAR_FIELDS;
+    const variableName = type === LabelType.Indexed ? VAR_LABELS : VAR_FIELDS;
     addToFilters(key, value, operator, this, variableName);
 
     reportAppInteraction(
@@ -134,7 +134,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
   };
 
   public handleIsFilterLabelActive = (key: string, value: string) => {
-    const filters = getAdHocFiltersVariable(VAR_FILTERS, this);
+    const filters = getAdHocFiltersVariable(VAR_LABELS, this);
     const fields = getAdHocFiltersVariable(VAR_FIELDS, this);
     return (
       (filters &&

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { PanelBuilders, SceneComponentProps, SceneObjectBase, SceneObjectState, VizPanel } from '@grafana/scenes';
 import { DrawStyle, LegendDisplayMode, StackingMode } from '@grafana/ui';
 import { getQueryRunner, setLeverColorOverrides } from 'services/panel';
-import { buildLokiQuery } from 'services/query';
-import { LEVEL_VARIABLE_VALUE, LOG_STREAM_SELECTOR_EXPR } from 'services/variables';
+import { buildBaseQueryExpression, buildLokiQuery } from 'services/query';
+import { LEVEL_VARIABLE_VALUE } from 'services/variables';
 
 export interface LogsVolumePanelState extends SceneObjectState {
   panel?: VizPanel;
@@ -33,7 +33,9 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       .setData(
         getQueryRunner(
           buildLokiQuery(
-            `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__ [$__auto]))`,
+            `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time(${buildBaseQueryExpression(
+              this
+            )} | drop __error__ [$__auto]))`,
             { legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}` }
           )
         )

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -33,7 +33,7 @@ import {
   LOG_STREAM_SELECTOR_EXPR,
   VAR_DATASOURCE,
   VAR_FIELDS,
-  VAR_FILTERS,
+  VAR_LABELS,
   VAR_LINE_FILTER,
   VAR_LOGS_FORMAT,
   VAR_PATTERNS,
@@ -80,7 +80,7 @@ export interface ServiceSceneState extends SceneObjectState {
 export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['actionView'] });
   protected _variableDependency = new VariableDependencyConfig(this, {
-    variableNames: [VAR_DATASOURCE, VAR_FILTERS, VAR_FIELDS, VAR_PATTERNS],
+    variableNames: [VAR_DATASOURCE, VAR_LABELS, VAR_FIELDS, VAR_PATTERNS],
     onReferencedVariableValueChanged: this.onReferencedVariableValueChanged.bind(this),
   });
 
@@ -96,7 +96,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
   }
 
   private getFiltersVariable(): AdHocFiltersVariable {
-    const variable = sceneGraph.lookupVariable(VAR_FILTERS, this)!;
+    const variable = sceneGraph.lookupVariable(VAR_LABELS, this)!;
     if (!(variable instanceof AdHocFiltersVariable)) {
       throw new Error('Filters variable not found');
     }
@@ -258,7 +258,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     }
 
     const timeRange = sceneGraph.getTimeRange(this).state.value;
-    const filters = sceneGraph.lookupVariable(VAR_FILTERS, this)! as AdHocFiltersVariable;
+    const filters = sceneGraph.lookupVariable(VAR_LABELS, this)! as AdHocFiltersVariable;
     const fields = sceneGraph.lookupVariable(VAR_FIELDS, this)! as AdHocFiltersVariable;
     const excludeLabels = [ALL_VARIABLE_VALUE, LEVEL_VARIABLE_VALUE];
 
@@ -293,7 +293,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
       return;
     }
     const timeRange = sceneGraph.getTimeRange(this).state.value;
-    const filters = sceneGraph.lookupVariable(VAR_FILTERS, this)! as AdHocFiltersVariable;
+    const filters = sceneGraph.lookupVariable(VAR_LABELS, this)! as AdHocFiltersVariable;
     const { detectedLabels } = await ds.getResource<DetectedLabelsResponse>(
       'detected_labels',
       {

--- a/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
+++ b/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
@@ -10,7 +10,7 @@ import {
 import { Button } from '@grafana/ui';
 import { VariableHide } from '@grafana/schema';
 import { addToFavoriteServicesInStorage } from 'services/store';
-import { VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
+import { VAR_DATASOURCE, VAR_LABELS } from 'services/variables';
 import { SERVICE_NAME, StartingPointSelectedEvent } from './ServiceSelectionScene';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { FilterOp } from 'services/filters';
@@ -21,7 +21,7 @@ export interface SelectServiceButtonState extends SceneObjectState {
 
 export class SelectServiceButton extends SceneObjectBase<SelectServiceButtonState> {
   public onClick = () => {
-    const variable = sceneGraph.lookupVariable(VAR_FILTERS, this);
+    const variable = sceneGraph.lookupVariable(VAR_LABELS, this);
     if (!(variable instanceof AdHocFiltersVariable)) {
       return;
     }

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -31,7 +31,7 @@ import {
 import { getLokiDatasource } from 'services/scenes';
 import { getFavoriteServicesFromStorage } from 'services/store';
 import { testIds } from 'services/testIds';
-import { LEVEL_VARIABLE_VALUE, VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
+import { LEVEL_VARIABLE_VALUE, VAR_DATASOURCE, VAR_LABELS } from 'services/variables';
 import { SelectServiceButton } from './SelectServiceButton';
 import { PLUGIN_ID } from 'services/routing';
 import { buildLokiQuery } from 'services/query';
@@ -94,7 +94,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
 
   private onActivate() {
     // Clear all adhoc filters when the scene is activated, if there are any
-    const variable = sceneGraph.lookupVariable(VAR_FILTERS, this);
+    const variable = sceneGraph.lookupVariable(VAR_LABELS, this);
     if (variable instanceof AdHocFiltersVariable && variable.state.filters.length > 0) {
       variable.setState({
         filters: [],

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -3,7 +3,7 @@ import { DrawStyle, StackingMode } from '@grafana/ui';
 import { PanelBuilders, SceneCSSGridItem, SceneDataNode } from '@grafana/scenes';
 import { getColorByIndex } from './scenes';
 import { AddToFiltersButton } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
-import { VAR_FIELDS, VAR_FILTERS } from './variables';
+import { VAR_FIELDS, VAR_LABELS } from './variables';
 import { setLeverColorOverrides } from './panel';
 
 export type DetectedLabel = {
@@ -41,7 +41,7 @@ export function extractParserAndFieldsFromDataFrame(data: DataFrame) {
 export function getFilterBreakdownValueScene(
   getTitle: (df: DataFrame) => string,
   style: DrawStyle,
-  variableName: typeof VAR_FIELDS | typeof VAR_FILTERS
+  variableName: typeof VAR_FIELDS | typeof VAR_LABELS
 ) {
   return (data: PanelData, frame: DataFrame, frameIndex: number) => {
     const panel = PanelBuilders.timeseries() //

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -1,4 +1,6 @@
+import { SceneObject, sceneGraph, AdHocFiltersVariable, CustomVariable } from '@grafana/scenes';
 import { PLUGIN_ID } from './routing';
+import { VAR_LABELS, VAR_PATTERNS, VAR_LINE_FILTER, VAR_LOGS_FORMAT, VAR_FIELDS } from './variables';
 
 export type LokiQuery = {
   refId: string;
@@ -23,3 +25,41 @@ const defaultQueryParams = {
   editorMode: 'code',
   supportingQueryType: PLUGIN_ID,
 };
+
+export function buildBaseQueryExpression(sceneObject: SceneObject) {
+  let expr = '';
+
+  // build streamselector from all indexed labels
+  const indexedLabels = sceneGraph.lookupVariable(VAR_LABELS, sceneObject) as AdHocFiltersVariable | null;
+  if (!indexedLabels || !indexedLabels.state.filterExpression) {
+    return '';
+  }
+  let streamSelector = indexedLabels.state.filterExpression;
+  expr = streamSelector;
+
+  // add all pattern expressions
+  const patterns = sceneGraph.lookupVariable(VAR_PATTERNS, sceneObject) as AdHocFiltersVariable | null;
+  if (patterns && patterns.state.filterExpression) {
+    expr += ' ' + patterns.state.filterExpression;
+  }
+
+  // add line filter expression
+  const lineFilter = sceneGraph.lookupVariable(VAR_LINE_FILTER, sceneObject) as CustomVariable | null;
+  if (lineFilter && lineFilter.state.value) {
+    expr += ' ' + lineFilter.state.value;
+  }
+
+  // add `logfmt` or `json`
+  const format = sceneGraph.lookupVariable(VAR_LOGS_FORMAT, sceneObject) as CustomVariable | null;
+  if (format && format.state.value) {
+    expr += ' ' + format.state.value;
+  }
+
+  // add all label filter expressions
+  const labelFilters = sceneGraph.lookupVariable(VAR_FIELDS, sceneObject) as AdHocFiltersVariable | null;
+  if (labelFilters && labelFilters.state.filterExpression) {
+    expr += ' ' + labelFilters.state.filterExpression;
+  }
+
+  return expr;
+}

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -26,6 +26,9 @@ const defaultQueryParams = {
   supportingQueryType: PLUGIN_ID,
 };
 
+/**
+ * Build an optimized base query expression.
+ */
 export function buildBaseQueryExpression(sceneObject: SceneObject) {
   let expr = '';
 

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -26,10 +26,25 @@ const defaultQueryParams = {
   supportingQueryType: PLUGIN_ID,
 };
 
+type QueryExpressionOptions = {
+  patterns: boolean;
+  lineFilters: boolean;
+  lineFormat: boolean;
+  labelFilters: boolean;
+};
+const defaultQueryExpressionOptions: QueryExpressionOptions = {
+  patterns: true,
+  lineFilters: true,
+  lineFormat: true,
+  labelFilters: true,
+};
 /**
  * Build an optimized base query expression.
  */
-export function buildBaseQueryExpression(sceneObject: SceneObject) {
+export function buildBaseQueryExpression(
+  sceneObject: SceneObject,
+  options: QueryExpressionOptions = defaultQueryExpressionOptions
+) {
   let expr = '';
 
   // build streamselector from all indexed labels
@@ -40,28 +55,36 @@ export function buildBaseQueryExpression(sceneObject: SceneObject) {
   let streamSelector = indexedLabels.state.filterExpression;
   expr = streamSelector;
 
-  // add all pattern expressions
-  const patterns = sceneGraph.lookupVariable(VAR_PATTERNS, sceneObject) as AdHocFiltersVariable | null;
-  if (patterns && patterns.state.filterExpression) {
-    expr += ' ' + patterns.state.filterExpression;
+  if (options.patterns) {
+    // add all pattern expressions
+    const patterns = sceneGraph.lookupVariable(VAR_PATTERNS, sceneObject) as AdHocFiltersVariable | null;
+    if (patterns && patterns.state.filterExpression) {
+      expr += ' ' + patterns.state.filterExpression;
+    }
   }
 
-  // add line filter expression
-  const lineFilter = sceneGraph.lookupVariable(VAR_LINE_FILTER, sceneObject) as CustomVariable | null;
-  if (lineFilter && lineFilter.state.value) {
-    expr += ' ' + lineFilter.state.value;
+  if (options.lineFilters) {
+    // add line filter expression
+    const lineFilter = sceneGraph.lookupVariable(VAR_LINE_FILTER, sceneObject) as CustomVariable | null;
+    if (lineFilter && lineFilter.state.value) {
+      expr += ' ' + lineFilter.state.value;
+    }
   }
 
-  // add `logfmt` or `json`
-  const format = sceneGraph.lookupVariable(VAR_LOGS_FORMAT, sceneObject) as CustomVariable | null;
-  if (format && format.state.value) {
-    expr += ' ' + format.state.value;
+  if (options.lineFormat) {
+    // add `logfmt` or `json`
+    const format = sceneGraph.lookupVariable(VAR_LOGS_FORMAT, sceneObject) as CustomVariable | null;
+    if (format && format.state.value) {
+      expr += ' ' + format.state.value;
+    }
   }
 
-  // add all label filter expressions
-  const labelFilters = sceneGraph.lookupVariable(VAR_FIELDS, sceneObject) as AdHocFiltersVariable | null;
-  if (labelFilters && labelFilters.state.filterExpression) {
-    expr += ' ' + labelFilters.state.filterExpression;
+  if (options.labelFilters) {
+    // add all label filter expressions
+    const labelFilters = sceneGraph.lookupVariable(VAR_FIELDS, sceneObject) as AdHocFiltersVariable | null;
+    if (labelFilters && labelFilters.state.filterExpression) {
+      expr += ' ' + labelFilters.state.filterExpression;
+    }
   }
 
   return expr;

--- a/src/services/scenes.ts
+++ b/src/services/scenes.ts
@@ -7,7 +7,7 @@ import {
   SceneObject,
   SceneObjectUrlValues,
 } from '@grafana/scenes';
-import { VAR_DATASOURCE_EXPR, LOG_STREAM_SELECTOR_EXPR } from './variables';
+import { VAR_DATASOURCE_EXPR } from './variables';
 import { EXPLORATIONS_ROUTE } from './routing';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
 
@@ -25,10 +25,6 @@ export function getUrlForValues(values: SceneObjectUrlValues) {
 
 export function getDataSource(exploration: IndexScene) {
   return sceneGraph.interpolate(exploration, VAR_DATASOURCE_EXPR);
-}
-
-export function getQueryExpr(exploration: IndexScene) {
-  return sceneGraph.interpolate(exploration, LOG_STREAM_SELECTOR_EXPR).replace(/\s+/g, ' ');
 }
 
 export function getColorByIndex(index: number) {

--- a/src/services/variables.ts
+++ b/src/services/variables.ts
@@ -13,7 +13,6 @@ export const VAR_LOGS_FORMAT_EXPR = '${logsFormat}';
 export const VAR_LINE_FILTER = 'lineFilter';
 export const VAR_LINE_FILTER_EXPR = '${lineFilter}';
 
-export const LOG_STREAM_SELECTOR_EXPR = `${VAR_LABELS_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LOGS_FORMAT_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FILTER_EXPR}`;
 export const explorationDS = { uid: VAR_DATASOURCE_EXPR };
 
 export const ALL_VARIABLE_VALUE = '$__all';

--- a/src/services/variables.ts
+++ b/src/services/variables.ts
@@ -1,5 +1,5 @@
-export const VAR_FILTERS = 'filters';
-export const VAR_FILTERS_EXPR = '${filters}';
+export const VAR_LABELS = 'labels';
+export const VAR_LABELS_EXPR = '${labels}';
 export const VAR_FIELDS = 'fields';
 export const VAR_FIELDS_EXPR = '${fields}';
 export const VAR_PATTERNS = 'patterns';
@@ -13,7 +13,7 @@ export const VAR_LOGS_FORMAT_EXPR = '${logsFormat}';
 export const VAR_LINE_FILTER = 'lineFilter';
 export const VAR_LINE_FILTER_EXPR = '${lineFilter}';
 
-export const LOG_STREAM_SELECTOR_EXPR = `${VAR_FILTERS_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LOGS_FORMAT_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FILTER_EXPR}`;
+export const LOG_STREAM_SELECTOR_EXPR = `${VAR_LABELS_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LOGS_FORMAT_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FILTER_EXPR}`;
 export const explorationDS = { uid: VAR_DATASOURCE_EXPR };
 
 export const ALL_VARIABLE_VALUE = '$__all';

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -28,7 +28,7 @@ export class ExplorePage {
 
   async gotoServicesBreakdown() {
     await this.page.goto(
-      `/a/${pluginJson.id}/${ROUTES.Explore}?mode=service_details&var-patterns=&var-filters=service_name%7C%3D%7Ctempo-distributor&actionView=logs&var-logsFormat=%20%7C%20logfmt`
+      `/a/${pluginJson.id}/${ROUTES.Explore}?mode=service_details&var-patterns=&var-labels=service_name%7C%3D%7Ctempo-distributor&actionView=logs&var-logsFormat=%20%7C%20logfmt`
     );
   }
 }


### PR DESCRIPTION
`buildBaseQueryExpression` will create the basic LogQL expression instead of relying on AdhocFilters to do the trick. This allows to more easily adapt expressions where needed.

The PR also renames the `VAR_FILTERS` to `VAR_LABELS` to make it clear that that variable stores all indexed labels. 

Additional side effect: this fixes the "Go to Explore" button, that did not include `| logfmt` in some cases.

Fixes https://github.com/grafana/explore-logs/issues/257