### PR TITLE
refactor(IndexScene): move LogsExplorationScene to a module and rename as LayoutScene

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -74,7 +74,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
       ...state,
     });
 
-    this.addActivationHandler(this._onActivate.bind(this));
+    this.addActivationHandler(this.onActivate.bind(this));
   }
 
   static Component = ({ model }: SceneComponentProps<IndexScene>) => {
@@ -84,7 +84,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     return <div className={styles.bodyContainer}> {body && <body.Component model={body} />} </div>;
   };
 
-  public _onActivate() {
+  public onActivate() {
     if (!this.state.topScene) {
       this.setState({ topScene: getTopScene(this.state.mode) });
     }

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -1,7 +1,6 @@
-import { css } from '@emotion/css';
 import React from 'react';
 
-import { AdHocVariableFilter, GrafanaTheme2, SelectableValue, VariableHide } from '@grafana/data';
+import { AdHocVariableFilter, SelectableValue, VariableHide } from '@grafana/data';
 import {
   AdHocFiltersVariable,
   CustomVariable,
@@ -21,7 +20,6 @@ import {
   getUrlSyncManager,
   sceneGraph,
 } from '@grafana/scenes';
-import { Badge, useStyles2 } from '@grafana/ui';
 import {
   VAR_DATASOURCE,
   VAR_FIELDS,
@@ -34,8 +32,8 @@ import {
 
 import { ServiceScene } from '../ServiceScene/ServiceScene';
 import { ServiceSelectionComponent, StartingPointSelectedEvent } from '../ServiceSelectionScene/ServiceSelectionScene';
-import { PatternControls } from './PatternControls';
 import { addLastUsedDataSourceToStorage, getLastUsedDataSourceFromStorage } from 'services/store';
+import { LayoutScene } from './LayoutScene';
 
 type LogExplorationMode = 'service_selection' | 'service_details';
 
@@ -45,10 +43,10 @@ export interface AppliedPattern {
 }
 
 export interface IndexSceneState extends SceneObjectState {
-  // topScene is the scene that is displayed in the main body of the index scene - it can be either the service selection or service scene
-  topScene?: SceneObject;
+  // contentScene is the scene that is displayed in the main body of the index scene - it can be either the service selection or service scene
+  contentScene?: SceneObject;
   controls: SceneObject[];
-  body: LogExplorationScene;
+  body: LayoutScene;
   // mode is the current mode of the index scene - it can be either 'service_selection' or 'service_details'
   mode?: LogExplorationMode;
   initialFilters?: AdHocVariableFilter[];
@@ -70,7 +68,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
         new SceneTimePicker({}),
         new SceneRefreshPicker({}),
       ],
-      body: new LogExplorationScene({}),
+      body: new LayoutScene({}),
       ...state,
     });
 
@@ -79,14 +77,13 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
 
   static Component = ({ model }: SceneComponentProps<IndexScene>) => {
     const { body } = model.useState();
-    const styles = useStyles2(getStyles);
 
-    return <div className={styles.bodyContainer}> {body && <body.Component model={body} />} </div>;
+    return <body.Component model={body} />;
   };
 
   public onActivate() {
-    if (!this.state.topScene) {
-      this.setState({ topScene: getTopScene(this.state.mode) });
+    if (!this.state.contentScene) {
+      this.setState({ contentScene: getContentScene(this.state.mode) });
     }
 
     // Some scene elements publish this
@@ -94,7 +91,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
 
     this.subscribeToState((newState, oldState) => {
       if (newState.mode !== oldState.mode) {
-        this.setState({ topScene: getTopScene(newState.mode) });
+        this.setState({ contentScene: getContentScene(newState.mode) });
       }
 
       const patternsVariable = sceneGraph.lookupVariable(VAR_PATTERNS, this);
@@ -122,7 +119,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     if (values.mode !== this.state.mode) {
       const mode: LogExplorationMode = (values.mode as LogExplorationMode) ?? 'service_selection';
       stateUpdate.mode = mode;
-      stateUpdate.topScene = getTopScene(mode);
+      stateUpdate.contentScene = getContentScene(mode);
     }
     if (this.state.mode === 'service_selection') {
       // Clear patterns on start
@@ -140,43 +137,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
   }
 }
 
-export class LogExplorationScene extends SceneObjectBase {
-  static Component = ({ model }: SceneComponentProps<LogExplorationScene>) => {
-    const logExploration = sceneGraph.getAncestor(model, IndexScene);
-    const { controls, topScene, patterns } = logExploration.useState();
-    const styles = useStyles2(getStyles);
-    return (
-      <div className={styles.container}>
-        {controls && (
-          <div className={styles.controlsContainer}>
-            <div className={styles.filters}>
-              {controls.map((control) =>
-                control instanceof VariableValueSelectors ? (
-                  <control.Component key={control.state.key} model={control} />
-                ) : null
-              )}
-            </div>
-            <div className={styles.controls}>
-              <Badge text={'Preview'} color={'blue'} icon={'rocket'} />
-              {controls.map((control) =>
-                control instanceof VariableValueSelectors === false ? (
-                  <control.Component key={control.state.key} model={control} />
-                ) : null
-              )}
-            </div>
-          </div>
-        )}
-        <PatternControls
-          patterns={patterns}
-          onRemove={(patterns: AppliedPattern[]) => logExploration.setState({ patterns })}
-        />
-        <div className={styles.body}>{topScene && <topScene.Component model={topScene} />}</div>
-      </div>
-    );
-  };
-}
-
-function getTopScene(mode?: LogExplorationMode) {
+function getContentScene(mode?: LogExplorationMode) {
   if (mode === 'service_details') {
     return new ServiceScene({});
   }
@@ -260,93 +221,4 @@ export function renderLogQLFieldFilters(filters: AdHocVariableFilter[]) {
 
 function renderFilter(filter: AdHocVariableFilter) {
   return `${filter.key}${filter.operator}\`${filter.value}\``;
-}
-
-function getStyles(theme: GrafanaTheme2) {
-  return {
-    bodyContainer: css({
-      flexGrow: 1,
-      display: 'flex',
-      minHeight: '100%',
-      flexDirection: 'column',
-    }),
-    container: css({
-      flexGrow: 1,
-      display: 'flex',
-      gap: theme.spacing(2),
-      minHeight: '100%',
-      flexDirection: 'column',
-      padding: theme.spacing(2),
-      maxWidth: '100vw',
-    }),
-    body: css({
-      flexGrow: 1,
-      display: 'flex',
-      flexDirection: 'column',
-      gap: theme.spacing(1),
-    }),
-    controlsContainer: css({
-      display: 'flex',
-      gap: theme.spacing(2),
-      justifyContent: 'space-between',
-      alignItems: 'flex-start',
-    }),
-    filters: css({
-      display: 'flex',
-      gap: theme.spacing(2),
-      width: 'calc(100% - 450)',
-      flexWrap: 'wrap',
-      alignItems: 'flex-end',
-      '& + div[data-testid="data-testid Dashboard template variables submenu Label Filters"]:empty': {
-        visibility: 'hidden',
-      },
-
-      //@todo not like this
-      // The filter variables container: i.e. services, filters
-      '&:first-child': {
-        // The wrapper of each filter
-        '& > div': {
-          // the 'service_name' filter wrapper
-          '&:nth-child(2) > div': {
-            gap: 0,
-          },
-          // The actual inputs container
-          '& > div': {
-            flexWrap: 'wrap',
-            // wrapper around all inputs
-            '& > div': {
-              maxWidth: '380px',
-
-              // Wrapper around each input: i.e. label name, binary operator, value
-              '& > div': {
-                // These inputs need to flex, otherwise the value takes all of available space and they look broken
-                flex: '1 0 auto',
-
-                // The value input needs to shrink when the parent component is at max width
-                '&:nth-child(3)': {
-                  flex: '0 1 auto',
-                },
-              },
-            },
-          },
-        },
-      },
-
-      ['div >[title="Add filter"]']: {
-        border: 0,
-        visibility: 'hidden',
-        width: 0,
-        padding: 0,
-        margin: 0,
-      },
-    }),
-    controls: css({
-      display: 'flex',
-      paddingTop: theme.spacing(3),
-      gap: theme.spacing(1),
-    }),
-    rotateIcon: css({
-      svg: { transform: 'rotate(180deg)' },
-    }),
-  };
 }

--- a/src/Components/IndexScene/LayoutScene.tsx
+++ b/src/Components/IndexScene/LayoutScene.tsx
@@ -1,0 +1,143 @@
+import { GrafanaTheme2 } from '@grafana/data';
+import { SceneComponentProps, SceneObjectBase, VariableValueSelectors } from '@grafana/scenes';
+import { useStyles2 } from '@grafana/ui';
+import React from 'react';
+import { PatternControls } from './PatternControls';
+import { AppliedPattern, IndexSceneState } from './IndexScene';
+import { css } from '@emotion/css';
+
+export class LayoutScene extends SceneObjectBase {
+  static Component = ({ model }: SceneComponentProps<LayoutScene>) => {
+    if (!model.parent) {
+      return null;
+    }
+
+    const { controls, contentScene, patterns } = model.parent.useState() as IndexSceneState;
+    if (!contentScene) {
+      return null;
+    }
+
+    const styles = useStyles2(getStyles);
+    return (
+      <div className={styles.bodyContainer}>
+        <div className={styles.container}>
+          {controls && (
+            <div className={styles.controlsContainer}>
+              <div className={styles.filters}>
+                {controls.map((control) =>
+                  control instanceof VariableValueSelectors ? (
+                    <control.Component key={control.state.key} model={control} />
+                  ) : null
+                )}
+              </div>
+              <div className={styles.controls}>
+                {controls.map((control) =>
+                  control instanceof VariableValueSelectors === false ? (
+                    <control.Component key={control.state.key} model={control} />
+                  ) : null
+                )}
+              </div>
+            </div>
+          )}
+          <PatternControls
+            patterns={patterns}
+            onRemove={(patterns: AppliedPattern[]) => model.parent?.setState({ patterns } as IndexSceneState)}
+          />
+          <div className={styles.body}>
+            <contentScene.Component model={contentScene} />
+          </div>
+        </div>
+      </div>
+    );
+  };
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    bodyContainer: css({
+      flexGrow: 1,
+      display: 'flex',
+      minHeight: '100%',
+      flexDirection: 'column',
+    }),
+    container: css({
+      flexGrow: 1,
+      display: 'flex',
+      gap: theme.spacing(2),
+      minHeight: '100%',
+      flexDirection: 'column',
+      padding: theme.spacing(2),
+      maxWidth: '100vw',
+    }),
+    body: css({
+      flexGrow: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+    }),
+    controlsContainer: css({
+      display: 'flex',
+      gap: theme.spacing(2),
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+    }),
+    filters: css({
+      display: 'flex',
+      gap: theme.spacing(2),
+      width: 'calc(100% - 450)',
+      flexWrap: 'wrap',
+      alignItems: 'flex-end',
+      '& + div[data-testid="data-testid Dashboard template variables submenu Label Filters"]:empty': {
+        visibility: 'hidden',
+      },
+
+      //@todo not like this
+      // The filter variables container: i.e. services, filters
+      '&:first-child': {
+        // The wrapper of each filter
+        '& > div': {
+          // the 'service_name' filter wrapper
+          '&:nth-child(2) > div': {
+            gap: 0,
+          },
+          // The actual inputs container
+          '& > div': {
+            flexWrap: 'wrap',
+            // wrapper around all inputs
+            '& > div': {
+              maxWidth: '380px',
+
+              // Wrapper around each input: i.e. label name, binary operator, value
+              '& > div': {
+                // These inputs need to flex, otherwise the value takes all of available space and they look broken
+                flex: '1 0 auto',
+
+                // The value input needs to shrink when the parent component is at max width
+                '&:nth-child(3)': {
+                  flex: '0 1 auto',
+                },
+              },
+            },
+          },
+        },
+      },
+
+      ['div >[title="Add filter"]']: {
+        border: 0,
+        visibility: 'hidden',
+        width: 0,
+        padding: 0,
+        margin: 0,
+      },
+    }),
+    controls: css({
+      display: 'flex',
+      maxWidth: 450,
+      paddingTop: theme.spacing(3),
+      gap: theme.spacing(2),
+    }),
+    rotateIcon: css({
+      svg: { transform: 'rotate(180deg)' },
+    }),
+  };
+}

--- a/src/Components/IndexScene/LayoutScene.tsx
+++ b/src/Components/IndexScene/LayoutScene.tsx
@@ -1,6 +1,6 @@
 import { GrafanaTheme2 } from '@grafana/data';
 import { SceneComponentProps, SceneObjectBase, VariableValueSelectors } from '@grafana/scenes';
-import { useStyles2 } from '@grafana/ui';
+import { Badge, useStyles2 } from '@grafana/ui';
 import React from 'react';
 import { PatternControls } from './PatternControls';
 import { AppliedPattern, IndexSceneState } from './IndexScene';
@@ -31,6 +31,7 @@ export class LayoutScene extends SceneObjectBase {
                 )}
               </div>
               <div className={styles.controls}>
+                <Badge text={'Preview'} color={'blue'} icon={'rocket'} />
                 {controls.map((control) =>
                   control instanceof VariableValueSelectors === false ? (
                     <control.Component key={control.state.key} model={control} />
@@ -43,9 +44,7 @@ export class LayoutScene extends SceneObjectBase {
             patterns={patterns}
             onRemove={(patterns: AppliedPattern[]) => model.parent?.setState({ patterns } as IndexSceneState)}
           />
-          <div className={styles.body}>
-            <contentScene.Component model={contentScene} />
-          </div>
+          <div className={styles.body}>{contentScene && <contentScene.Component model={contentScene} />}</div>
         </div>
       </div>
     );
@@ -132,9 +131,8 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     controls: css({
       display: 'flex',
-      maxWidth: 450,
       paddingTop: theme.spacing(3),
-      gap: theme.spacing(2),
+      gap: theme.spacing(1),
     }),
     rotateIcon: css({
       svg: { transform: 'rotate(180deg)' },

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -63,10 +63,10 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
       ...state,
     });
 
-    this.addActivationHandler(this._onActivate.bind(this));
+    this.addActivationHandler(this.onActivate.bind(this));
   }
 
-  private _onActivate() {
+  private onActivate() {
     const variable = this.getVariable();
 
     sceneGraph.getAncestor(this, ServiceScene)!.subscribeToState((newState, oldState) => {

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -61,10 +61,10 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
       ...state,
     });
 
-    this.addActivationHandler(this._onActivate.bind(this));
+    this.addActivationHandler(this.onActivate.bind(this));
   }
 
-  private _onActivate() {
+  private onActivate() {
     const variable = this.getVariable();
 
     variable.subscribeToState((newState, oldState) => {

--- a/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
@@ -58,7 +58,7 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
       ...state,
     });
 
-    this.addActivationHandler(this._onActivate.bind(this));
+    this.addActivationHandler(this.onActivate.bind(this));
   }
 
   // parent render
@@ -114,7 +114,7 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
     );
   };
 
-  private _onActivate() {
+  private onActivate() {
     this.updateBody();
     this._subs.add(
       sceneGraph.getAncestor(this, ServiceScene).subscribeToState((newState, prevState) => {

--- a/src/Components/ServiceScene/LineFilter.tsx
+++ b/src/Components/ServiceScene/LineFilter.tsx
@@ -16,10 +16,10 @@ export class LineFilter extends SceneObjectBase<LineFilterState> {
 
   constructor(state?: Partial<LineFilterState>) {
     super({ lineFilter: state?.lineFilter || '', ...state });
-    this.addActivationHandler(this._onActivate);
+    this.addActivationHandler(this.onActivate);
   }
 
-  private _onActivate = () => {
+  private onActivate = () => {
     const lineFilterValue = this.getVariable().getValue();
     if (!lineFilterValue) {
       return;

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -21,10 +21,10 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
       ...state,
     });
 
-    this.addActivationHandler(this._onActivate.bind(this));
+    this.addActivationHandler(this.onActivate.bind(this));
   }
 
-  public _onActivate() {
+  public onActivate() {
     if (!this.state.panel) {
       this.setState({
         panel: this.getVizPanel(),

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -14,10 +14,10 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   constructor(state: LogsVolumePanelState) {
     super(state);
 
-    this.addActivationHandler(this._onActivate.bind(this));
+    this.addActivationHandler(this.onActivate.bind(this));
   }
 
-  private _onActivate() {
+  private onActivate() {
     if (!this.state.panel) {
       this.setState({
         panel: this.getVizPanel(),

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -88,7 +88,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
       ...state,
     });
 
-    this.addActivationHandler(this._onActivate.bind(this));
+    this.addActivationHandler(this.onActivate.bind(this));
   }
 
   private getFiltersVariable(): AdHocFiltersVariable {
@@ -141,7 +141,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     locationService.push(`${EXPLORATIONS_ROUTE}?${newParams}`);
   }
 
-  private _onActivate() {
+  private onActivate() {
     if (this.state.actionView === undefined) {
       this.setActionView('logs');
     }

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -78,10 +78,10 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
       ...state,
     });
 
-    this.addActivationHandler(this._onActivate.bind(this));
+    this.addActivationHandler(this.onActivate.bind(this));
   }
 
-  private _onActivate() {
+  private onActivate() {
     // Clear all adhoc filters when the scene is activated, if there are any
     const variable = sceneGraph.lookupVariable(VAR_FILTERS, this);
     if (variable instanceof AdHocFiltersVariable && variable.state.filters.length > 0) {


### PR DESCRIPTION
This PR extracts `LogsExplorationScene` out of `IndexScene`, and renames `LogsExplorationScene` to `LayoutScene`. The reason for the new name is that `LayoutScene` contains the header contents (Variable controls + pattern filters) and a variable body, which can be the `ServiceScene` or the `ServiceSelectionScene`, so there's no "logs exploration", but rather a combination of fixed contents + a variable body.

Other changes:
- Renamed a few `onActivate()` methods and removed the private underscore suffix. It used to be a mix of with and without underscore, and I don't think this is a pattern that we'd like to follow.
- Within `LayoutScene`, instead of accessing `IndexScene` internal state thorugh `sceneGraph`, we now use `model.parent.useState/setState`.