### PR TITLE
Logs Table UI: Legacy dataplane fix

### DIFF
--- a/src/Components/Table/Context/TableColumnsContext.tsx
+++ b/src/Components/Table/Context/TableColumnsContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 import { ActiveFieldMeta, FieldNameMetaStore } from 'Components/Table/TableTypes';
-import { DATAPLANE_BODY_NAME, DATAPLANE_TIMESTAMP_NAME, LogsFrame } from '../../../services/logsFrame';
+import { getBodyName, getTimeName, LogsFrame } from '../../../services/logsFrame';
 
 type TableColumnsContextType = {
   // the current list of labels from the dataframe combined with UI metadata
@@ -35,17 +35,21 @@ const TableColumnsContext = createContext<TableColumnsContextType>({
   setBodyState: () => {},
 });
 
-function setDefaultColumns(columns: FieldNameMetaStore, handleSetColumns: (newColumns: FieldNameMetaStore) => void) {
+function setDefaultColumns(
+  columns: FieldNameMetaStore,
+  handleSetColumns: (newColumns: FieldNameMetaStore) => void,
+  logsFrame: LogsFrame
+) {
   const pendingColumns = { ...columns };
 
-  pendingColumns[DATAPLANE_TIMESTAMP_NAME] = {
+  pendingColumns[getTimeName(logsFrame)] = {
     index: 0,
     active: true,
     type: 'TIME_FIELD',
     percentOfLinesWithLabel: 100,
     cardinality: Infinity,
   };
-  pendingColumns[DATAPLANE_BODY_NAME] = {
+  pendingColumns[getBodyName(logsFrame)] = {
     index: 1,
     active: true,
     type: 'BODY_FIELD',
@@ -119,7 +123,7 @@ export const TableColumnContextProvider = ({
 
       // If we're missing all fields, the user must have removed the last column, let's revert back to the default state
       if (activeFields.length === 0) {
-        setDefaultColumns(columns, handleSetColumns);
+        setDefaultColumns(columns, handleSetColumns, logsFrame);
       }
 
       // Reset any local search state

--- a/src/Components/Table/LogLineCellComponent.tsx
+++ b/src/Components/Table/LogLineCellComponent.tsx
@@ -13,7 +13,7 @@ import { Scroller } from 'Components/Table/Scroller';
 import { css } from '@emotion/css';
 import { LineActionIcons } from 'Components/Table/LineActionIcons';
 import { RawLogLineText } from 'Components/Table/RawLogLineText';
-import { DATAPLANE_BODY_NAME } from '../../services/logsFrame';
+import { getBodyName } from '../../services/logsFrame';
 
 export type SelectedTableRow = {
   row: number;
@@ -51,7 +51,7 @@ export const LogLineCellComponent = (props: Props) => {
   const renderLabels = (labels: Labels) => {
     const columnLabelNames = Object.keys(columns);
     const labelNames = columnLabelNames
-      .filter((name) => name !== DATAPLANE_BODY_NAME)
+      .filter((name) => name !== getBodyName(logsFrame))
       .sort((a, b) => {
         // Sort level first
         if (a === 'level') {

--- a/src/Components/Table/LogsTableHeader.tsx
+++ b/src/Components/Table/LogsTableHeader.tsx
@@ -5,7 +5,8 @@ import { Field, GrafanaTheme2 } from '@grafana/data';
 import { ClickOutsideWrapper, Icon, Popover, useTheme2 } from '@grafana/ui';
 
 import { useTableHeaderContext } from 'Components/Table/Context/TableHeaderContext';
-import { DATAPLANE_BODY_NAME } from '../../services/logsFrame';
+import { useQueryContext } from './Context/QueryContext';
+import { getBodyName } from '../../services/logsFrame';
 
 export interface LogsTableHeaderProps extends PropsWithChildren<CustomHeaderRendererProps> {
   fieldIndex: number;
@@ -57,9 +58,10 @@ const getStyles = (theme: GrafanaTheme2, isFirstColumn: boolean, isLine: boolean
 
 export const LogsTableHeader = (props: LogsTableHeaderProps) => {
   const { setHeaderMenuActive, isHeaderMenuActive } = useTableHeaderContext();
+  const { logsFrame } = useQueryContext();
   const referenceElement = useRef<HTMLButtonElement | null>(null);
   const theme = useTheme2();
-  const styles = getStyles(theme, props.fieldIndex === 0, props.field.name === DATAPLANE_BODY_NAME);
+  const styles = getStyles(theme, props.fieldIndex === 0, props.field.name === getBodyName(logsFrame));
 
   return (
     <span className={styles.wrapper}>

--- a/src/Components/Table/LogsTableHeaderWrap.tsx
+++ b/src/Components/Table/LogsTableHeaderWrap.tsx
@@ -5,8 +5,9 @@ import { LogLineState, useTableColumnContext } from 'Components/Table/Context/Ta
 import { Icon } from '@grafana/ui';
 import React, { useCallback } from 'react';
 import { Field } from '@grafana/data';
-import { DATAPLANE_BODY_NAME } from '../../services/logsFrame';
+import { getBodyName } from '../../services/logsFrame';
 import { css, cx } from '@emotion/css';
+import { useQueryContext } from './Context/QueryContext';
 
 export function LogsTableHeaderWrap(props: {
   headerProps: LogsTableHeaderProps;
@@ -18,6 +19,7 @@ export function LogsTableHeaderWrap(props: {
 }) {
   const { setHeaderMenuActive } = useTableHeaderContext();
   const { columns, setColumns, bodyState, setBodyState } = useTableColumnContext();
+  const { logsFrame } = useQueryContext();
   const styles = getStyles();
 
   const hideColumn = useCallback(
@@ -45,7 +47,7 @@ export function LogsTableHeaderWrap(props: {
     [columns, setColumns]
   );
 
-  const isBodyField = props.headerProps.field.name === DATAPLANE_BODY_NAME;
+  const isBodyField = props.headerProps.field.name === getBodyName(logsFrame);
 
   return (
     <LogsTableHeader {...props.headerProps}>

--- a/src/services/logsFrame.ts
+++ b/src/services/logsFrame.ts
@@ -1,4 +1,4 @@
-import { DataFrame, FieldCache, FieldType, FieldWithIndex, Labels } from '@grafana/data';
+import { DataFrame, DataFrameType, Field, FieldCache, FieldType, FieldWithIndex, Labels } from '@grafana/data';
 
 // these are like Labels, but their values can be
 // arbitrary structures, not just strings
@@ -45,6 +45,14 @@ export function logFrameLabelsToLabels(logFrameLabels: LogFrameLabels): Labels {
 }
 
 export function parseLogsFrame(frame: DataFrame): LogsFrame | null {
+  if (frame.meta?.type === DataFrameType.LogLines) {
+    return parseDataplaneLogsFrame(frame);
+  } else {
+    return parseLegacyLogsFrame(frame);
+  }
+}
+
+export function parseDataplaneLogsFrame(frame: DataFrame): LogsFrame | null {
   const cache = new FieldCache(frame);
 
   const timestampField = getField(cache, DATAPLANE_TIMESTAMP_NAME, FieldType.time);
@@ -82,4 +90,92 @@ export function parseLogsFrame(frame: DataFrame): LogsFrame | null {
     getLabelFieldName: () => (labelsField !== null ? labelsField.name : null),
     extraFields,
   };
+}
+
+export function parseLegacyLogsFrame(frame: DataFrame): LogsFrame | null {
+  const cache = new FieldCache(frame);
+  const timeField = cache.getFirstFieldOfType(FieldType.time);
+  const bodyField = cache.getFirstFieldOfType(FieldType.string);
+
+  // these two are mandatory
+  if (timeField === undefined || bodyField === undefined) {
+    return null;
+  }
+
+  const timeNanosecondField = cache.getFieldByName('tsNs') ?? null;
+  const severityField = cache.getFieldByName('level') ?? null;
+  const idField = cache.getFieldByName('id') ?? null;
+
+  // extracting the labels is done very differently for old-loki-style and simple-style
+  // dataframes, so it's a little awkward to handle it,
+  // we both need to on-demand extract the labels, and also get teh labelsField,
+  // but only if the labelsField is used.
+  const [labelsField, getL] = makeLabelsGetter(cache, bodyField, frame);
+
+  const extraFields = cache.fields.filter(
+    (_, i) =>
+      i !== timeField.index &&
+      i !== bodyField.index &&
+      i !== timeNanosecondField?.index &&
+      i !== severityField?.index &&
+      i !== idField?.index &&
+      i !== labelsField?.index
+  );
+
+  return {
+    timeField,
+    bodyField,
+    timeNanosecondField,
+    severityField,
+    idField,
+    getLogFrameLabels: getL,
+    getLogFrameLabelsAsLabels: getL,
+    getLabelFieldName: () => labelsField?.name ?? null,
+    extraFields,
+    raw: frame,
+  };
+}
+
+// if the frame has "labels" field with type "other", adjust the behavior.
+// we also have to return the labels-field (if we used it),
+// to be able to remove it from the unused-fields, later.
+function makeLabelsGetter(
+  cache: FieldCache,
+  lineField: Field,
+  frame: DataFrame
+): [FieldWithIndex | null, () => Labels[] | null] {
+  // If we have labels field with type "other", use that
+  const labelsField = cache.getFieldByName('labels');
+  if (labelsField !== undefined && labelsField.type === FieldType.other) {
+    const values = labelsField.values.map(logFrameLabelsToLabels);
+    return [labelsField, () => values];
+  } else {
+    // Otherwise we use the labels on the line-field, and make an array with it
+    return [null, () => makeLabelsArray(lineField, frame.length)];
+  }
+}
+
+// take the labels from the line-field, and "stretch" it into an array
+// with the length of the frame (so there are the same labels for every row)
+function makeLabelsArray(lineField: Field, length: number): Labels[] | null {
+  const lineLabels = lineField.labels;
+  if (lineLabels !== undefined) {
+    const result = new Array(length);
+    result.fill(lineLabels);
+    return result;
+  } else {
+    return null;
+  }
+}
+
+export function getTimeName(logsFrame?: LogsFrame) {
+  return logsFrame?.timeField.name ?? DATAPLANE_TIMESTAMP_NAME;
+}
+
+export function getBodyName(logsFrame?: LogsFrame | null): string {
+  return logsFrame?.bodyField.name ?? DATAPLANE_BODY_NAME;
+}
+
+export function getIdName(logsFrame?: LogsFrame): string {
+  return logsFrame?.idField?.name ?? DATAPLANE_ID_NAME;
 }

--- a/src/services/logsFrame.ts
+++ b/src/services/logsFrame.ts
@@ -92,6 +92,7 @@ export function parseDataplaneLogsFrame(frame: DataFrame): LogsFrame | null {
   };
 }
 
+// Copied from https://github.com/grafana/grafana/blob/main/public/app/features/logs/legacyLogsFrame.ts
 export function parseLegacyLogsFrame(frame: DataFrame): LogsFrame | null {
   const cache = new FieldCache(frame);
   const timeField = cache.getFirstFieldOfType(FieldType.time);


### PR DESCRIPTION
Adding backwards compatibility for legacy dataplane.
For some reason I thought the dataplane feature was required for the logs app, but I was incorrect.
