### PR TITLE
feat(search-icon): add icon to make search input more visible

### DIFF
--- a/src/Components/ServiceScene/LineFilter.tsx
+++ b/src/Components/ServiceScene/LineFilter.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { CustomVariable, SceneComponentProps, SceneObjectBase, SceneObjectState, sceneGraph } from '@grafana/scenes';
-import { Field, Input } from '@grafana/ui';
+import { Field, Icon, Input } from '@grafana/ui';
 import { debounce } from 'lodash';
 import React, { ChangeEvent } from 'react';
 import { VAR_LINE_FILTER } from 'services/variables';
@@ -72,7 +72,8 @@ function LineFilterRenderer({ model }: SceneComponentProps<LineFilter>) {
         value={lineFilter}
         className={styles.input}
         onChange={model.handleChange}
-        placeholder="Search"
+        prefix={<Icon name="search" />}
+        placeholder="Search in log lines"
       />
     </Field>
   );


### PR DESCRIPTION
Changes the search input from

![image](https://github.com/grafana/explore-logs/assets/8092184/50863e4e-99f1-4518-9726-38aa2c882039)

to

![image](https://github.com/grafana/explore-logs/assets/8092184/729b963f-008e-4bf0-9644-81e1b963f699)
