### PR TITLE
fix(ServiceSelectionScene): disable hover tooltips

### DIFF
--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -444,7 +444,7 @@ const MAIN_PANEL_MAX_HEIGHT = '30%';
 function buildGraphScene() {
   return new SceneFlexLayout({
     direction: 'column',
-    $behaviors: [new behaviors.CursorSync({ key: 'metricCrosshairSync', sync: DashboardCursorSync.Crosshair })],
+    $behaviors: [new behaviors.CursorSync({ key: 'logsCrosshairSync', sync: DashboardCursorSync.Crosshair })],
     children: [
       new SceneFlexItem({
         minHeight: MAIN_PANEL_MIN_HEIGHT,

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -22,6 +22,7 @@ import {
   LegendDisplayMode,
   LoadingPlaceholder,
   StackingMode,
+  TooltipDisplayMode,
   useStyles2,
 } from '@grafana/ui';
 import { getLokiDatasource } from 'services/scenes';
@@ -237,6 +238,9 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
           calcs: ['sum'],
           placement: 'right',
           displayMode: LegendDisplayMode.Table,
+        })
+        .setOption('tooltip', {
+          mode: TooltipDisplayMode.None,
         })
         .setHeaderActions(new SelectServiceButton({ service }))
         .build(),

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -22,7 +22,6 @@ import {
   LegendDisplayMode,
   LoadingPlaceholder,
   StackingMode,
-  TooltipDisplayMode,
   useStyles2,
 } from '@grafana/ui';
 import { getLokiDatasource } from 'services/scenes';
@@ -238,9 +237,6 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
           calcs: ['sum'],
           placement: 'right',
           displayMode: LegendDisplayMode.Table,
-        })
-        .setOption('tooltip', {
-          mode: TooltipDisplayMode.None,
         })
         .setHeaderActions(new SelectServiceButton({ service }))
         .build(),

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/css';
 import { debounce } from 'lodash';
 import React, { useCallback, useState } from 'react';
-import { BusEventBase, GrafanaTheme2, TimeRange } from '@grafana/data';
+import { BusEventBase, DashboardCursorSync, GrafanaTheme2, TimeRange } from '@grafana/data';
 import {
   AdHocFiltersVariable,
+  behaviors,
   PanelBuilders,
   SceneComponentProps,
   SceneCSSGridItem,
@@ -246,6 +247,7 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
   // Creates a layout with logs panel
   buildServiceLogsLayout(service: string) {
     return new SceneCSSGridItem({
+      $behaviors: [new behaviors.CursorSync({ sync: DashboardCursorSync.Off })],
       body: PanelBuilders.logs()
         // Hover header set to true removes unused header padding, displaying more logs
         .setHoverHeader(true)

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -222,7 +222,7 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
           getQueryRunner(
             buildLokiQuery(
               `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`,
-              { legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}`, splitDuration }
+              { legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}`, splitDuration, refId: `ts-${service}` }
             )
           )
         )
@@ -253,7 +253,11 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
       body: PanelBuilders.logs()
         // Hover header set to true removes unused header padding, displaying more logs
         .setHoverHeader(true)
-        .setData(getQueryRunner(buildLokiQuery(`{${SERVICE_NAME}=\`${service}\`}`, { maxLines: 100 })))
+        .setData(
+          getQueryRunner(
+            buildLokiQuery(`{${SERVICE_NAME}=\`${service}\`}`, { maxLines: 100, refId: `logs-${service}` })
+          )
+        )
         .setOption('showTime', true)
         .setOption('enableLogDetails', false)
         .build(),


### PR DESCRIPTION
This PR disables the hover tooltips that are shown in the following video:

https://github.com/grafana/explore-logs/assets/1069378/efc0e1f9-7c36-4dc9-b09a-f7b116dfbcae

The reason is that the behavior and information it shows is potentially confusing, and the tooltip is very hard to dismiss.