### PR TITLE
Patterns: Smaller text font

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
@@ -96,7 +96,7 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
         sortType: 'number',
         cell: (props) => (
           <div className={vizStyles.countTextWrap}>
-            <div className={vizStyles.countText}>{props.cell.row.original.sum.toLocaleString()}</div>
+            <div>{props.cell.row.original.sum.toLocaleString()}</div>
           </div>
         ),
       },
@@ -106,7 +106,7 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
         sortType: 'number',
         cell: (props) => (
           <div className={vizStyles.countTextWrap}>
-            <div className={vizStyles.countPercent}>{((100 * props.cell.row.original.sum) / total).toFixed(0)}%</div>
+            <div>{((100 * props.cell.row.original.sum) / total).toFixed(0)}%</div>
           </div>
         ),
       },
@@ -191,6 +191,7 @@ const theme = config.theme2;
 const getTablePatternTextStyles = (width: number) => {
   if (width > 0) {
     return css({
+      // the widths of the other columns is mostly static, and they take up about 525px, this will get cleaned up in #392
       width: `calc(${width}px - 525px)`,
     });
   }
@@ -204,13 +205,11 @@ const vizStyles = {
     maxWidth: '100%',
     overflow: 'hidden',
     overflowWrap: 'break-word',
-    fontSize: '12px',
+    fontSize: theme.typography.bodySmall.fontSize,
   }),
-  countPercent: css({}),
-  countText: css({}),
   countTextWrap: css({
     textAlign: 'right',
-    fontSize: '12px',
+    fontSize: theme.typography.bodySmall.fontSize,
   }),
   tableTimeSeriesWrap: css({
     width: '230px',

--- a/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
@@ -91,12 +91,21 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
         },
       },
       {
-        id: 'percent',
+        id: 'count',
         header: 'Count',
         sortType: 'number',
         cell: (props) => (
           <div className={vizStyles.countTextWrap}>
             <div className={vizStyles.countText}>{props.cell.row.original.sum.toLocaleString()}</div>
+          </div>
+        ),
+      },
+      {
+        id: 'percent',
+        header: '%',
+        sortType: 'number',
+        cell: (props) => (
+          <div className={vizStyles.countTextWrap}>
             <div className={vizStyles.countPercent}>{((100 * props.cell.row.original.sum) / total).toFixed(0)}%</div>
           </div>
         ),
@@ -182,7 +191,7 @@ const theme = config.theme2;
 const getTablePatternTextStyles = (width: number) => {
   if (width > 0) {
     return css({
-      width: `calc(${width}px - 485px)`,
+      width: `calc(${width}px - 525px)`,
     });
   }
   return null;
@@ -197,12 +206,8 @@ const vizStyles = {
     overflowWrap: 'break-word',
     fontSize: '12px',
   }),
-  countPercent: css({
-    fontStyle: 'italic',
-  }),
-  countText: css({
-    fontWeight: 'bold',
-  }),
+  countPercent: css({}),
+  countText: css({}),
   countTextWrap: css({
     textAlign: 'right',
     fontSize: '12px',

--- a/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
@@ -12,7 +12,7 @@ import { AppliedPattern, IndexScene } from '../../IndexScene/IndexScene';
 import { DataFrame, LoadingState, PanelData } from '@grafana/data';
 import { Column, InteractiveTable, TooltipDisplayMode } from '@grafana/ui';
 import { CellProps } from 'react-table';
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { onPatternClick } from './FilterByPatternsButton';
 import { FilterButton } from '../../FilterButton';
 import { config } from '@grafana/runtime';
@@ -94,8 +94,9 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
         header: 'Count',
         sortType: 'number',
         cell: (props) => (
-          <div className={vizStyles.countText}>
-            {props.cell.row.original.sum.toLocaleString()} ({((100 * props.cell.row.original.sum) / total).toFixed(0)}%)
+          <div className={vizStyles.countTextWrap}>
+            <div className={vizStyles.countText}>{props.cell.row.original.sum.toLocaleString()}</div>
+            <div className={vizStyles.countPercent}>{((100 * props.cell.row.original.sum) / total).toFixed(0)}%</div>
           </div>
         ),
       },
@@ -103,7 +104,11 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
         id: 'pattern',
         header: 'Pattern',
         cell: (props: CellProps<WithCustomCellData>) => {
-          return <div className={getTablePatternTextStyles(containerWidth)}>{props.cell.row.original.pattern}</div>;
+          return (
+            <div className={cx(getTablePatternTextStyles(containerWidth), vizStyles.tablePatternTextDefault)}>
+              {props.cell.row.original.pattern}
+            </div>
+          );
         },
       },
       {
@@ -176,25 +181,30 @@ const theme = config.theme2;
 const getTablePatternTextStyles = (width: number) => {
   if (width > 0) {
     return css({
-      minWidth: '200px',
       width: `calc(${width}px - 485px)`,
-      maxWidth: '100%',
-      fontFamily: theme.typography.fontFamilyMonospace,
-      overflow: 'hidden',
-      overflowWrap: 'break-word',
     });
   }
-  return css({
-    minWidth: '200px',
-    fontFamily: theme.typography.fontFamilyMonospace,
-    overflow: 'hidden',
-    overflowWrap: 'break-word',
-  });
+  return null;
 };
 
 const vizStyles = {
+  tablePatternTextDefault: css({
+    fontFamily: theme.typography.fontFamilyMonospace,
+    minWidth: '200px',
+    maxWidth: '100%',
+    overflow: 'hidden',
+    overflowWrap: 'break-word',
+    fontSize: '12px',
+  }),
+  countPercent: css({
+    fontStyle: 'italic',
+  }),
   countText: css({
+    fontWeight: 'bold',
+  }),
+  countTextWrap: css({
     textAlign: 'right',
+    fontSize: '12px',
   }),
   tableTimeSeriesWrap: css({
     width: '230px',


### PR DESCRIPTION
Fixes: https://github.com/grafana/explore-logs/issues/366

Also splits up the count/percent column into multiple columns, and tweaks a few styles: 

<img width="1722" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/5bd257bb-22e3-45f2-957c-ecdd969dfae5">

