### PR TITLE
Patterns: change label to singular and increase preview size

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "6.1.4",
     "@testing-library/react": "14.0.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.0",
     "@types/lodash": "^4.14.194",
     "@types/node": "^20.8.7",

--- a/src/Components/IndexScene/PatternControls.test.tsx
+++ b/src/Components/IndexScene/PatternControls.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { PatternControls } from './PatternControls';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AppliedPattern } from './IndexScene';
+
+const originalWidth = global.window.innerWidth;
+beforeAll(() => {
+  global.window.innerWidth = 1200;
+});
+
+afterAll(() => {
+  global.window.innerWidth = originalWidth;
+});
+
+const patterns = [
+  'level=warn <_> caller=instance.go:43 msg="TRACE_TOO_LARGE: max size of trace (52428800) exceeded tenant <_>',
+  'level=info <_> caller=compactor.go:242 msg="flushed to block" <_>',
+];
+
+describe('PatternControls', () => {
+  test('Does not render when there are no patterns', () => {
+    const { container } = render(<PatternControls patterns={undefined} onRemove={jest.fn()} />);
+
+    expect(container).toMatchInlineSnapshot('<div />');
+  });
+
+  test('Displays the applied pattern', () => {
+    render(<PatternControls patterns={[{ pattern: patterns[0], type: 'include' }]} onRemove={jest.fn()} />);
+
+    expect(screen.getByText('Pattern')).toBeInTheDocument();
+    expect(screen.getByText(patterns[0])).toBeInTheDocument();
+  });
+
+  test('Allows to remove patterns', async () => {
+    const onRemove = jest.fn();
+    render(<PatternControls patterns={[{ pattern: patterns[0], type: 'include' }]} onRemove={onRemove} />);
+
+    await userEvent.click(screen.getByLabelText('Remove pattern'));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  test('Displays an excluded pattern', () => {
+    render(<PatternControls patterns={[{ pattern: patterns[0], type: 'exclude' }]} onRemove={jest.fn()} />);
+
+    expect(screen.getByText(/Excluded pattern/)).toBeInTheDocument();
+    expect(screen.getByText(patterns[0])).toBeInTheDocument();
+  });
+
+  test('Displays excluded patterns', () => {
+    const excludedPatterns: AppliedPattern[] = patterns.map((pattern) => ({
+      pattern,
+      type: 'exclude',
+    }));
+    render(<PatternControls patterns={excludedPatterns} onRemove={jest.fn()} />);
+
+    expect(screen.getByText(/Excluded patterns/)).toBeInTheDocument();
+    expect(screen.getAllByLabelText('Remove pattern')).toHaveLength(2);
+  });
+});

--- a/src/Components/IndexScene/PatternControls.tsx
+++ b/src/Components/IndexScene/PatternControls.tsx
@@ -34,7 +34,7 @@ export const PatternControls = ({ patterns, onRemove }: Props) => {
       {includePatterns.length > 0 && (
         <div className={styles.patternsContainer}>
           <Text variant="bodySmall" weight="bold">
-            {excludePatterns.length > 0 ? 'Include patterns' : 'Patterns'}
+            {excludePatterns.length > 0 ? 'Include pattern' : 'Pattern'}
           </Text>
           <div className={styles.patterns}>
             {includePatterns.map((p) => (
@@ -46,7 +46,7 @@ export const PatternControls = ({ patterns, onRemove }: Props) => {
       {excludePatterns.length > 0 && (
         <div className={styles.patternsContainer}>
           <Text variant="bodySmall" weight="bold">
-            Exclude patterns:
+            Exclude pattern:
           </Text>
           <div className={styles.patterns}>
             {excludePatterns.map((p) => (

--- a/src/Components/IndexScene/PatternControls.tsx
+++ b/src/Components/IndexScene/PatternControls.tsx
@@ -34,11 +34,11 @@ export const PatternControls = ({ patterns, onRemove }: Props) => {
       {includePatterns.length > 0 && (
         <div className={styles.patternsContainer}>
           <Text variant="bodySmall" weight="bold">
-            {excludePatterns.length > 0 ? 'Include pattern' : 'Pattern'}
+            {excludePatterns.length > 0 ? 'Include pattern' : `Pattern${patterns.length > 1 ? 's' : ''}`}
           </Text>
           <div className={styles.patterns}>
             {includePatterns.map((p) => (
-              <PatternTag key={p.pattern} pattern={p.pattern} onRemove={() => onRemovePattern(p)} />
+              <PatternTag key={p.pattern} pattern={p.pattern} size="lg" onRemove={() => onRemovePattern(p)} />
             ))}
           </div>
         </div>
@@ -46,11 +46,16 @@ export const PatternControls = ({ patterns, onRemove }: Props) => {
       {excludePatterns.length > 0 && (
         <div className={styles.patternsContainer}>
           <Text variant="bodySmall" weight="bold">
-            Exclude pattern:
+            Excluded pattern{excludePatterns.length > 1 ? 's' : ''}:
           </Text>
           <div className={styles.patterns}>
             {excludePatterns.map((p) => (
-              <PatternTag key={p.pattern} pattern={p.pattern} onRemove={() => onRemovePattern(p)} />
+              <PatternTag
+                key={p.pattern}
+                pattern={p.pattern}
+                size={excludePatterns.length > 1 ? 'sm' : 'lg'}
+                onRemove={() => onRemovePattern(p)}
+              />
             ))}
           </div>
         </div>

--- a/src/Components/IndexScene/PatternTag.tsx
+++ b/src/Components/IndexScene/PatternTag.tsx
@@ -26,7 +26,7 @@ export const PatternTag = ({ onRemove, pattern }: Props) => {
   );
 };
 
-const MAX_PATTERN_WIDTH = 25;
+const MAX_PATTERN_WIDTH = Math.round(window.innerWidth / 8);
 
 function getPatternPreview(pattern: string) {
   const length = pattern.length;
@@ -34,7 +34,7 @@ function getPatternPreview(pattern: string) {
     return pattern;
   }
 
-  const substringLength = Math.round(length * 0.2);
+  const substringLength = Math.round(MAX_PATTERN_WIDTH * 0.4);
 
   return `${pattern.substring(0, substringLength)} … ${pattern.substring(length - substringLength)}`;
 }

--- a/src/Components/IndexScene/PatternTag.tsx
+++ b/src/Components/IndexScene/PatternTag.tsx
@@ -6,9 +6,12 @@ import React, { useState } from 'react';
 interface Props {
   onRemove(): void;
   pattern: string;
+  size?: PatternSize;
 }
 
-export const PatternTag = ({ onRemove, pattern }: Props) => {
+type PatternSize = 'sm' | 'lg';
+
+export const PatternTag = ({ onRemove, pattern, size = 'lg' }: Props) => {
   const styles = useStyles2(getStyles);
   const [expanded, setExpanded] = useState(false);
   return (
@@ -16,7 +19,7 @@ export const PatternTag = ({ onRemove, pattern }: Props) => {
       <Tag
         title={pattern}
         key={pattern}
-        name={expanded ? pattern : getPatternPreview(pattern)}
+        name={expanded ? pattern : getPatternPreview(pattern, size)}
         className={styles.tag}
       />
       <Button variant="secondary" size="sm" className={styles.removeButton} onClick={onRemove}>
@@ -26,15 +29,18 @@ export const PatternTag = ({ onRemove, pattern }: Props) => {
   );
 };
 
-const MAX_PATTERN_WIDTH = Math.round(window.innerWidth / 8);
+const PREVIEW_WIDTH: Record<PatternSize, number> = {
+  sm: 50,
+  lg: Math.round(window.innerWidth / 8),
+};
 
-function getPatternPreview(pattern: string) {
+function getPatternPreview(pattern: string, size: PatternSize) {
   const length = pattern.length;
-  if (length < MAX_PATTERN_WIDTH) {
+  if (length < PREVIEW_WIDTH[size]) {
     return pattern;
   }
 
-  const substringLength = Math.round(MAX_PATTERN_WIDTH * 0.4);
+  const substringLength = Math.round(PREVIEW_WIDTH[size] * 0.4);
 
   return `${pattern.substring(0, substringLength)} … ${pattern.substring(length - substringLength)}`;
 }

--- a/src/Components/IndexScene/PatternTag.tsx
+++ b/src/Components/IndexScene/PatternTag.tsx
@@ -22,7 +22,13 @@ export const PatternTag = ({ onRemove, pattern, size = 'lg' }: Props) => {
         name={expanded ? pattern : getPatternPreview(pattern, size)}
         className={styles.tag}
       />
-      <Button variant="secondary" size="sm" className={styles.removeButton} onClick={onRemove}>
+      <Button
+        aria-label="Remove pattern"
+        variant="secondary"
+        size="sm"
+        className={styles.removeButton}
+        onClick={onRemove}
+      >
         <Icon name="times" />
       </Button>
     </div>

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -91,7 +91,7 @@ test.describe('explore services breakdown page', () => {
     await secondExcludeButton.click();
 
     // Both exclude patterns should be visible
-    await expect(page.getByText('Patterns', { exact: true })).not.toBeVisible();
+    await expect(page.getByText('Pattern', { exact: true })).not.toBeVisible();
     await expect(page.getByText('Excluded patterns:', { exact: true })).toBeVisible();
     await expect(page.getByText('level=info <_> calle … ompleting block" <_>')).toBeVisible();
     await expect(page.getByText('level=debug <_> call … ectors/compactor <_>')).toBeVisible();
@@ -100,7 +100,7 @@ test.describe('explore services breakdown page', () => {
     await page.getByLabel('Tab Patterns').click();
 
     await firstIncludeButton.click();
-    await expect(page.getByText('Patterns', { exact: true })).toBeVisible();
+    await expect(page.getByText('Pattern', { exact: true })).toBeVisible();
     await expect(page.getByText('Excluded patterns:', { exact: true })).not.toBeVisible();
     await expect(page.getByText('level=info <_> caller=flush.go:253 msg="completing block" <_>')).toBeVisible();
   });

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -53,7 +53,7 @@ test.describe('explore services breakdown page', () => {
     // Should see the logs panel full of patterns
     await expect(page.getByTestId('data-testid search-logs')).toBeVisible();
     // Pattern filter should be added
-    await expect(page.getByText('Patterns', { exact: true })).toBeVisible();
+    await expect(page.getByText('Pattern', { exact: true })).toBeVisible();
     await expect(page.getByText('level=info < … g block" <_>')).toBeVisible();
   });
 

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -93,8 +93,8 @@ test.describe('explore services breakdown page', () => {
     // Both exclude patterns should be visible
     await expect(page.getByText('Patterns', { exact: true })).not.toBeVisible();
     await expect(page.getByText('Excluded patterns:', { exact: true })).toBeVisible();
-    await expect(page.getByText('level=info < … g block" <_>')).toBeVisible();
-    await expect(page.getByText('level=debug <_> calle … lectors/compactor')).toBeVisible();
+    await expect(page.getByText('level=info <_> calle … ompleting block" <_>')).toBeVisible();
+    await expect(page.getByText('level=debug <_> call … ectors/compactor <_>')).toBeVisible();
 
     // Back to patterns to include a pattern instead
     await page.getByLabel('Tab Patterns').click();
@@ -102,7 +102,7 @@ test.describe('explore services breakdown page', () => {
     await firstIncludeButton.click();
     await expect(page.getByText('Patterns', { exact: true })).toBeVisible();
     await expect(page.getByText('Excluded patterns:', { exact: true })).not.toBeVisible();
-    await expect(page.getByText('level=info < … g block" <_>')).toBeVisible();
+    await expect(page.getByText('level=info <_> caller=flush.go:253 msg="completing block" <_>')).toBeVisible();
   });
 
   test('should update a filter and run new logs', async ({ page }) => {

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -92,7 +92,7 @@ test.describe('explore services breakdown page', () => {
 
     // Both exclude patterns should be visible
     await expect(page.getByText('Patterns', { exact: true })).not.toBeVisible();
-    await expect(page.getByText('Exclude patterns:', { exact: true })).toBeVisible();
+    await expect(page.getByText('Excluded patterns:', { exact: true })).toBeVisible();
     await expect(page.getByText('level=info < … g block" <_>')).toBeVisible();
     await expect(page.getByText('level=debug <_> calle … lectors/compactor')).toBeVisible();
 
@@ -101,7 +101,7 @@ test.describe('explore services breakdown page', () => {
 
     await firstIncludeButton.click();
     await expect(page.getByText('Patterns', { exact: true })).toBeVisible();
-    await expect(page.getByText('Exclude patterns:', { exact: true })).not.toBeVisible();
+    await expect(page.getByText('Excluded patterns:', { exact: true })).not.toBeVisible();
     await expect(page.getByText('level=info < … g block" <_>')).toBeVisible();
   });
 

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -54,7 +54,7 @@ test.describe('explore services breakdown page', () => {
     await expect(page.getByTestId('data-testid search-logs')).toBeVisible();
     // Pattern filter should be added
     await expect(page.getByText('Pattern', { exact: true })).toBeVisible();
-    await expect(page.getByText('level=info < … g block" <_>')).toBeVisible();
+    await expect(page.getByText('level=info <_> caller=flush.go:253 msg="completing block" <_>')).toBeVisible();
   });
 
   test('Should add multiple exclude patterns, which are replaced by include pattern', async ({ page }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,6 +1840,11 @@
     "@testing-library/dom" "^9.0.0"
     "@types/react-dom" "^18.0.0"
 
+"@testing-library/user-event@^14.5.2":
+  version "14.5.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.5.2.tgz#db7257d727c891905947bd1c1a99da20e03c2ebd"
+  integrity sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"


### PR DESCRIPTION
After https://github.com/grafana/explore-logs/pull/343 we no longer allow multiple pattern filters. For that, in this PR:
- Added `lg` and `sm` sizes to `PatternTag`
- Use `lg` "Pattern" when filtering by a single pattern
  ![Pattern](https://github.com/grafana/explore-logs/assets/1069378/285b4d74-964d-4fa6-8be5-625402dd42f1)
- Use `lg` "Excluded pattern" when excluding a single pattern
  ![Excluded pattern](https://github.com/grafana/explore-logs/assets/1069378/96086549-d418-452d-97e2-4fabdb1724eb)
- Use `sm` "Excluded patterns" when excluding multiple patterns
  ![Excluded patterns](https://github.com/grafana/explore-logs/assets/1069378/b98c97fd-076d-4533-a2b8-4b6c44566b3b)
- Define the `lg` pattern tag preview size based on the screen size. The chosen value seems to nicely behave under different viewport sizes:

https://github.com/grafana/explore-logs/assets/1069378/82d9e59c-f028-4bdd-b444-df007146436b

