### PR TITLE
fix(LineFilter): keep track of search length and attributes but not contents

### DIFF
--- a/src/Components/ServiceScene/LineFilter.tsx
+++ b/src/Components/ServiceScene/LineFilter.tsx
@@ -55,7 +55,8 @@ export class LineFilter extends SceneObjectBase<LineFilterState> {
       USER_EVENTS_PAGES.service_details,
       USER_EVENTS_ACTIONS.service_details.search_string_in_logs_changed,
       {
-        searchQuery: search,
+        searchQueryLength: search.length,
+        containsLevel: search.toLowerCase().includes('level'),
       }
     );
   }, 350);


### PR DESCRIPTION
I was looking at usage tracking, and realized we were storing the contents of the line filter searches. We don't even store original queries, which are [obfuscated](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/loki/tracking.ts#L185). Ammending that in this PR.