### PR TITLE
Revert "fix: skip all e2e tests"

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
@@ -15,6 +15,7 @@ import { CellProps } from 'react-table';
 import { css } from '@emotion/css';
 import { onPatternClick } from './FilterByPatternsButton';
 import { config } from '@grafana/runtime';
+import { testIds } from '../../../services/testIds';
 
 export interface SingleViewTableSceneState extends SceneObjectState {
   patternFrames: PatternFrame[];
@@ -53,7 +54,7 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
     const columns = model.buildColumns(total, appliedPatterns);
 
     return (
-      <div className={renderStyles}>
+      <div data-testid={testIds.patterns.tableWrapper} className={renderStyles}>
         <InteractiveTable columns={columns} data={tableData} getRowId={(r: WithCustomCellData) => r.pattern} />
       </div>
     );

--- a/src/services/testIds.ts
+++ b/src/services/testIds.ts
@@ -12,4 +12,7 @@ export const testIds = {
     search: 'data-testid search-logs',
     openExplore: 'data-testid open-explore',
   },
+  patterns: {
+    tableWrapper: 'data-testid table-wrapper',
+  },
 };

--- a/tests/appNavigation.spec.ts
+++ b/tests/appNavigation.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@grafana/plugin-e2e';
 import { ROUTES } from '../src/services/routing';
 import { ExplorePage } from './fixtures/explore';
 
-test.describe.skip('navigating app', () => {
+test.describe('navigating app', () => {
   let explorePage: ExplorePage;
 
   test.beforeEach(async ({ page }) => {

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@grafana/plugin-e2e';
 import { ExplorePage } from './fixtures/explore';
 
-test.describe.skip('explore services page', () => {
+test.describe('explore services page', () => {
   let explorePage: ExplorePage;
 
   test.beforeEach(async ({ page }) => {

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -49,14 +49,13 @@ test.describe('explore services breakdown page', () => {
     const firstIncludeButton = page
       .getByTestId(testIds.patterns.tableWrapper)
       .getByRole('table')
-      .getByRole('row', { name: /level=info <_> caller=flush\.go/ })
+      .getByRole('row').nth(2)
       .getByText('Select');
     await firstIncludeButton.click();
     // Should see the logs panel full of patterns
     await expect(page.getByTestId('data-testid search-logs')).toBeVisible();
     // Pattern filter should be added
     await expect(page.getByText('Pattern', { exact: true })).toBeVisible();
-    await expect(page.getByText('level=info <_> caller=flush.go:253 msg="completing block" <_>')).toBeVisible();
   });
 
   test('Should add multiple exclude patterns, which are replaced by include pattern', async ({ page }) => {
@@ -65,12 +64,12 @@ test.describe('explore services breakdown page', () => {
     const firstIncludeButton = page
       .getByTestId(testIds.patterns.tableWrapper)
       .getByRole('table')
-      .getByRole('row', { name: /level=info <_> caller=flush\.go/ })
+      .getByRole('row').nth(2)
       .getByText('Select');
     const firstExcludeButton = page
       .getByTestId(testIds.patterns.tableWrapper)
       .getByRole('table')
-      .getByRole('row', { name: /level=info <_> caller=flush\.go/ })
+      .getByRole('row').nth(2)
       .getByText('Exclude');
 
     await expect(firstIncludeButton).toBeVisible();
@@ -91,15 +90,13 @@ test.describe('explore services breakdown page', () => {
     const secondExcludeButton = page
       .getByTestId(testIds.patterns.tableWrapper)
       .getByRole('table')
-      .getByRole('row', { name: /level=debug <_> caller=broadcast\.go:48/ })
+      .getByRole('row').nth(3)
       .getByText('Exclude');
     await secondExcludeButton.click();
 
     // Both exclude patterns should be visible
     await expect(page.getByText('Pattern', { exact: true })).not.toBeVisible();
     await expect(page.getByText('Excluded patterns:', { exact: true })).toBeVisible();
-    await expect(page.getByText('level=info <_> calle … ompleting block" <_>')).toBeVisible();
-    await expect(page.getByText('level=debug <_> call … ectors/compactor <_>')).toBeVisible();
 
     // Back to patterns to include a pattern instead
     await page.getByLabel('Tab Patterns').click();
@@ -107,7 +104,6 @@ test.describe('explore services breakdown page', () => {
     await firstIncludeButton.click();
     await expect(page.getByText('Pattern', { exact: true })).toBeVisible();
     await expect(page.getByText('Excluded patterns:', { exact: true })).not.toBeVisible();
-    await expect(page.getByText('level=info <_> caller=flush.go:253 msg="completing block" <_>')).toBeVisible();
   });
 
   test('should update a filter and run new logs', async ({ page }) => {

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@grafana/plugin-e2e';
 import { ExplorePage } from './fixtures/explore';
 
-test.describe.skip('explore services breakdown page', () => {
+test.describe('explore services breakdown page', () => {
   let explorePage: ExplorePage;
 
   test.beforeEach(async ({ page }) => {

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@grafana/plugin-e2e';
 import { ExplorePage } from './fixtures/explore';
+import {testIds} from "../src/services/testIds";
 
 test.describe('explore services breakdown page', () => {
   let explorePage: ExplorePage;
@@ -46,6 +47,7 @@ test.describe('explore services breakdown page', () => {
 
     // Include pattern
     const firstIncludeButton = page
+      .getByTestId(testIds.patterns.tableWrapper)
       .getByRole('table')
       .getByRole('row', { name: /level=info <_> caller=flush\.go/ })
       .getByText('Select');
@@ -61,10 +63,12 @@ test.describe('explore services breakdown page', () => {
     await page.getByLabel('Tab Patterns').click();
 
     const firstIncludeButton = page
+      .getByTestId(testIds.patterns.tableWrapper)
       .getByRole('table')
       .getByRole('row', { name: /level=info <_> caller=flush\.go/ })
       .getByText('Select');
     const firstExcludeButton = page
+      .getByTestId(testIds.patterns.tableWrapper)
       .getByRole('table')
       .getByRole('row', { name: /level=info <_> caller=flush\.go/ })
       .getByText('Exclude');
@@ -85,6 +89,7 @@ test.describe('explore services breakdown page', () => {
     await expect(firstExcludeButton).not.toBeVisible();
 
     const secondExcludeButton = page
+      .getByTestId(testIds.patterns.tableWrapper)
       .getByRole('table')
       .getByRole('row', { name: /level=debug <_> caller=broadcast\.go:48/ })
       .getByText('Exclude');


### PR DESCRIPTION
Reverts grafana/explore-logs#376

Turn e2e tests back on, removes hardcoded strings that were changing since the datagenerator used in CI is returning different patterns then the generator ran locally.