### PR TITLE
Chore: Refactor patterns breakdown

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
@@ -1,33 +1,25 @@
 import { css } from '@emotion/css';
 import React from 'react';
 
-import { ConfigOverrideRule, DataFrame, FieldColor, FieldType, GrafanaTheme2, LoadingState } from '@grafana/data';
+import { DataFrame, FieldType, GrafanaTheme2 } from '@grafana/data';
 import {
   CustomVariable,
-  PanelBuilders,
   SceneComponentProps,
-  SceneCSSGridLayout,
-  SceneDataNode,
   SceneFlexItem,
   sceneGraph,
   SceneObject,
   SceneObjectBase,
   SceneObjectState,
   SceneVariableSet,
-  VizPanel,
 } from '@grafana/scenes';
-import { LegendDisplayMode, PanelContext, SeriesVisibilityChangeMode, Text, TextLink, useStyles2 } from '@grafana/ui';
+import { Text, TextLink, useStyles2 } from '@grafana/ui';
 import { LayoutSwitcher } from 'Components/ServiceScene/Breakdowns/LayoutSwitcher';
 import { StatusWrapper } from 'Components/ServiceScene/Breakdowns/StatusWrapper';
 import { GrotError } from 'Components/GrotError';
 import { VAR_LABEL_GROUP_BY } from 'services/variables';
 import { LokiPattern, ServiceScene } from '../ServiceScene';
-import { onPatternClick } from './FilterByPatternsButton';
 import { IndexScene } from '../../IndexScene/IndexScene';
-import { PatternsViewTableScene } from './PatternsViewTableScene';
-import { config } from '@grafana/runtime';
-
-const palette = config.theme2.visualization.palette;
+import { PatternsFrameScene } from './PatternsFrameScene';
 
 export interface PatternsBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -35,7 +27,6 @@ export interface PatternsBreakdownSceneState extends SceneObjectState {
   loading?: boolean;
   error?: string;
   blockingMessage?: string;
-  legendSyncPatterns: Set<string>;
 }
 
 export type PatternFrame = {
@@ -54,7 +45,6 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
           variables: [new CustomVariable({ name: VAR_LABEL_GROUP_BY, defaultToAll: true, includeAll: true })],
         }),
       loading: true,
-      legendSyncPatterns: new Set(),
       ...state,
     });
 
@@ -134,106 +124,11 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
 
     const patternFrames = this.buildPatterns(lokiPatterns);
 
-    const logExploration = sceneGraph.getAncestor(this, IndexScene);
-
     this.setState({
-      body: this.getSingleViewLayout(patternFrames, logExploration),
+      body: new PatternsFrameScene({
+        patternFrames,
+      }),
       loading: false,
-    });
-  }
-
-  private extendTimeSeriesLegendBus(vizPanel: VizPanel, context: PanelContext) {
-    const originalOnToggleSeriesVisibility = context.onToggleSeriesVisibility;
-
-    context.onToggleSeriesVisibility = (label: string, mode: SeriesVisibilityChangeMode) => {
-      originalOnToggleSeriesVisibility?.(label, mode);
-
-      const override: ConfigOverrideRule | undefined = vizPanel.state.fieldConfig.overrides?.[0];
-      const patternsToShow: string[] = override?.matcher.options.names;
-      const legendSyncPatterns = new Set<string>();
-
-      if (patternsToShow) {
-        patternsToShow.forEach(legendSyncPatterns.add, legendSyncPatterns);
-      }
-
-      this.setState({
-        legendSyncPatterns,
-      });
-    };
-  }
-
-  private getSingleViewLayout(patternFrames: PatternFrame[], logExploration: IndexScene) {
-    const appliedPatterns = sceneGraph.getAncestor(logExploration, IndexScene).state.patterns;
-    const timeRange = sceneGraph.getTimeRange(this).state.value;
-
-    const timeSeries = PanelBuilders.timeseries()
-      .setData(
-        new SceneDataNode({
-          data: {
-            series: patternFrames.map((patternFrame, seriesIndex) => {
-              // Mutating the dataframe config here means that we don't need to update the colors in the table view
-              const dataFrame = patternFrame.dataFrame;
-              dataFrame.fields[1].config.color = overrideToFixedColor(seriesIndex);
-              return dataFrame;
-            }),
-            state: LoadingState.Done,
-            timeRange: timeRange,
-          },
-        })
-      )
-      .setOption('legend', {
-        asTable: true,
-        showLegend: true,
-        displayMode: LegendDisplayMode.Table,
-        placement: 'right',
-        width: 200,
-      })
-      .setLinks([
-        {
-          url: '#',
-          targetBlank: false,
-          onClick: (event) => {
-            onPatternClick({
-              pattern: event.origin.name,
-              type: 'include',
-              indexScene: logExploration,
-            });
-          },
-          title: 'Include',
-        },
-        {
-          url: '#',
-          targetBlank: false,
-          onClick: (event) => {
-            onPatternClick({
-              pattern: event.origin.name,
-              type: 'exclude',
-              indexScene: logExploration,
-            });
-          },
-          title: 'Exclude',
-        },
-      ])
-      .build();
-
-    timeSeries.setState({
-      extendPanelContext: (vizPanel, context) => this.extendTimeSeriesLegendBus(vizPanel, context),
-    });
-
-    return new SceneCSSGridLayout({
-      templateColumns: '100%',
-
-      children: [
-        new SceneFlexItem({
-          minHeight: 200,
-          maxWidth: '100%',
-          body: timeSeries,
-        }),
-        new PatternsViewTableScene({
-          patternFrames,
-          appliedPatterns,
-        }),
-      ],
     });
   }
 
@@ -344,11 +239,4 @@ export function buildPatternsScene() {
   return new SceneFlexItem({
     body: new PatternsBreakdownScene({}),
   });
-}
-
-export function overrideToFixedColor(key: keyof typeof palette): FieldColor {
-  return {
-    mode: 'fixed',
-    fixedColor: palette[key] as string,
-  };
 }

--- a/src/Components/ServiceScene/Breakdowns/PatternsFrameScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsFrameScene.tsx
@@ -51,7 +51,6 @@ export class PatternsFrameScene extends SceneObjectBase<PatternsFrameSceneState>
 
   // parent render
   public static Component = ({ model }: SceneComponentProps<PatternsFrameScene>) => {
-    console.log('PatternsFrameScene render');
     const { body, loading } = model.useState();
     const logsByServiceScene = sceneGraph.getAncestor(model, ServiceScene);
     const { patterns } = logsByServiceScene.useState();

--- a/src/Components/ServiceScene/Breakdowns/PatternsFrameScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsFrameScene.tsx
@@ -19,6 +19,7 @@ import { onPatternClick } from './FilterByPatternsButton';
 import { IndexScene } from '../../IndexScene/IndexScene';
 import { PatternsViewTableScene } from './PatternsViewTableScene';
 import { config } from '@grafana/runtime';
+import { css } from '@emotion/css';
 
 const palette = config.theme2.visualization.palette;
 
@@ -54,7 +55,11 @@ export class PatternsFrameScene extends SceneObjectBase<PatternsFrameSceneState>
     const { body, loading } = model.useState();
     const logsByServiceScene = sceneGraph.getAncestor(model, ServiceScene);
     const { patterns } = logsByServiceScene.useState();
-    return <>{!loading && patterns && patterns.length > 0 && <>{body && <body.Component model={body} />}</>}</>;
+    return (
+      <div className={styles.container}>
+        {!loading && patterns && patterns.length > 0 && <>{body && <body.Component model={body} />}</>}
+      </div>
+    );
   };
 
   private onActivate() {
@@ -74,8 +79,6 @@ export class PatternsFrameScene extends SceneObjectBase<PatternsFrameSceneState>
     if (!lokiPatterns) {
       return;
     }
-
-    console.log('udpateBody');
 
     const logExploration = sceneGraph.getAncestor(this, IndexScene);
 
@@ -188,3 +191,9 @@ export function overrideToFixedColor(key: keyof typeof palette): FieldColor {
     fixedColor: palette[key] as string,
   };
 }
+
+const styles = {
+  container: css({
+    width: '100%',
+  }),
+};

--- a/src/Components/ServiceScene/Breakdowns/PatternsFrameScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsFrameScene.tsx
@@ -1,0 +1,203 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { ConfigOverrideRule, DataFrame, FieldColor, GrafanaTheme2, LoadingState } from '@grafana/data';
+import {
+  PanelBuilders,
+  SceneComponentProps,
+  SceneCSSGridLayout,
+  SceneDataNode,
+  SceneFlexItem,
+  sceneGraph,
+  SceneObject,
+  SceneObjectBase,
+  SceneObjectState,
+  VizPanel,
+} from '@grafana/scenes';
+import { LegendDisplayMode, PanelContext, SeriesVisibilityChangeMode, useStyles2 } from '@grafana/ui';
+import { ServiceScene } from '../ServiceScene';
+import { onPatternClick } from './FilterByPatternsButton';
+import { IndexScene } from '../../IndexScene/IndexScene';
+import { PatternsViewTableScene } from './PatternsViewTableScene';
+import { config } from '@grafana/runtime';
+
+const palette = config.theme2.visualization.palette;
+
+export interface PatternsFrameSceneState extends SceneObjectState {
+  body?: SceneObject;
+  loading?: boolean;
+  patternFrames: PatternFrame[];
+  legendSyncPatterns: Set<string>;
+}
+
+export type PatternFrame = {
+  dataFrame: DataFrame;
+  pattern: string;
+  sum: number;
+  status?: 'include' | 'exclude';
+};
+
+export class PatternsFrameScene extends SceneObjectBase<PatternsFrameSceneState> {
+  constructor(state: { patternFrames: PatternFrame[] }) {
+    super({
+      loading: true,
+      ...state,
+      patternFrames: state.patternFrames,
+      legendSyncPatterns: new Set(),
+    });
+
+    this.addActivationHandler(this.onActivate.bind(this));
+  }
+
+  // parent render
+  public static Component = ({ model }: SceneComponentProps<PatternsFrameScene>) => {
+    console.log('PatternsFrameScene render');
+    const { body, loading } = model.useState();
+    const logsByServiceScene = sceneGraph.getAncestor(model, ServiceScene);
+    const { patterns } = logsByServiceScene.useState();
+    const styles = useStyles2(getStyles);
+    return (
+      <div className={styles.container}>
+        {!loading && patterns && patterns.length > 0 && <>{body && <body.Component model={body} />}</>}
+      </div>
+    );
+  };
+
+  private onActivate() {
+    this.updateBody();
+    this._subs.add(
+      sceneGraph.getAncestor(this, ServiceScene).subscribeToState((newState, prevState) => {
+        if (newState.patterns !== prevState.patterns) {
+          this.updateBody();
+        }
+      })
+    );
+  }
+
+  private async updateBody() {
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
+    const lokiPatterns = serviceScene.state.patterns;
+    if (!lokiPatterns) {
+      return;
+    }
+
+    console.log('udpateBody');
+
+    const logExploration = sceneGraph.getAncestor(this, IndexScene);
+
+    this.setState({
+      body: this.getSingleViewLayout(this.state.patternFrames, logExploration),
+      loading: false,
+    });
+  }
+
+  private extendTimeSeriesLegendBus(vizPanel: VizPanel, context: PanelContext) {
+    const originalOnToggleSeriesVisibility = context.onToggleSeriesVisibility;
+
+    context.onToggleSeriesVisibility = (label: string, mode: SeriesVisibilityChangeMode) => {
+      originalOnToggleSeriesVisibility?.(label, mode);
+
+      const override: ConfigOverrideRule | undefined = vizPanel.state.fieldConfig.overrides?.[0];
+      const patternsToShow: string[] = override?.matcher.options.names;
+      const legendSyncPatterns = new Set<string>();
+
+      if (patternsToShow) {
+        patternsToShow.forEach(legendSyncPatterns.add, legendSyncPatterns);
+      }
+
+      this.setState({
+        legendSyncPatterns,
+      });
+    };
+  }
+
+  private getSingleViewLayout(patternFrames: PatternFrame[], logExploration: IndexScene) {
+    const appliedPatterns = sceneGraph.getAncestor(logExploration, IndexScene).state.patterns;
+    const timeRange = sceneGraph.getTimeRange(this).state.value;
+
+    const timeSeries = PanelBuilders.timeseries()
+      .setData(
+        new SceneDataNode({
+          data: {
+            series: patternFrames.map((patternFrame, seriesIndex) => {
+              // Mutating the dataframe config here means that we don't need to update the colors in the table view
+              const dataFrame = patternFrame.dataFrame;
+              dataFrame.fields[1].config.color = overrideToFixedColor(seriesIndex);
+              return dataFrame;
+            }),
+            state: LoadingState.Done,
+            timeRange: timeRange,
+          },
+        })
+      )
+      .setOption('legend', {
+        asTable: true,
+        showLegend: true,
+        displayMode: LegendDisplayMode.Table,
+        placement: 'right',
+        width: 200,
+      })
+      .setLinks([
+        {
+          url: '#',
+          targetBlank: false,
+          onClick: (event) => {
+            onPatternClick({
+              pattern: event.origin.name,
+              type: 'include',
+              indexScene: logExploration,
+            });
+          },
+          title: 'Include',
+        },
+        {
+          url: '#',
+          targetBlank: false,
+          onClick: (event) => {
+            onPatternClick({
+              pattern: event.origin.name,
+              type: 'exclude',
+              indexScene: logExploration,
+            });
+          },
+          title: 'Exclude',
+        },
+      ])
+      .build();
+
+    timeSeries.setState({
+      extendPanelContext: (vizPanel, context) => this.extendTimeSeriesLegendBus(vizPanel, context),
+    });
+
+    return new SceneCSSGridLayout({
+      templateColumns: '100%',
+      templateRows: 'auto',
+
+      children: [
+        new SceneFlexItem({
+          minHeight: 200,
+          maxWidth: '100%',
+          body: timeSeries,
+        }),
+        new PatternsViewTableScene({
+          patternFrames,
+          appliedPatterns,
+        }),
+      ],
+    });
+  }
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    content: css({}),
+    container: css({}),
+  };
+}
+
+export function overrideToFixedColor(key: keyof typeof palette): FieldColor {
+  return {
+    mode: 'fixed',
+    fixedColor: palette[key] as string,
+  };
+}

--- a/src/Components/ServiceScene/Breakdowns/PatternsFrameScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsFrameScene.tsx
@@ -1,7 +1,6 @@
-import { css } from '@emotion/css';
 import React from 'react';
 
-import { ConfigOverrideRule, DataFrame, FieldColor, GrafanaTheme2, LoadingState } from '@grafana/data';
+import { ConfigOverrideRule, DataFrame, FieldColor, LoadingState } from '@grafana/data';
 import {
   PanelBuilders,
   SceneComponentProps,
@@ -14,7 +13,7 @@ import {
   SceneObjectState,
   VizPanel,
 } from '@grafana/scenes';
-import { LegendDisplayMode, PanelContext, SeriesVisibilityChangeMode, useStyles2 } from '@grafana/ui';
+import { LegendDisplayMode, PanelContext, SeriesVisibilityChangeMode } from '@grafana/ui';
 import { ServiceScene } from '../ServiceScene';
 import { onPatternClick } from './FilterByPatternsButton';
 import { IndexScene } from '../../IndexScene/IndexScene';
@@ -55,12 +54,7 @@ export class PatternsFrameScene extends SceneObjectBase<PatternsFrameSceneState>
     const { body, loading } = model.useState();
     const logsByServiceScene = sceneGraph.getAncestor(model, ServiceScene);
     const { patterns } = logsByServiceScene.useState();
-    const styles = useStyles2(getStyles);
-    return (
-      <div className={styles.container}>
-        {!loading && patterns && patterns.length > 0 && <>{body && <body.Component model={body} />}</>}
-      </div>
-    );
+    return <>{!loading && patterns && patterns.length > 0 && <>{body && <body.Component model={body} />}</>}</>;
   };
 
   private onActivate() {
@@ -186,13 +180,6 @@ export class PatternsFrameScene extends SceneObjectBase<PatternsFrameSceneState>
       ],
     });
   }
-}
-
-function getStyles(theme: GrafanaTheme2) {
-  return {
-    content: css({}),
-    container: css({}),
-  };
 }
 
 export function overrideToFixedColor(key: keyof typeof palette): FieldColor {

--- a/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
@@ -188,15 +188,20 @@ const vizStyles = {
     width: '230px',
     pointerEvents: 'none',
   }),
-  tableWrapWrap: css({
-    width: '100%',
-    overflowX: 'hidden',
-    // Need to define explicit height for overflowX
-    height: 'calc(100vh - 580px)',
-    minHeight: '470px',
-  }),
   tableWrap: css({
-    // width: '100%',
+    // Override interactive table style
+    '> div': {
+      // Need to define explicit height for overflowX
+      height: 'calc(100vh - 450px)',
+      minHeight: '470px',
+    },
+    // Make table headers sticky
+    th: {
+      top: 0,
+      position: 'sticky',
+      backgroundColor: theme.colors.background.canvas,
+      zIndex: theme.zIndex.navbarFixed,
+    },
   }),
   tableTimeSeries: css({
     height: '30px',


### PR DESCRIPTION
Having a new container gets rid of the need for useMeasure hook, which reduces the number of re-rendering we're doing in scenes. Also this tees up further work in the patterns view like text search.,

Shouldn't be much change in functionality, although now the column headers are sticky when scrolling through the patterns, and the header has been removed from the main pattern timeseries up top.

Double vertical scrollbar is still possible, for devices with small screen heights, and when many filters are applied pushing down the top of the page. Perhaps in https://github.com/grafana/explore-logs/issues/396 we should address this via measuring the height of the sticky header, or by adding the ability for the user to manually resize how much of the viewport height is dedicated to each section.