### PR TITLE
fix(fields): disable tag provider

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -214,8 +214,8 @@ function getVariableSet(initialDS?: string, initialFilters?: AdHocVariableFilter
     label: 'Filters',
     applyMode: 'manual',
     layout: 'vertical',
-    getTagKeysProvider: () => Promise.resolve({ values: [] }),
-    getTagValuesProvider: () => Promise.resolve({ values: [] }),
+    getTagKeysProvider: () => Promise.resolve({ replace: true, values: [] }),
+    getTagValuesProvider: () => Promise.resolve({ replace: true, values: [] }),
     expressionBuilder: renderLogQLFieldFilters,
     hide: VariableHide.hideLabel,
   });


### PR DESCRIPTION
For now this disables to show more label values, as the label values previously were showing results from a wrong datasource.

In the future we can look into more sophisticated solutions.