### PR TITLE
chore: make patterns graph smaller - the same size as logs volume

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
@@ -227,7 +227,7 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
       maxWidth: '100%',
       children: [
         new SceneFlexItem({
-          minHeight: 300,
+          minHeight: 200,
           maxWidth: '100%',
           body: timeSeries,
         }),

--- a/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
@@ -165,7 +165,7 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
   private getSingleViewLayout(patternFrames: PatternFrame[], logExploration: IndexScene) {
     const appliedPatterns = sceneGraph.getAncestor(logExploration, IndexScene).state.patterns;
     const timeRange = sceneGraph.getTimeRange(this).state.value;
-    // @ts-ignore
+
     const timeSeries = PanelBuilders.timeseries()
       .setData(
         new SceneDataNode({

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -42,7 +42,11 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
         }),
         new SceneFlexItem({
           height: 'calc(100vh - 220px)',
-          body: PanelBuilders.logs().setOption('showLogContextToggle', true).setOption('showTime', true).build(),
+          body: PanelBuilders.logs()
+            .setOption('showLogContextToggle', true)
+            .setOption('showTime', true)
+            .setHoverHeader(true)
+            .build(),
         }),
       ],
     });

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -42,11 +42,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
         }),
         new SceneFlexItem({
           height: 'calc(100vh - 220px)',
-          body: PanelBuilders.logs()
-            .setTitle('Logs')
-            .setOption('showLogContextToggle', true)
-            .setOption('showTime', true)
-            .build(),
+          body: PanelBuilders.logs().setOption('showLogContextToggle', true).setOption('showTime', true).build(),
         }),
       ],
     });

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -105,7 +105,7 @@ test.describe('explore services breakdown page', () => {
     await expect(page.getByText('level=info <_> caller=flush.go:253 msg="completing block" <_>')).toBeVisible();
   });
 
-  test('should update a filter and run new logs', async ({ page }) => {
+  test.only('should update a filter and run new logs', async ({ page }) => {
     await page.getByTestId('AdHocFilter-service_name').getByRole('img').nth(1).click();
     await page.getByText('mimir-distributor').click();
 
@@ -113,6 +113,6 @@ test.describe('explore services breakdown page', () => {
     await page.getByTitle('See log details').nth(1).click();
 
     // find text corresponding text to match adhoc filter
-    await expect(page.getByTestId('data-testid Panel header Logs').getByText('mimir-distributor').nth(0)).toBeVisible();
+    await expect(page.getByRole('cell', { name: 'Fields Ad-hoc statistics' }).getByText('mimir-distributor').nth(0)).toBeVisible();
   });
 });

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -105,7 +105,7 @@ test.describe('explore services breakdown page', () => {
     await expect(page.getByText('level=info <_> caller=flush.go:253 msg="completing block" <_>')).toBeVisible();
   });
 
-  test.only('should update a filter and run new logs', async ({ page }) => {
+  test('should update a filter and run new logs', async ({ page }) => {
     await page.getByTestId('AdHocFilter-service_name').getByRole('img').nth(1).click();
     await page.getByText('mimir-distributor').click();
 


### PR DESCRIPTION
plus remove logs from logs panel
<img width="1499" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/7851b1a5-03d8-4e18-afe3-efbde7df925b">
<img width="1500" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/08641ebd-22ae-4bf0-92ad-f37e404aab28">
