### PR TITLE
feat(LabelBreakdownScene): display an error message when the request fails

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -185,7 +185,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
               </div>
             )}
             {error && (
-              <Alert title="">
+              <Alert title="" severity="warning">
                 The labels are not available at this moment. Try using a different time range or check again later.
               </Alert>
             )}


### PR DESCRIPTION
Closes https://github.com/grafana/explore-logs/issues/402

Message:

![imagen](https://github.com/grafana/explore-logs/assets/1069378/36e172b1-f199-41ba-b5dd-580f9793d290)

Open for suggestions for the error message. The important part is that:
- It should let the user know what happened.
- It should offer at least one workaround.