### PR TITLE
feat(patterns): style patterns in the same way other graphs are styled

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
@@ -36,6 +36,8 @@ export function onPatternClick(props: FilterByPatternsState) {
     excludePatternsLength: excludePatternsLength + (type === 'exclude' ? 1 : 0),
   });
 
+  console.log('filteredPatterns', filteredPatterns);
+
   // If we have type undo, then we don't need to add the pattern
   if (type === 'undo') {
     indexScene.setState({

--- a/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
@@ -36,8 +36,6 @@ export function onPatternClick(props: FilterByPatternsState) {
     excludePatternsLength: excludePatternsLength + (type === 'exclude' ? 1 : 0),
   });
 
-  console.log('filteredPatterns', filteredPatterns);
-
   // If we have type undo, then we don't need to add the pattern
   if (type === 'undo') {
     indexScene.setState({

--- a/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
@@ -226,8 +226,6 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
       autoRows: '200px',
       children: [
         new SceneFlexItem({
-          height: 200,
-          maxWidth: '100%',
           body: timeSeries,
         }),
         new PatternsViewTableScene({

--- a/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
@@ -188,6 +188,7 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
         placement: 'right',
         width: 200,
       })
+      .setUnit('short')
       .setLinks([
         {
           url: '#',
@@ -222,10 +223,10 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
 
     return new SceneCSSGridLayout({
       templateColumns: '100%',
-
+      autoRows: '200px',
       children: [
         new SceneFlexItem({
-          minHeight: 200,
+          height: 200,
           maxWidth: '100%',
           body: timeSeries,
         }),
@@ -268,21 +269,13 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
               name: 'time',
               type: FieldType.time,
               values: timeValues,
-              config: {
-                custom: {
-                  axisPlacement: 'hidden',
-                },
-              },
+              config: {},
             },
             {
               name: pat.pattern,
               type: FieldType.number,
               values: sampleValues,
-              config: {
-                custom: {
-                  axisPlacement: 'hidden',
-                },
-              },
+              config: {},
             },
           ],
           length: pat.samples.length,

--- a/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsViewTableScene.tsx
@@ -10,7 +10,7 @@ import { PatternFrame, PatternsBreakdownScene } from './PatternsBreakdownScene';
 import React, { RefCallback } from 'react';
 import { AppliedPattern, IndexScene } from '../../IndexScene/IndexScene';
 import { DataFrame, LoadingState, PanelData } from '@grafana/data';
-import { Column, InteractiveTable, TooltipDisplayMode } from '@grafana/ui';
+import { AxisPlacement, Column, InteractiveTable, TooltipDisplayMode } from '@grafana/ui';
 import { CellProps } from 'react-table';
 import { css } from '@emotion/css';
 import { onPatternClick } from './FilterByPatternsButton';
@@ -77,6 +77,7 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
               legend: true,
               tooltip: true,
             })
+            .setCustomFieldConfig('axisPlacement', AxisPlacement.Hidden)
             .setDisplayMode('transparent')
             .build();
 


### PR DESCRIPTION
To keep our graphs similar style, plus it is more clear how many patterns and at what time frame were detected. 

New:
<img width="1499" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/4ed59645-4d9d-428c-bc0e-6d5ccfdaace3">
<img width="1503" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/46caff31-8871-4a86-a6be-cad7c39423f8">

Old: 
<img width="1511" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/7ed38af6-7112-4587-bd87-855a9e742f80">
