### PR TITLE
fix(service-selection): only show favorite services if there is data

### DIFF
--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -340,8 +340,8 @@ function createListOfServicesToQuery(services: string[], ds: string, searchStrin
   }
 
   const servicesToQuery = services.filter((service) => service.toLowerCase().includes(searchString.toLowerCase()));
-  const favoriteServicesToQuery = getFavoriteServicesFromStorage(ds).filter((service) =>
-    service.toLowerCase().includes(searchString.toLowerCase())
+  const favoriteServicesToQuery = getFavoriteServicesFromStorage(ds).filter(
+    (service) => service.toLowerCase().includes(searchString.toLowerCase()) && servicesToQuery.includes(service)
   );
 
   // Deduplicate


### PR DESCRIPTION
"Favorite" or rather previous selected services will be shown at the top of the service selection. This PR fixes a behavior where favorite services are shown even if they are not included in the response of the /volume API:

![image](https://github.com/grafana/explore-logs/assets/8092184/d65dcd3c-90f7-44d4-bede-771f611d5408)
