### PR TITLE
fix: url sync causing complete re-instantiation

### DIFF
--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -2,8 +2,14 @@ import React from 'react';
 import { AppRootProps } from '@grafana/data';
 import { Routes } from './Routes';
 
+const PluginPropsContext = React.createContext<AppRootProps | null>(null);
+
 export class App extends React.PureComponent<AppRootProps> {
   render() {
-    return <Routes />;
+    return (
+      <PluginPropsContext.Provider value={this.props}>
+        <Routes />
+      </PluginPropsContext.Provider>
+    );
   }
 }

--- a/src/Components/LogExplorationPage.tsx
+++ b/src/Components/LogExplorationPage.tsx
@@ -6,6 +6,7 @@ const DEFAULT_TIME_RANGE = { from: 'now-15m', to: 'now' };
 
 export function LogExplorationView() {
   const [isInitialized, setIsInitialized] = React.useState(false);
+  // Must memoize the top-level scene or any route change will re-instantiate all the scene classes
   const scene = useMemo(
     () =>
       new IndexScene({

--- a/src/Components/LogExplorationPage.tsx
+++ b/src/Components/LogExplorationPage.tsx
@@ -1,33 +1,29 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { SceneTimeRange, getUrlSyncManager } from '@grafana/scenes';
 import { IndexScene } from './IndexScene/IndexScene';
 const DEFAULT_TIME_RANGE = { from: 'now-15m', to: 'now' };
 
-export const LogExplorationPage = () => {
-  // Here we are initializing the scene with the default time range
-  const [exploration] = useState(
-    new IndexScene({
-      $timeRange: new SceneTimeRange(DEFAULT_TIME_RANGE),
-    })
-  );
-
-  return <LogExplorationView exploration={exploration} />;
-};
-
-function LogExplorationView({ exploration }: { exploration: IndexScene }) {
+export function LogExplorationView() {
   const [isInitialized, setIsInitialized] = React.useState(false);
+  const scene = useMemo(
+    () =>
+      new IndexScene({
+        $timeRange: new SceneTimeRange(DEFAULT_TIME_RANGE),
+      }),
+    []
+  );
 
   useEffect(() => {
     if (!isInitialized) {
-      getUrlSyncManager().initSync(exploration);
+      getUrlSyncManager().initSync(scene);
       setIsInitialized(true);
     }
-  }, [exploration, isInitialized]);
+  }, [scene, isInitialized]);
 
   if (!isInitialized) {
     return null;
   }
 
-  return <exploration.Component model={exploration} />;
+  return <scene.Component model={scene} />;
 }

--- a/src/Components/Routes.tsx
+++ b/src/Components/Routes.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { config } from '@grafana/runtime';
-import { LogExplorationPage } from './LogExplorationPage';
-import { ROUTES, prefixRoute } from 'services/routing';
+import { prefixRoute, ROUTES } from 'services/routing';
+import { LogExplorationView } from './LogExplorationPage';
 
 export const Routes = () => {
   const userPermissions = config.bootData.user.permissions;
@@ -13,7 +13,7 @@ export const Routes = () => {
 
   return (
     <Switch>
-      <Route path={prefixRoute(ROUTES.Explore)} component={LogExplorationPage} />
+      <Route path={prefixRoute(ROUTES.Explore)} component={LogExplorationView} />
       <Redirect to={prefixRoute(ROUTES.Explore)} />
     </Switch>
   );


### PR DESCRIPTION
Currently the IndexScene instantiates on every action that causes a url sync. This PR fixes and memoizes the index component, and adds the PluginPropsContext 