### PR TITLE
fix: service button could add multiple services

### DIFF
--- a/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
+++ b/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
@@ -10,47 +10,47 @@ import {
 import { Button } from '@grafana/ui';
 import { VariableHide } from '@grafana/schema';
 import { addToFavoriteServicesInStorage } from 'services/store';
-import { VAR_DATASOURCE } from 'services/variables';
+import { VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
 import { SERVICE_NAME, StartingPointSelectedEvent } from './ServiceSelectionScene';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 
-export interface SelectFieldButtonState extends SceneObjectState {
-  value: string;
+export interface SelectServiceButtonState extends SceneObjectState {
+  service: string;
 }
 
-export class SelectFieldButton extends SceneObjectBase<SelectFieldButtonState> {
+export class SelectServiceButton extends SceneObjectBase<SelectServiceButtonState> {
   public onClick = () => {
-    const variable = sceneGraph.lookupVariable('filters', this);
+    const variable = sceneGraph.lookupVariable(VAR_FILTERS, this);
     if (!(variable instanceof AdHocFiltersVariable)) {
       return;
     }
 
-    if (!this.state.value) {
+    if (!this.state.service) {
       return;
     }
 
     reportAppInteraction(USER_EVENTS_PAGES.service_selection, USER_EVENTS_ACTIONS.service_selection.service_selected, {
-      service: this.state.value,
+      service: this.state.service,
     });
 
     variable.setState({
       filters: [
-        ...variable.state.filters,
+        ...variable.state.filters.filter((f) => f.key !== SERVICE_NAME),
         {
           key: SERVICE_NAME,
           operator: '=',
-          value: this.state.value,
+          value: this.state.service,
         },
       ],
       hide: VariableHide.hideLabel,
     });
     const ds = sceneGraph.lookupVariable(VAR_DATASOURCE, this)?.getValue();
-    addToFavoriteServicesInStorage(ds, this.state.value);
+    addToFavoriteServicesInStorage(ds, this.state.service);
 
     this.publishEvent(new StartingPointSelectedEvent(), true);
   };
 
-  public static Component = ({ model }: SceneComponentProps<SelectFieldButton>) => {
+  public static Component = ({ model }: SceneComponentProps<SelectServiceButton>) => {
     return (
       <Button variant="secondary" size="sm" onClick={model.onClick}>
         Select

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -30,7 +30,7 @@ import { getFavoriteServicesFromStorage } from 'services/store';
 import { testIds } from 'services/testIds';
 import { LEVEL_VARIABLE_VALUE, VAR_DATASOURCE, VAR_FILTERS } from 'services/variables';
 import { GrotError } from '../GrotError';
-import { SelectFieldButton } from './SelectFieldButton';
+import { SelectServiceButton } from './SelectServiceButton';
 import { PLUGIN_ID } from 'services/routing';
 import { buildLokiQuery } from 'services/query';
 import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
@@ -224,7 +224,7 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
         .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
         .setOverrides(setLeverColorOverrides)
         .setOption('legend', { showLegend: false })
-        .setHeaderActions(new SelectFieldButton({ value: service }))
+        .setHeaderActions(new SelectServiceButton({ service }))
         .build(),
     });
   }


### PR DESCRIPTION

https://github.com/grafana/explore-logs/assets/8092184/cbd937d7-d6bf-4a52-966a-afa125a23ae5

In some edge cases multiple services could be selected. This PR should fix this behaviour.

Additionally, I rename the class to most suitable name.