### PR TITLE
feat(patterns): include multiple patterns

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -96,8 +96,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
 
       const patternsVariable = sceneGraph.lookupVariable(VAR_PATTERNS, this);
       if (patternsVariable instanceof CustomVariable) {
-        const patternsLine =
-          newState.patterns?.map((p) => `${p.type === 'include' ? '|> ' : '!> '} \`${p.pattern}\``)?.join(' ') || '';
+        const patternsLine = renderPatternFilters(newState.patterns ?? []);
         patternsVariable.changeValueTo(patternsLine);
       }
     });
@@ -221,4 +220,23 @@ export function renderLogQLFieldFilters(filters: AdHocVariableFilter[]) {
 
 function renderFilter(filter: AdHocVariableFilter) {
   return `${filter.key}${filter.operator}\`${filter.value}\``;
+}
+
+export function renderPatternFilters(patterns: AppliedPattern[]) {
+  const excludePatterns = patterns.filter((pattern) => pattern.type === 'exclude');
+  const excludePatternsLine = excludePatterns
+    .map((p) => `!> \`${p.pattern}\``)
+    .join(' ')
+    .trim();
+
+  const includePatterns = patterns.filter((pattern) => pattern.type === 'include');
+  let includePatternsLine = '';
+  if (includePatterns.length > 0) {
+    if (includePatterns.length === 1) {
+      includePatternsLine = `|> \`${includePatterns[0].pattern}\``;
+    } else {
+      includePatternsLine = `|>  ${includePatterns.map((p) => `\`${p.pattern}\``).join(' or ')}`;
+    }
+  }
+  return `${excludePatternsLine} ${includePatternsLine}`.trim();
 }

--- a/src/Components/IndexScene/PatternControls.tsx
+++ b/src/Components/IndexScene/PatternControls.tsx
@@ -34,7 +34,7 @@ export const PatternControls = ({ patterns, onRemove }: Props) => {
       {includePatterns.length > 0 && (
         <div className={styles.patternsContainer}>
           <Text variant="bodySmall" weight="bold">
-            {excludePatterns.length > 0 ? 'Include pattern' : `Pattern${patterns.length > 1 ? 's' : ''}`}
+            Included pattern{patterns.length > 1 ? 's' : ''}
           </Text>
           <div className={styles.patterns}>
             {includePatterns.map((p) => (

--- a/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
@@ -24,9 +24,10 @@ export function onPatternClick(props: FilterByPatternsState) {
   const { patterns = [] } = indexScene.state;
 
   // Remove the pattern if it's already there
-  const filteredPatterns = patterns.filter(
-    (pat) => pat.pattern !== pattern && type !== 'include' && pat.type !== 'include'
-  );
+  //   const filteredPatterns = patterns.filter(
+  //   (pat) => pat.pattern !== pattern && type !== 'include' && pat.type !== 'include'
+  // );
+  const filteredPatterns = patterns.filter((pat) => pat.pattern !== pattern);
   // Analytics
   const includePatternsLength = filteredPatterns.filter((p) => p.type === 'include')?.length ?? 0;
   const excludePatternsLength = filteredPatterns.filter((p) => p.type === 'exclude')?.length ?? 0;

--- a/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FilterByPatternsButton.tsx
@@ -24,9 +24,6 @@ export function onPatternClick(props: FilterByPatternsState) {
   const { patterns = [] } = indexScene.state;
 
   // Remove the pattern if it's already there
-  //   const filteredPatterns = patterns.filter(
-  //   (pat) => pat.pattern !== pattern && type !== 'include' && pat.type !== 'include'
-  // );
   const filteredPatterns = patterns.filter((pat) => pat.pattern !== pattern);
   // Analytics
   const includePatternsLength = filteredPatterns.filter((p) => p.type === 'include')?.length ?? 0;

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -95,14 +95,14 @@ test.describe('explore services breakdown page', () => {
     await secondExcludeButton.click();
 
     // Both exclude patterns should be visible
-    await expect(page.getByText('Pattern', { exact: true })).not.toBeVisible();
+    await expect(page.getByText('Included patterns', { exact: true })).not.toBeVisible();
     await expect(page.getByText('Excluded patterns:', { exact: true })).toBeVisible();
 
     // Back to patterns to include a pattern instead
     await page.getByLabel('Tab Patterns').click();
 
     await firstIncludeButton.click();
-    await expect(page.getByText('Pattern', { exact: true })).toBeVisible();
+    await expect(page.getByText('Included patterns', { exact: true })).toBeVisible();
     await expect(page.getByText('Excluded patterns:', { exact: true })).not.toBeVisible();
   });
 


### PR DESCRIPTION
<img width="1910" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/12952288-f598-41c3-8c4d-565492547131">
<img width="1912" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/d2b5c810-eed1-4e1d-b469-e0b9caf2def6">

There is an issue with multiple include patterns chained with `or` in Loki https://github.com/grafana/loki/issues/13160, but I don't think it should stop us with proceeding with this. 