### PR TITLE
fix: label filter dropdown should show options

### DIFF
--- a/src/Components/IndexScene/LayoutScene.tsx
+++ b/src/Components/IndexScene/LayoutScene.tsx
@@ -96,10 +96,6 @@ function getStyles(theme: GrafanaTheme2) {
       '&:first-child': {
         // The wrapper of each filter
         '& > div': {
-          // the 'service_name' filter wrapper
-          '&:nth-child(2) > div': {
-            gap: theme.spacing(2),
-          },
           // The actual inputs container
           '& > div': {
             flexWrap: 'wrap',
@@ -124,7 +120,7 @@ function getStyles(theme: GrafanaTheme2) {
 
       ['div >[title="Add filter"]']: {
         border: 0,
-        visibility: 'hidden',
+        display: 'none',
         width: 0,
         padding: 0,
         margin: 0,

--- a/src/Components/IndexScene/LayoutScene.tsx
+++ b/src/Components/IndexScene/LayoutScene.tsx
@@ -98,7 +98,7 @@ function getStyles(theme: GrafanaTheme2) {
         '& > div': {
           // the 'service_name' filter wrapper
           '&:nth-child(2) > div': {
-            gap: 0,
+            gap: theme.spacing(2),
           },
           // The actual inputs container
           '& > div': {

--- a/src/Components/ServiceScene/Breakdowns/AddToFilterButton.test.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFilterButton.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AddToFiltersButton } from './AddToFiltersButton';
+import { FieldType, createDataFrame } from '@grafana/data';
+import userEvent from '@testing-library/user-event';
+import { sceneGraph } from '@grafana/scenes';
+import { LEVEL_VARIABLE_VALUE, VAR_FIELDS } from 'services/variables';
+
+describe('AddToFiltersButton', () => {
+  it('updates correct variable passed to AddToFiltersButton', async () => {
+    const button = new AddToFiltersButton({
+      frame: createDataFrame({
+        name: 'frame1',
+        fields: [
+          {
+            name: 'time',
+            type: FieldType.time,
+            values: [0],
+          },
+          {
+            name: 'value',
+            type: FieldType.number,
+            values: [100],
+            labels: {
+              test: 'error',
+            },
+          },
+        ],
+      }),
+      variableName: 'testVariableName',
+    });
+    const lookup = jest.spyOn(sceneGraph, 'lookupVariable');
+    render(<button.Component model={button} />);
+    userEvent.click(screen.getByRole('button', { name: 'Add to filters' }));
+    await waitFor(async () => expect(lookup).toHaveBeenCalledWith('testVariableName', expect.anything()));
+  });
+
+  it('updates correct variable when LEVEL_VARIABLE_VALUE', async () => {
+    const labels: { [key: string]: string } = {};
+    labels[LEVEL_VARIABLE_VALUE] = 'error';
+    const button = new AddToFiltersButton({
+      frame: createDataFrame({
+        name: 'frame2',
+        fields: [
+          {
+            name: 'time',
+            type: FieldType.time,
+            values: [0],
+          },
+          {
+            name: 'value',
+            type: FieldType.number,
+            values: [100],
+            labels,
+          },
+        ],
+      }),
+      variableName: 'testVariableName',
+    });
+    const lookup = jest.spyOn(sceneGraph, 'lookupVariable');
+    render(<button.Component model={button} />);
+    userEvent.click(screen.getByRole('button', { name: 'Add to filters' }));
+    await waitFor(async () => expect(lookup).toHaveBeenCalledWith(VAR_FIELDS, expect.anything()));
+  });
+});

--- a/src/Components/ServiceScene/Breakdowns/AddToFilterButton.test.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFilterButton.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { AddToFiltersButton } from './AddToFiltersButton';
 import { FieldType, createDataFrame } from '@grafana/data';
 import userEvent from '@testing-library/user-event';
-import { sceneGraph } from '@grafana/scenes';
+import { AdHocFiltersVariable, sceneGraph } from '@grafana/scenes';
 import { LEVEL_VARIABLE_VALUE, VAR_FIELDS } from 'services/variables';
 
 describe('AddToFiltersButton', () => {
@@ -29,9 +29,9 @@ describe('AddToFiltersButton', () => {
       }),
       variableName: 'testVariableName',
     });
-    const lookup = jest.spyOn(sceneGraph, 'lookupVariable');
+    const lookup = jest.spyOn(sceneGraph, 'lookupVariable').mockReturnValue(new AdHocFiltersVariable({}));
     render(<button.Component model={button} />);
-    userEvent.click(screen.getByRole('button', { name: 'Add to filters' }));
+    userEvent.click(screen.getByRole('button', { name: 'Include' }));
     await waitFor(async () => expect(lookup).toHaveBeenCalledWith('testVariableName', expect.anything()));
   });
 
@@ -57,9 +57,9 @@ describe('AddToFiltersButton', () => {
       }),
       variableName: 'testVariableName',
     });
-    const lookup = jest.spyOn(sceneGraph, 'lookupVariable');
+    const lookup = jest.spyOn(sceneGraph, 'lookupVariable').mockReturnValue(new AdHocFiltersVariable({}));
     render(<button.Component model={button} />);
-    userEvent.click(screen.getByRole('button', { name: 'Add to filters' }));
+    userEvent.click(screen.getByRole('button', { name: 'Include' }));
     await waitFor(async () => expect(lookup).toHaveBeenCalledWith(VAR_FIELDS, expect.anything()));
   });
 });

--- a/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@grafana/ui';
 import { VariableHide } from '@grafana/schema';
 import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
+import { LEVEL_VARIABLE_VALUE, VAR_FIELDS } from 'services/variables';
 
 export interface AddToFiltersButtonState extends SceneObjectState {
   frame: DataFrame;
@@ -19,16 +20,23 @@ export interface AddToFiltersButtonState extends SceneObjectState {
 
 export class AddToFiltersButton extends SceneObjectBase<AddToFiltersButtonState> {
   public onClick = () => {
-    const variable = sceneGraph.lookupVariable(this.state.variableName, this);
-    if (!(variable instanceof AdHocFiltersVariable)) {
-      return;
-    }
-
     const labels = this.state.frame.fields[1]?.labels ?? {};
     if (Object.keys(labels).length !== 1) {
       return;
     }
     const labelName = Object.keys(labels)[0];
+
+    let variableName = this.state.variableName;
+    // If the variable is a level variable, we need to use the VAR_FIELDS variable
+    // as that one is detected field
+    if (labelName === LEVEL_VARIABLE_VALUE) {
+      variableName = VAR_FIELDS;
+    }
+
+    const variable = sceneGraph.lookupVariable(variableName, this);
+    if (!(variable instanceof AdHocFiltersVariable)) {
+      return;
+    }
 
     // Check if the filter is already there
     const isFilterDuplicate = variable.state.filters.some((f) => {

--- a/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
@@ -1,17 +1,12 @@
 import React from 'react';
 
 import { DataFrame } from '@grafana/data';
-import {
-  SceneObjectState,
-  SceneObjectBase,
-  SceneComponentProps,
-  sceneGraph,
-  AdHocFiltersVariable,
-} from '@grafana/scenes';
+import { SceneObjectState, SceneObjectBase, SceneComponentProps } from '@grafana/scenes';
 import { VariableHide } from '@grafana/schema';
 import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 import { LEVEL_VARIABLE_VALUE, VAR_FIELDS } from 'services/variables';
 import { FilterButton } from 'Components/FilterButton';
+import { getAdHocFiltersVariable } from 'services/scenes';
 
 export interface AddToFiltersButtonState extends SceneObjectState {
   frame: DataFrame;
@@ -34,8 +29,8 @@ export class AddToFiltersButton extends SceneObjectBase<AddToFiltersButtonState>
     if (selectedFilter.name === LEVEL_VARIABLE_VALUE) {
       variableName = VAR_FIELDS;
     }
-    const variable = sceneGraph.lookupVariable(variableName, this);
-    if (!(variable instanceof AdHocFiltersVariable)) {
+    const variable = getAdHocFiltersVariable(variableName, this);
+    if (!variable) {
       return;
     }
 
@@ -85,9 +80,9 @@ export class AddToFiltersButton extends SceneObjectBase<AddToFiltersButtonState>
     if (filter.name === LEVEL_VARIABLE_VALUE) {
       variableName = VAR_FIELDS;
     }
-    const variable = sceneGraph.lookupVariable(variableName, this);
-    if (!(variable instanceof AdHocFiltersVariable)) {
-      return;
+    const variable = getAdHocFiltersVariable(variableName, this);
+    if (!variable) {
+      return false;
     }
 
     // Check if the filter is already there

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -21,11 +21,17 @@ import {
 } from '@grafana/scenes';
 import { Alert, Button, DrawStyle, Field, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafana/ui';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
-import { getLabelValueScene } from 'services/fields';
+import { getFilterBreakdownValueScene } from 'services/fields';
 import { getQueryRunner, setLeverColorOverrides } from 'services/panel';
 import { buildLokiQuery } from 'services/query';
 import { getUniqueFilters } from 'services/scenes';
-import { ALL_VARIABLE_VALUE, LOG_STREAM_SELECTOR_EXPR, VAR_FIELD_GROUP_BY, VAR_FILTERS } from 'services/variables';
+import {
+  ALL_VARIABLE_VALUE,
+  LOG_STREAM_SELECTOR_EXPR,
+  VAR_FIELDS,
+  VAR_FIELD_GROUP_BY,
+  VAR_FILTERS,
+} from 'services/variables';
 import { ServiceScene } from '../ServiceScene';
 import { AddToFiltersButton } from './AddToFiltersButton';
 import { ByFrameRepeater } from './ByFrameRepeater';
@@ -378,9 +384,10 @@ function buildNormalLayout(variable: CustomVariable) {
           ],
           isLazy: true,
         }),
-        getLayoutChild: getLabelValueScene(
+        getLayoutChild: getFilterBreakdownValueScene(
           getLabelValue,
-          query.expr.includes('count_over_time') ? DrawStyle.Bars : DrawStyle.Line
+          query.expr.includes('count_over_time') ? DrawStyle.Bars : DrawStyle.Line,
+          VAR_FIELDS
         ),
       }),
       new ByFrameRepeater({
@@ -396,9 +403,10 @@ function buildNormalLayout(variable: CustomVariable) {
           ],
           isLazy: true,
         }),
-        getLayoutChild: getLabelValueScene(
+        getLayoutChild: getFilterBreakdownValueScene(
           getLabelValue,
-          query.expr.includes('count_over_time') ? DrawStyle.Bars : DrawStyle.Line
+          query.expr.includes('count_over_time') ? DrawStyle.Bars : DrawStyle.Line,
+          VAR_FIELDS
         ),
       }),
     ],

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -22,7 +22,7 @@ import {
 } from '@grafana/scenes';
 import { Alert, Button, DrawStyle, Field, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafana/ui';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
-import { DetectedLabel, DetectedLabelsResponse, getLabelValueScene } from 'services/fields';
+import { DetectedLabel, DetectedLabelsResponse, getFilterBreakdownValueScene } from 'services/fields';
 import { getQueryRunner, setLeverColorOverrides } from 'services/panel';
 import { buildLokiQuery } from 'services/query';
 import { PLUGIN_ID } from 'services/routing';
@@ -337,9 +337,10 @@ function buildLabelValuesLayout(variable: CustomVariable) {
             }),
           ],
         }),
-        getLayoutChild: getLabelValueScene(
+        getLayoutChild: getFilterBreakdownValueScene(
           getLabelValue,
-          query.expr.includes('count_over_time') ? DrawStyle.Bars : DrawStyle.Line
+          query.expr.includes('count_over_time') ? DrawStyle.Bars : DrawStyle.Line,
+          VAR_FILTERS
         ),
       }),
       new ByFrameRepeater({
@@ -354,9 +355,10 @@ function buildLabelValuesLayout(variable: CustomVariable) {
             }),
           ],
         }),
-        getLayoutChild: getLabelValueScene(
+        getLayoutChild: getFilterBreakdownValueScene(
           getLabelValue,
-          query.expr.includes('count_over_time') ? DrawStyle.Bars : DrawStyle.Line
+          query.expr.includes('count_over_time') ? DrawStyle.Bars : DrawStyle.Line,
+          VAR_FILTERS
         ),
       }),
     ],

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -3,7 +3,7 @@ import { DrawStyle, StackingMode } from '@grafana/ui';
 import { PanelBuilders, SceneCSSGridItem, SceneDataNode } from '@grafana/scenes';
 import { getColorByIndex } from './scenes';
 import { AddToFiltersButton } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
-import { VAR_FIELDS } from './variables';
+import { VAR_FIELDS, VAR_FILTERS } from './variables';
 import { setLeverColorOverrides } from './panel';
 
 export type DetectedLabel = {
@@ -38,7 +38,11 @@ export function extractParserAndFieldsFromDataFrame(data: DataFrame) {
   return result;
 }
 
-export function getLabelValueScene(getTitle: (df: DataFrame) => string, style: DrawStyle) {
+export function getFilterBreakdownValueScene(
+  getTitle: (df: DataFrame) => string,
+  style: DrawStyle,
+  variableName: typeof VAR_FIELDS | typeof VAR_FILTERS
+) {
   return (data: PanelData, frame: DataFrame, frameIndex: number) => {
     const panel = PanelBuilders.timeseries() //
       .setOption('legend', { showLegend: false })
@@ -47,7 +51,7 @@ export function getLabelValueScene(getTitle: (df: DataFrame) => string, style: D
       .setData(new SceneDataNode({ data: { ...data, series: [frame] } }))
       .setColor({ mode: 'fixed', fixedColor: getColorByIndex(frameIndex) })
       .setOverrides(setLeverColorOverrides)
-      .setHeaderActions(new AddToFiltersButton({ frame, variableName: VAR_FIELDS }));
+      .setHeaderActions(new AddToFiltersButton({ frame, variableName }));
 
     if (style === DrawStyle.Bars) {
       panel

--- a/src/services/scenes.ts
+++ b/src/services/scenes.ts
@@ -51,6 +51,7 @@ export function getLabelOptions(sceneObject: SceneObject, allOptions: string[]) 
   }));
 
   const levelOption = [];
+  // We are adding LEVEL_VARIABLE_VALUE which is structured metadata, but we want to show it as a label
   if (!allOptions.includes(LEVEL_VARIABLE_VALUE)) {
     levelOption.push({ label: LEVEL_VARIABLE_VALUE, value: LEVEL_VARIABLE_VALUE });
   }

--- a/src/services/scenes.ts
+++ b/src/services/scenes.ts
@@ -92,3 +92,19 @@ export async function getLokiDatasource(sceneObject: SceneObject) {
     | undefined;
   return ds;
 }
+
+export function getAdHocFiltersVariable(variableName: string, sceneObject: SceneObject) {
+  const variable = sceneGraph.lookupVariable(variableName, sceneObject);
+
+  if (!variable) {
+    console.warn(`Could not get AdHocFiltersVariable ${variableName}. Variable not found.`);
+    return null;
+  }
+  if (!(variable instanceof AdHocFiltersVariable)) {
+    console.warn(
+      `Could not get AdHocFiltersVariable ${variableName}. Variable is not an instance of AdHocFiltersVariable`
+    );
+    return null;
+  }
+  return variable;
+}


### PR DESCRIPTION
We had an issue where clicking on the label ad hoc filters didn't show/provide any options. This was a bug because we were not setting **labels** as **label filters** but as **detected fields**. This PR fixes it and ensures that the only label that we want to select as a detected field is `detected_level` since it is structured metadata and won't work as a label.

The PR also adds tests.

**Fixed:**

https://github.com/grafana/explore-logs/assets/30407135/6eb0fb56-dba1-49e5-8851-919aa97ccdb0
<img width="715" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/c2835dc9-9559-41ff-8e92-73d06d9168b4">


**Broken on main:**

https://github.com/grafana/explore-logs/assets/30407135/ea8a9c38-e503-45dc-85fb-41a3c59c288b

