### PR TITLE
feat(tracking): change event names to not include dashes

### DIFF
--- a/src/services/analytics.test.ts
+++ b/src/services/analytics.test.ts
@@ -9,10 +9,7 @@ test('Reports an event with the expected name and properties', () => {
     USER_EVENTS_ACTIONS[USER_EVENTS_PAGES.service_details].open_in_explore_clicked,
     { query: '{a="b"}' }
   );
-  expect(reportInteraction).toHaveBeenCalledWith(
-    'grafana_grafana-lokiexplore-app_service_selection_open_in_explore_clicked',
-    {
-      query: '{a="b"}',
-    }
-  );
+  expect(reportInteraction).toHaveBeenCalledWith('grafana_lokiexplore_app_service_selection_open_in_explore_clicked', {
+    query: '{a="b"}',
+  });
 });

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -3,7 +3,7 @@ import pluginJson from '../plugin.json';
 
 // Helper function to create a unique interaction name for analytics
 const createInteractionName = (page: UserEventPagesType, action: string) => {
-  return `grafana_${pluginJson.id}_${page}_${action}`;
+  return `${pluginJson.id.replace(/-/g, '_')}_${page}_${action}`;
 };
 
 // Runs reportInteraction with a standardized interaction name


### PR DESCRIPTION
Event names should not include underscores, however the plugin id contained dashed. Those will be replaced by underscores for now.