### PR TITLE
fix(patterns): only allow a single include pattern

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
@@ -52,7 +52,7 @@ export class FilterByPatternsButton extends SceneObjectBase<FilterByPatternsButt
     const { type } = model.useState();
     return (
       <Button variant="secondary" size="sm" onClick={model.onClick}>
-        {type === 'include' ? 'Add to filters' : 'Exclude from filters'}
+        {type === 'include' ? 'Select' : 'Exclude'}
       </Button>
     );
   };

--- a/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
@@ -21,7 +21,18 @@ export class FilterByPatternsButton extends SceneObjectBase<FilterByPatternsButt
     const { patterns = [] } = logExploration.state;
 
     // Remove the pattern if it's already there
-    const filteredPatterns = patterns.filter((pattern) => pattern.pattern !== this.state.pattern);
+    let filteredPatterns = patterns.filter((pattern) => pattern.pattern !== this.state.pattern);
+
+    if (this.state.type === 'include') {
+      // Patterns are mutually exclusive, if one is included, we should remove the rest
+      filteredPatterns = [{ pattern: this.state.pattern, type: this.state.type }];
+    } else {
+      // If a pattern is excluded, remove any existing included patterns
+      filteredPatterns = [
+        ...filteredPatterns.filter((pat) => pat.type === 'exclude'),
+        { pattern: this.state.pattern, type: this.state.type },
+      ];
+    }
 
     // Analytics
     const includePatternsLength = filteredPatterns.filter((p) => p.type === 'include')?.length ?? 0;
@@ -33,7 +44,7 @@ export class FilterByPatternsButton extends SceneObjectBase<FilterByPatternsButt
     });
 
     logExploration.setState({
-      patterns: [...filteredPatterns, { pattern: this.state.pattern, type: this.state.type }],
+      patterns: filteredPatterns,
     });
   };
 

--- a/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
@@ -268,6 +268,7 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
     const headerActions = buildPatternHeaderActions(status, pattern);
     return PanelBuilders.timeseries()
       .setTitle(`${pattern}`)
+
       .setDescription(`The pattern \`${pattern}\` has been matched \`${sum}\` times in the given timerange.`)
       .setOption('legend', { showLegend: false })
       .setData(

--- a/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
@@ -15,6 +15,7 @@ import {
   SceneObjectBase,
   SceneObjectState,
   SceneVariableSet,
+  VizPanelState,
 } from '@grafana/scenes';
 import { Button, DrawStyle, StackingMode, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { AddToFiltersButton } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
@@ -25,6 +26,7 @@ import { VAR_LABEL_GROUP_BY } from 'services/variables';
 import { getColorByIndex } from 'services/scenes';
 import { LokiPattern, ServiceScene } from '../ServiceScene';
 import { FilterByPatternsButton } from './FilterByPatternsButton';
+import { AppliedPattern, IndexScene } from '../../IndexScene/IndexScene';
 
 export interface PatternsBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -38,7 +40,26 @@ type PatternFrame = {
   dataFrame: DataFrame;
   pattern: string;
   sum: number;
+  status?: 'include' | 'exclude';
 };
+
+function buildPatternHeaderActions(
+  status: 'include' | 'exclude' | undefined,
+  pattern: string
+): VizPanelState['headerActions'] {
+  if (status) {
+    if (status === 'include') {
+      return [new FilterByPatternsButton({ pattern: pattern, type: 'exclude' })];
+    } else {
+      return [new FilterByPatternsButton({ pattern: pattern, type: 'include' })];
+    }
+  } else {
+    return [
+      new FilterByPatternsButton({ pattern: pattern, type: 'exclude' }),
+      new FilterByPatternsButton({ pattern: pattern, type: 'include' }),
+    ];
+  }
+}
 
 export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSceneState> {
   constructor(state: Partial<PatternsBreakdownSceneState>) {
@@ -137,14 +158,14 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
   }
 
   private async updateBody() {
-    const children: SceneFlexItemLike[] = [];
-
-    const patterns = sceneGraph.getAncestor(this, ServiceScene).state.patterns;
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
+    const patterns = serviceScene.state.patterns;
+    const appliedPatterns = sceneGraph.getAncestor(serviceScene, IndexScene).state.patterns;
     if (!patterns) {
       return;
     }
 
-    this.buildPatterns(patterns, children);
+    const children = this.buildPatterns(patterns, appliedPatterns);
 
     this.setState({
       body: new LayoutSwitcher({
@@ -173,7 +194,8 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
     });
   }
 
-  private buildPatterns(patterns: LokiPattern[], children: SceneFlexItemLike[]) {
+  private buildPatterns(patterns: LokiPattern[], appliedPatterns?: AppliedPattern[]) {
+    const children: SceneFlexItemLike[] = [];
     let maxValue = -Infinity;
     let minValue = 0;
 
@@ -215,11 +237,13 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
             preferredVisualisationType: 'graph',
           },
         };
+        const existingPattern = appliedPatterns?.find((appliedPattern) => appliedPattern.pattern === pat.pattern);
 
         return {
           dataFrame,
           pattern: pat.pattern,
           sum,
+          status: existingPattern?.type,
         };
       })
       .sort((a, b) => b.sum - a.sum);
@@ -227,20 +251,21 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
     const timeRange = sceneGraph.getTimeRange(this).state.value;
 
     for (let i = 0; i < frames.length; i++) {
-      const { dataFrame, pattern, sum } = frames[i];
-      children.push(this.buildPatternTimeseries(dataFrame, timeRange, pattern, sum, i, minValue, maxValue));
+      children.push(this.buildPatternTimeseries(frames[i], timeRange, i, minValue, maxValue));
     }
+
+    return children;
   }
 
   private buildPatternTimeseries(
-    dataFrame: DataFrame,
+    patternFrame: PatternFrame,
     timeRange: TimeRange,
-    pattern: string,
-    sum: number,
     index: number,
     minValue: number,
     maxValue: number
   ) {
+    const { dataFrame, pattern, sum, status } = patternFrame;
+    const headerActions = buildPatternHeaderActions(status, pattern);
     return PanelBuilders.timeseries()
       .setTitle(`${pattern}`)
       .setDescription(`The pattern \`${pattern}\` has been matched \`${sum}\` times in the given timerange.`)
@@ -262,10 +287,7 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
       .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
       .setCustomFieldConfig('axisSoftMax', maxValue)
       .setCustomFieldConfig('axisSoftMin', minValue)
-      .setHeaderActions([
-        new FilterByPatternsButton({ pattern: pattern, type: 'exclude' }),
-        new FilterByPatternsButton({ pattern: pattern, type: 'include' }),
-      ])
+      .setHeaderActions(headerActions)
       .build();
   }
 }

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -55,9 +55,9 @@ test.describe('explore services breakdown page', () => {
     await expect(page.getByText('level=info < … g block" <_>')).toBeVisible();
   });
 
-  test('patterns should be lazy loaded', async ({ page }) => {
+  test.only('patterns should be lazy loaded', async ({ page }) => {
     await page.getByLabel('Tab Patterns').click();
-    const addToFilterButtons = page
+    const addToFilterButtons = page.getByTestId('header-container')
         .getByRole('button', { name: 'Select' })
 
     // Only the first 4 patterns are visible above the fold

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -46,7 +46,7 @@ test.describe('explore services breakdown page', () => {
     await page.getByLabel('Tab Patterns').click();
     await page
       .getByTestId('data-testid Panel header level=info <_> caller=flush.go:253 msg="completing block" <_>')
-      .getByRole('button', { name: 'Add to filters' })
+      .getByRole('button', { name: 'Select' })
       .click();
     // Should see the logs panel full of patterns
     await expect(page.getByTestId('data-testid search-logs')).toBeVisible();
@@ -58,7 +58,7 @@ test.describe('explore services breakdown page', () => {
   test('patterns should be lazy loaded', async ({ page }) => {
     await page.getByLabel('Tab Patterns').click();
     const addToFilterButtons = page
-        .getByRole('button', { name: 'Add to filters' })
+        .getByRole('button', { name: 'Select' })
 
     // Only the first 4 patterns are visible above the fold
     await expect(addToFilterButtons).toHaveCount(4)

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -55,7 +55,7 @@ test.describe('explore services breakdown page', () => {
     await expect(page.getByText('level=info < … g block" <_>')).toBeVisible();
   });
 
-  test.only('patterns should be lazy loaded', async ({ page }) => {
+  test('patterns should be lazy loaded', async ({ page }) => {
     await page.getByLabel('Tab Patterns').click();
     const addToFilterButtons = page.getByTestId('header-container')
         .getByRole('button', { name: 'Select' })


### PR DESCRIPTION
Fixes: https://github.com/grafana/explore-logs/issues/218

This PR does 2 things:
1. When a pattern is already excluded, it will hide the exclude pattern button. Same with included patterns
2. When a pattern is included, all other patterns are removed from state.

https://github.com/grafana/explore-logs/assets/109082771/2e8afe1d-53d1-4933-a0fa-fb0ec1b0b3ca

