### PR TITLE
fix(FieldsBreakDownScene): add loading state and empty state

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -19,7 +19,7 @@ import {
   SceneVariableSet,
   VariableDependencyConfig,
 } from '@grafana/scenes';
-import { Button, DrawStyle, Field, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafana/ui';
+import { Alert, Button, DrawStyle, Field, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafana/ui';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { getLabelValueScene } from 'services/fields';
 import { getQueryRunner, setLeverColorOverrides } from 'services/panel';
@@ -101,6 +101,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
           value: f,
         })),
       ],
+      loading: logsScene.state.loading,
     });
 
     this.updateBody(variable);
@@ -131,14 +132,36 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
 
   private async updateBody(variable: CustomVariable) {
     const stateUpdate: Partial<FieldsBreakdownSceneState> = {
-      loading: false,
       value: String(variable.state.value),
       blockingMessage: undefined,
     };
 
-    stateUpdate.body = variable.hasAllValue() ? this.buildAllLayout(this.state.fields) : buildNormalLayout(variable);
+    if (this.state.loading === false && this.state.fields.length === 1) {
+      stateUpdate.body = this.buildEmptyLayout();
+    } else {
+      stateUpdate.body = variable.hasAllValue() ? this.buildAllLayout(this.state.fields) : buildNormalLayout(variable);
+    }
 
     this.setState(stateUpdate);
+  }
+
+  private buildEmptyLayout() {
+    return new SceneFlexLayout({
+      direction: 'column',
+      children: [
+        new SceneFlexItem({
+          body: new SceneReactObject({
+            reactNode: (
+              <div>
+                <Alert title="" severity="warning">
+                  No detected fields. Please contact us if you think this is a mistake.
+                </Alert>
+              </div>
+            ),
+          }),
+        }),
+      ],
+    });
   }
 
   private buildAllLayout(options: Array<SelectableValue<string>>) {

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -154,7 +154,16 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
             reactNode: (
               <div>
                 <Alert title="" severity="warning">
-                  No detected fields. Please contact us if you think this is a mistake.
+                  No detected fields. Please{' '}
+                  <a
+                    className={emptyStateStyles.link}
+                    href="https://forms.gle/1sYWCTPvD72T1dPH9"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    let us know
+                  </a>{' '}
+                  if you think this is a mistake.
                 </Alert>
               </div>
             ),
@@ -273,6 +282,12 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     );
   };
 }
+
+const emptyStateStyles = {
+  link: css({
+    textDecoration: 'underline',
+  }),
+};
 
 function getStyles(theme: GrafanaTheme2) {
   return {


### PR DESCRIPTION
Fixes https://github.com/grafana/explore-logs/issues/393

This PR:
- Adds a missing loading state to Detected Fields
- Adds an empty state to Detected fields

![Message](https://github.com/grafana/explore-logs/assets/1069378/9e2c9bf1-819f-4931-a770-5ee505bb0b01)

https://github.com/grafana/explore-logs/assets/1069378/4a132ace-561f-4437-85aa-7c8c1f2bf0fe

