### PR TITLE
fix(GoToExplore): link to explore was missing log parser

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -29,6 +29,7 @@ import {
   VAR_LINE_FILTER,
   VAR_PATTERNS,
   explorationDS,
+  VAR_LOGS_FORMAT,
 } from 'services/variables';
 
 import { ServiceScene } from '../ServiceScene/ServiceScene';
@@ -244,6 +245,7 @@ function getVariableSet(initialDS?: string, initialFilters?: AdHocVariableFilter
         hide: VariableHide.hideVariable,
       }),
       new CustomVariable({ name: VAR_LINE_FILTER, value: '', hide: VariableHide.hideVariable }),
+      new CustomVariable({ name: VAR_LOGS_FORMAT, value: '', hide: VariableHide.hideVariable }),
     ],
   });
 }

--- a/src/Components/ServiceScene/GoToExploreButton.tsx
+++ b/src/Components/ServiceScene/GoToExploreButton.tsx
@@ -5,7 +5,6 @@ import { config } from '@grafana/runtime';
 import { sceneGraph } from '@grafana/scenes';
 import { ToolbarButton } from '@grafana/ui';
 
-import { VAR_LOGS_FORMAT_EXPR } from 'services/variables';
 import { getDataSource, getQueryExpr } from 'services/scenes';
 import { testIds } from 'services/testIds';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
@@ -21,7 +20,7 @@ export const GoToExploreButton = ({ exploration }: ShareExplorationButtonState) 
       USER_EVENTS_ACTIONS.service_details.open_in_explore_clicked
     );
     const datasource = getDataSource(exploration);
-    const expr = getQueryExpr(exploration).replace(VAR_LOGS_FORMAT_EXPR, '').replace(/\s+/g, ' ').trimEnd();
+    const expr = getQueryExpr(exploration).replace(/\s+/g, ' ').trimEnd();
     const timeRange = sceneGraph.getTimeRange(exploration).state.value;
     const exploreState = JSON.stringify({
       ['loki-explore']: {

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -84,7 +84,6 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
   public constructor(state: MakeOptional<ServiceSceneState, 'body'>) {
     super({
       body: state.body ?? buildGraphScene(),
-      $variables: state.$variables,
       $data: getQueryRunner(buildLokiQuery(LOG_STREAM_SELECTOR_EXPR)),
       ...state,
     });

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -17,7 +17,6 @@ import {
   SceneObjectUrlSyncConfig,
   SceneObjectUrlValues,
   SceneVariable,
-  SceneVariableSet,
   VariableDependencyConfig,
 } from '@grafana/scenes';
 import { Box, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
@@ -85,9 +84,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
   public constructor(state: MakeOptional<ServiceSceneState, 'body'>) {
     super({
       body: state.body ?? buildGraphScene(),
-      $variables:
-        state.$variables ??
-        new SceneVariableSet({ variables: [new CustomVariable({ name: VAR_LOGS_FORMAT, value: '' })] }),
+      $variables: state.$variables,
       $data: getQueryRunner(buildLokiQuery(LOG_STREAM_SELECTOR_EXPR)),
       ...state,
     });


### PR DESCRIPTION
Clicking the explore button did not include the log format. This PR has a fix to include it.