### PR TITLE
feat(volume panels): add legend to volume panels with logs sum and possibility to filter in panel

### DIFF
--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -8,7 +8,7 @@ import {
   SceneObjectBase,
   SceneObjectState,
 } from '@grafana/scenes';
-import { DrawStyle, StackingMode } from '@grafana/ui';
+import { DrawStyle, LegendDisplayMode, StackingMode } from '@grafana/ui';
 import { getQueryRunner, setLeverColorOverrides } from 'services/panel';
 import { buildLokiQuery } from 'services/query';
 import { LEVEL_VARIABLE_VALUE, LOG_STREAM_SELECTOR_EXPR } from 'services/variables';
@@ -39,7 +39,8 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
         new SceneFlexItem({
           body: PanelBuilders.timeseries()
             .setTitle('Log volume')
-            .setOption('legend', { showLegend: false })
+            .setOption('legend', { showLegend: true, calcs: ['sum'], displayMode: LegendDisplayMode.List })
+            .setUnit('short')
             .setData(
               getQueryRunner(
                 buildLokiQuery(

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -220,7 +220,7 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
         .setData(
           getQueryRunner(
             buildLokiQuery(
-              `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME}=\`${service}\`} | logfmt| drop __error__ [$__auto]))`,
+              `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`,
               { legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}`, splitDuration }
             )
           )

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -14,7 +14,16 @@ import {
   SceneVariable,
   VariableDependencyConfig,
 } from '@grafana/scenes';
-import { DrawStyle, Field, Icon, Input, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafana/ui';
+import {
+  DrawStyle,
+  Field,
+  Icon,
+  Input,
+  LegendDisplayMode,
+  LoadingPlaceholder,
+  StackingMode,
+  useStyles2,
+} from '@grafana/ui';
 import { getLokiDatasource } from 'services/scenes';
 import { getFavoriteServicesFromStorage } from 'services/store';
 import { testIds } from 'services/testIds';
@@ -185,7 +194,7 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
           new SceneCSSGridLayout({
             children,
             isLazy: true,
-            templateColumns: 'repeat(auto-fit, minmax(400px, 1fr) minmax(600px, 70%))',
+            templateColumns: 'repeat(auto-fit, minmax(500px, 1fr) minmax(300px, 70%))',
             autoRows: '200px',
             md: {
               templateColumns: '1fr',
@@ -211,7 +220,7 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
         .setData(
           getQueryRunner(
             buildLokiQuery(
-              `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`,
+              `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME}=\`${service}\`} | logfmt| drop __error__ [$__auto]))`,
               { legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}`, splitDuration }
             )
           )
@@ -221,8 +230,14 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
         .setCustomFieldConfig('lineWidth', 0)
         .setCustomFieldConfig('pointSize', 0)
         .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
+        .setUnit('short')
         .setOverrides(setLeverColorOverrides)
-        .setOption('legend', { showLegend: false })
+        .setOption('legend', {
+          showLegend: true,
+          calcs: ['sum'],
+          placement: 'right',
+          displayMode: LegendDisplayMode.Table,
+        })
         .setHeaderActions(new SelectServiceButton({ service }))
         .build(),
     });

--- a/src/services/panel.test.ts
+++ b/src/services/panel.test.ts
@@ -12,12 +12,13 @@ describe('setLeverColorOverrides', () => {
     };
     setLeverColorOverrides(overrides);
 
-    expect(matchFieldsWithNameMock).toHaveBeenCalledTimes(4);
-    expect(overrideColorMock).toHaveBeenCalledTimes(4);
+    expect(matchFieldsWithNameMock).toHaveBeenCalledTimes(5);
+    expect(overrideColorMock).toHaveBeenCalledTimes(5);
     expect(matchFieldsWithNameMock).toHaveBeenCalledWith('info');
     expect(matchFieldsWithNameMock).toHaveBeenCalledWith('debug');
     expect(matchFieldsWithNameMock).toHaveBeenCalledWith('error');
     expect(matchFieldsWithNameMock).toHaveBeenCalledWith('warn');
+    expect(matchFieldsWithNameMock).toHaveBeenCalledWith('logs');
   });
 });
 

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -4,6 +4,7 @@ import { map, Observable } from 'rxjs';
 import { LokiQuery } from './query';
 import { explorationDS } from './variables';
 
+const UNKNOWN_LEVEL_LOGS = 'logs';
 // TODO: `FieldConfigOverridesBuilder` is not exported, so it can not be used
 // here.
 export function setLeverColorOverrides(overrides: any) {
@@ -23,19 +24,30 @@ export function setLeverColorOverrides(overrides: any) {
     mode: 'fixed',
     fixedColor: 'semi-dark-orange',
   });
+  overrides.matchFieldsWithName('logs').overrideColor({
+    mode: 'fixed',
+    fixedColor: 'darkgray',
+  });
 }
 
 export function sortLevelTransformation() {
   return (source: Observable<DataFrame[]>) => {
     return source.pipe(
       map((data: DataFrame[]) => {
-        return data.sort((a, b) => {
-          const aName: string | undefined = a.fields[1].config.displayNameFromDS;
-          const aVal = aName?.includes('error') ? 4 : aName?.includes('warn') ? 3 : aName?.includes('info') ? 2 : 1;
-          const bName: string | undefined = b.fields[1].config.displayNameFromDS;
-          const bVal = bName?.includes('error') ? 4 : bName?.includes('warn') ? 3 : bName?.includes('info') ? 2 : 1;
-          return aVal - bVal;
-        });
+        return data
+          .map((d) => {
+            if (!d.fields[1].config.displayNameFromDS) {
+              d.fields[1].config.displayNameFromDS = UNKNOWN_LEVEL_LOGS;
+            }
+            return d;
+          })
+          .sort((a, b) => {
+            const aName: string | undefined = a.fields[1].config.displayNameFromDS;
+            const aVal = aName?.includes('error') ? 4 : aName?.includes('warn') ? 3 : aName?.includes('info') ? 2 : 1;
+            const bName: string | undefined = b.fields[1].config.displayNameFromDS;
+            const bVal = bName?.includes('error') ? 4 : bName?.includes('warn') ? 3 : bName?.includes('info') ? 2 : 1;
+            return aVal - bVal;
+          });
       })
     );
   };


### PR DESCRIPTION
This PR:
1. Adds total count of logs to  in service selection in form of table on right (levels are not filterable)
  - also makes time series panel 100px wider to accomodate new legend table 
3. Adds total count of logs to  in service detail in form of list on the bottom (levels are not filterable)
4. If we don't have level, instead of having `Value`, it renames it to `logs`. We could also do `unknown`, but in explore, we were just naming it `logs` which I like
5. If we don't have level, changes color to `gray` to distinguish from `info`

https://github.com/grafana/explore-logs/assets/30407135/396116d0-74f1-44dd-9a17-16770a0ee90d

Fixes: https://github.com/grafana/explore-logs/issues/217