### PR TITLE
fix(patterns): fix bug introduced by using viewport units in styles

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
@@ -6,9 +6,9 @@ import {
   CustomVariable,
   PanelBuilders,
   SceneComponentProps,
+  SceneCSSGridLayout,
   SceneDataNode,
   SceneFlexItem,
-  SceneFlexLayout,
   sceneGraph,
   SceneObject,
   SceneObjectBase,
@@ -220,9 +220,9 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
       extendPanelContext: (vizPanel, context) => this.extendTimeSeriesLegendBus(vizPanel, context),
     });
 
-    return new SceneFlexLayout({
-      direction: 'column',
-      maxWidth: '100%',
+    return new SceneCSSGridLayout({
+      templateColumns: '100%',
+
       children: [
         new SceneFlexItem({
           minHeight: 200,

--- a/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
@@ -222,7 +222,6 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
 
     return new SceneFlexLayout({
       direction: 'column',
-      width: 'calc(100vw - 60px)',
       maxWidth: '100%',
       children: [
         new SceneFlexItem({

--- a/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
@@ -39,6 +39,7 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
     });
   }
 
+  // The component PatternTableViewSceneComponent contains hooks, eslint will complain if hooks are used within typescript class, so we work around this by defining the render method as a separate function
   public static Component = PatternTableViewSceneComponent;
 
   /**

--- a/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
@@ -236,7 +236,7 @@ const getTableStyles = () => {
 };
 
 const renderStyles = css({
-  // mostly works, but still overflows on smaller viewports with long pattern text
+  // mostly works, but still overflows (with horizontal scroll) on smaller viewports with long pattern text
   maxWidth: 'calc(100vw - 34px)',
   width: '100%',
   height: '470px',

--- a/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
@@ -54,7 +54,12 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
 
     return (
       <div className={renderStyles}>
-        <InteractiveTable columns={columns} data={tableData} getRowId={(r: WithCustomCellData) => r.pattern} />
+        <InteractiveTable
+          className={getTableStyles()}
+          columns={columns}
+          data={tableData}
+          getRowId={(r: WithCustomCellData) => r.pattern}
+        />
       </div>
     );
   }
@@ -205,9 +210,10 @@ const theme = config.theme2;
 
 const vizStyles = {
   tablePatternText: css({
-    width: 'calc(100vw - 640px)',
     minWidth: '200px',
     fontFamily: theme.typography.fontFamilyMonospace,
+    overflow: 'hidden',
+    overflowWrap: 'break-word',
   }),
   tableTimeSeriesWrap: css({
     width: '230px',
@@ -222,8 +228,18 @@ const vizStyles = {
   }),
 };
 
+const getTableStyles = () => {
+  return css({
+    width: '100%',
+    overflow: 'hidden',
+  });
+};
+
 const renderStyles = css({
-  maxWidth: 'calc(100vw - 31px)',
+  // mostly works, but still overflows on smaller viewports with long pattern text
+  maxWidth: 'calc(100vw - 34px)',
+  width: '100%',
   height: '470px',
   overflowY: 'scroll',
+  overflowX: 'hidden',
 });

--- a/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
@@ -172,7 +172,8 @@ const getTablePatternTextStyles = (width: number) => {
   if (width > 0) {
     return css({
       minWidth: '200px',
-      width: `calc(${width}px - 640px)`,
+      width: `calc(${width}px - 460px)`,
+      maxWidth: '100%',
       fontFamily: theme.typography.fontFamilyMonospace,
       overflow: 'hidden',
       overflowWrap: 'break-word',
@@ -190,10 +191,6 @@ const vizStyles = {
   tableTimeSeriesWrap: css({
     width: '230px',
   }),
-  table: css({
-    width: '100%',
-    overflow: 'hidden',
-  }),
   tableWrapWrap: css({
     width: '100%',
     overflow: 'hidden',
@@ -202,8 +199,6 @@ const vizStyles = {
     // mostly works, but still overflows (with horizontal scroll) on smaller viewports with long pattern text
     maxWidth: 'calc(100vw - 34px)',
     width: '100%',
-    height: '470px',
-    overflowY: 'scroll',
   }),
   tableTimeSeries: css({
     height: '30px',
@@ -233,14 +228,9 @@ export function PatternTableViewSceneComponent({ model }: SceneComponentProps<Pa
   const columns = model.buildColumns(total, width, appliedPatterns);
 
   return (
-    <div ref={ref as RefCallback<HTMLDivElement>} className={vizStyles.tableWrapWrap}>
+    <div className={vizStyles.tableWrapWrap} ref={ref as RefCallback<HTMLDivElement>}>
       <div data-testid={testIds.patterns.tableWrapper} className={vizStyles.tableWrap}>
-        <InteractiveTable
-          className={vizStyles.table}
-          columns={columns}
-          data={tableData}
-          getRowId={(r: WithCustomCellData) => r.pattern}
-        />
+        <InteractiveTable columns={columns} data={tableData} getRowId={(r: WithCustomCellData) => r.pattern} />
       </div>
     </div>
   );

--- a/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
@@ -193,7 +193,9 @@ const vizStyles = {
   }),
   tableWrapWrap: css({
     width: '100%',
-    overflow: 'hidden',
+    overflowX: 'hidden',
+    height: 'calc(100vh - 580px)',
+    minHeight: '470px',
   }),
   tableWrap: css({
     // mostly works, but still overflows (with horizontal scroll) on smaller viewports with long pattern text

--- a/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
@@ -194,12 +194,11 @@ const vizStyles = {
   tableWrapWrap: css({
     width: '100%',
     overflowX: 'hidden',
+    // Need to define explicit height for overflowX
     height: 'calc(100vh - 580px)',
     minHeight: '470px',
   }),
   tableWrap: css({
-    // mostly works, but still overflows (with horizontal scroll) on smaller viewports with long pattern text
-    maxWidth: 'calc(100vw - 34px)',
     width: '100%',
   }),
   tableTimeSeries: css({

--- a/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
@@ -241,5 +241,4 @@ const renderStyles = css({
   width: '100%',
   height: '470px',
   overflowY: 'scroll',
-  overflowX: 'hidden',
 });

--- a/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
@@ -53,9 +53,9 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
     const columns = model.buildColumns(total, appliedPatterns);
 
     return (
-      <div className={renderStyles}>
+      <div className={vizStyles.tableWrap}>
         <InteractiveTable
-          className={getTableStyles()}
+          className={vizStyles.table}
           columns={columns}
           data={tableData}
           getRowId={(r: WithCustomCellData) => r.pattern}
@@ -218,6 +218,17 @@ const vizStyles = {
   tableTimeSeriesWrap: css({
     width: '230px',
   }),
+  table: css({
+    width: '100%',
+    overflow: 'hidden',
+  }),
+  tableWrap: css({
+    // mostly works, but still overflows (with horizontal scroll) on smaller viewports with long pattern text
+    maxWidth: 'calc(100vw - 34px)',
+    width: '100%',
+    height: '470px',
+    overflowY: 'scroll',
+  }),
   tableTimeSeries: css({
     height: '30px',
     overflow: 'hidden',
@@ -227,18 +238,3 @@ const vizStyles = {
     },
   }),
 };
-
-const getTableStyles = () => {
-  return css({
-    width: '100%',
-    overflow: 'hidden',
-  });
-};
-
-const renderStyles = css({
-  // mostly works, but still overflows (with horizontal scroll) on smaller viewports with long pattern text
-  maxWidth: 'calc(100vw - 34px)',
-  width: '100%',
-  height: '470px',
-  overflowY: 'scroll',
-});


### PR DESCRIPTION
Fixes: https://github.com/grafana/explore-logs/issues/373

Small viewports will scroll horizontally instead of pushing out the container width.

To reproduce on main: Find a really long pattern without any spaces to break, or go into the inspector and change the content of a pattern string within the table to something really long without any spaces.