### PR TITLE
fix: use content irrelative unit to get more consistent calculations

### DIFF
--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -195,7 +195,7 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
           new SceneCSSGridLayout({
             children,
             isLazy: true,
-            templateColumns: 'repeat(auto-fit, minmax(500px, 1fr) minmax(300px, 70%))',
+            templateColumns: 'repeat(auto-fit, minmax(500px, 1fr) minmax(300px, 70vw))',
             autoRows: '200px',
             md: {
               templateColumns: '1fr',


### PR DESCRIPTION
Fixes: https://github.com/grafana/explore-logs/issues/380

Note for reviewers: As far as I can tell this doesn't change the layout in chrome/ff, but it fixes the bug where it looks like safari is calculating a different 70% then the other browsers

<img width="1728" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/d31f4929-ecf6-4fe5-a915-43f591ab6cf8">
