### PR TITLE
fix: wrap components in PluginPage to fix breadcrumbs

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -383,8 +383,12 @@ function getLabelValue(frame: DataFrame) {
 }
 
 export function buildFieldsBreakdownActionScene(changeFieldNumber: (n: string[]) => void) {
-  return new SceneFlexItem({
-    body: new FieldsBreakdownScene({ changeFields: changeFieldNumber }),
+  return new SceneFlexLayout({
+    children: [
+      new SceneFlexItem({
+        body: new FieldsBreakdownScene({ changeFields: changeFieldNumber }),
+      }),
+    ],
   });
 }
 

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -379,8 +379,12 @@ function getLabelValue(frame: DataFrame) {
 }
 
 export function buildLabelBreakdownActionScene() {
-  return new SceneFlexItem({
-    body: new LabelBreakdownScene({}),
+  return new SceneFlexLayout({
+    children: [
+      new SceneFlexItem({
+        body: new LabelBreakdownScene({}),
+      }),
+    ],
   });
 }
 

--- a/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/PatternsBreakdownScene.tsx
@@ -9,6 +9,7 @@ import {
   SceneCSSGridLayout,
   SceneDataNode,
   SceneFlexItem,
+  SceneFlexLayout,
   sceneGraph,
   SceneObject,
   SceneObjectBase,
@@ -332,8 +333,12 @@ function getStyles(theme: GrafanaTheme2) {
 }
 
 export function buildPatternsScene() {
-  return new SceneFlexItem({
-    body: new PatternsBreakdownScene({}),
+  return new SceneFlexLayout({
+    children: [
+      new SceneFlexItem({
+        body: new PatternsBreakdownScene({}),
+      }),
+    ],
   });
 }
 

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -72,8 +72,6 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
 export function buildLogsListScene() {
   return new SceneFlexLayout({
     direction: 'column',
-
-    // ySizing: '',
     children: [
       new SceneFlexItem({
         minHeight: 200,

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -10,6 +10,7 @@ import {
 } from '@grafana/scenes';
 import { LineFilter } from './LineFilter';
 import { LogsVolumePanel } from './LogsVolumePanel';
+import { css } from '@emotion/css';
 
 export interface LogsListSceneState extends SceneObjectState {
   loading?: boolean;
@@ -60,21 +61,38 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
       return;
     }
 
-    return <panel.Component model={panel} />;
+    return (
+      <div className={styles.panelWrapper}>
+        <panel.Component model={panel} />
+      </div>
+    );
   };
 }
 
 export function buildLogsListScene() {
   return new SceneFlexLayout({
     direction: 'column',
+
+    // ySizing: '',
     children: [
       new SceneFlexItem({
-        height: 200,
+        minHeight: 200,
         body: new LogsVolumePanel({}),
       }),
       new SceneFlexItem({
+        minHeight: '470px',
+        height: 'calc(100vh - 500px)',
         body: new LogsListScene({}),
       }),
     ],
   });
 }
+
+const styles = {
+  panelWrapper: css({
+    // If you use hover-header without any header options we must manually hide the remnants, or it shows up as a 1px line in the top-right corner of the viz
+    '.show-on-hover': {
+      display: 'none',
+    },
+  }),
+};

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -49,9 +49,6 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
 
   public static Component = ({ model }: SceneComponentProps<LogsVolumePanel>) => {
     const { panel } = model.useState();
-
-    console.log('render panel');
-
     if (!panel) {
       return;
     }

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -50,6 +50,8 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   public static Component = ({ model }: SceneComponentProps<LogsVolumePanel>) => {
     const { panel } = model.useState();
 
+    console.log('render panel');
+
     if (!panel) {
       return;
     }

--- a/src/Components/ServiceScene/PageScene.tsx
+++ b/src/Components/ServiceScene/PageScene.tsx
@@ -1,0 +1,25 @@
+import { SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import { PageLayoutType } from '@grafana/data';
+import { PluginPage } from '@grafana/runtime';
+import React from 'react';
+
+interface PageSceneState extends SceneObjectState {
+  body: SceneObject;
+  title: string;
+}
+export class PageScene extends SceneObjectBase<PageSceneState> {
+  constructor(state: PageSceneState) {
+    super({
+      body: state.body,
+      title: state.title,
+    });
+  }
+  public static Component = ({ model }: SceneComponentProps<PageScene>) => {
+    const { body, title } = model.useState();
+    return (
+      <PluginPage pageNav={{ text: title }} layout={PageLayoutType.Custom}>
+        <body.Component model={body} />
+      </PluginPage>
+    );
+  };
+}

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -43,6 +43,7 @@ import { buildLabelBreakdownActionScene } from './Breakdowns/LabelBreakdownScene
 import { buildPatternsScene } from './Breakdowns/PatternsBreakdownScene';
 import { GoToExploreButton } from './GoToExploreButton';
 import { buildLogsListScene } from './LogsListScene';
+import { PageScene } from './PageScene';
 
 export interface LokiPattern {
   pattern: string;
@@ -344,10 +345,26 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
 }
 
 const actionViewsDefinitions: ActionViewDefinition[] = [
-  { displayName: 'Logs', value: 'logs', getScene: buildLogsListScene },
-  { displayName: 'Labels', value: 'labels', getScene: buildLabelBreakdownActionScene },
-  { displayName: 'Detected fields', value: 'fields', getScene: buildFieldsBreakdownActionScene },
-  { displayName: 'Patterns', value: 'patterns', getScene: buildPatternsScene },
+  {
+    displayName: 'Logs',
+    value: 'logs',
+    getScene: () => new PageScene({ body: buildLogsListScene(), title: 'Logs' }),
+  },
+  {
+    displayName: 'Labels',
+    value: 'labels',
+    getScene: () => new PageScene({ body: buildLabelBreakdownActionScene(), title: 'Labels' }),
+  },
+  {
+    displayName: 'Detected fields',
+    value: 'fields',
+    getScene: (f) => new PageScene({ body: buildFieldsBreakdownActionScene(f), title: 'Detected fields' }),
+  },
+  {
+    displayName: 'Patterns',
+    value: 'patterns',
+    getScene: () => new PageScene({ body: buildPatternsScene(), title: 'Patterns' }),
+  },
 ];
 
 export interface LogsActionBarState extends SceneObjectState {}

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { debounce } from 'lodash';
 import React, { useCallback, useState } from 'react';
-import { BusEventBase, DashboardCursorSync, GrafanaTheme2, TimeRange } from '@grafana/data';
+import { BusEventBase, DashboardCursorSync, GrafanaTheme2, PageLayoutType, TimeRange } from '@grafana/data';
 import {
   AdHocFiltersVariable,
   behaviors,
@@ -36,6 +36,7 @@ import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'se
 import { getQueryRunner, setLeverColorOverrides } from 'services/panel';
 import { ConfigureVolumeError } from './ConfigureVolumeError';
 import { NoVolumeError } from './NoVolumeError';
+import { PluginPage } from '@grafana/runtime';
 
 export const SERVICE_NAME = 'service_name';
 
@@ -298,34 +299,36 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
       [model]
     );
     return (
-      <div className={styles.container}>
-        <div className={styles.bodyWrapper}>
-          <div>
-            {/** When services fetched, show how many services are we showing */}
-            {isServicesByVolumeLoading && (
-              <LoadingPlaceholder text={'Loading services'} className={styles.loadingText} />
-            )}
-            {!isServicesByVolumeLoading && <>Showing {servicesToQuery?.length ?? 0} services</>}
-          </div>
-          <Field className={styles.searchField}>
-            <Input
-              data-testid={testIds.exploreService.search}
-              value={searchQuery}
-              prefix={<Icon name="search" />}
-              placeholder="Search services"
-              onChange={onSearchChange}
-            />
-          </Field>
-          {/** If we don't have any servicesByVolume, volume endpoint is probably not enabled */}
-          {!isServicesByVolumeLoading && volumeApiError && <ConfigureVolumeError />}
-          {!isServicesByVolumeLoading && !volumeApiError && !servicesByVolume?.length && <NoVolumeError />}
-          {!isServicesByVolumeLoading && servicesToQuery && servicesToQuery.length > 0 && (
-            <div className={styles.body}>
-              <body.Component model={body} />
+      <PluginPage pageNav={{ text: 'Services' }} layout={PageLayoutType.Custom}>
+        <div className={styles.container}>
+          <div className={styles.bodyWrapper}>
+            <div>
+              {/** When services fetched, show how many services are we showing */}
+              {isServicesByVolumeLoading && (
+                <LoadingPlaceholder text={'Loading services'} className={styles.loadingText} />
+              )}
+              {!isServicesByVolumeLoading && <>Showing {servicesToQuery?.length ?? 0} services</>}
             </div>
-          )}
+            <Field className={styles.searchField}>
+              <Input
+                data-testid={testIds.exploreService.search}
+                value={searchQuery}
+                prefix={<Icon name="search" />}
+                placeholder="Search services"
+                onChange={onSearchChange}
+              />
+            </Field>
+            {/** If we don't have any servicesByVolume, volume endpoint is probably not enabled */}
+            {!isServicesByVolumeLoading && volumeApiError && <ConfigureVolumeError />}
+            {!isServicesByVolumeLoading && !volumeApiError && !servicesByVolume?.length && <NoVolumeError />}
+            {!isServicesByVolumeLoading && servicesToQuery && servicesToQuery.length > 0 && (
+              <div className={styles.body}>
+                <body.Component model={body} />
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      </PluginPage>
     );
   };
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/explore-logs/issues/358.

This is a temporary workaround until we have time to refactor the breakdowns into routes (see https://github.com/grafana/explore-logs/issues/351)

Shouldn't impact layout at all. Clicking on the top level nav item still takes user back to the "services" view, which is the desired functionality AFAIK.

<img width="355" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/2448037b-5593-4dba-955e-14e7277753eb">
<img width="430" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/cc2f9594-06e0-41fe-9ac7-611eb3ad4842">

<img width="1728" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/407ca0ad-f6fc-4c41-9b34-59efa0028be2">
<img width="683" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/1bee9680-ec71-47de-ad7d-d91ede45a533">
<img width="601" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/5d3a936a-2133-4f78-96ad-641961fbe413">

This won't fix the browser history though. I looked at using the hook useHistory, while it somewhat worked for children routes, it throws an error when the IndexScene is loading, if we want browser history we'll need to implement a route for each page.
