### PR TITLE
Fields breakdown: add value filter

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
@@ -16,6 +16,8 @@ interface ByFrameRepeaterState extends SceneObjectState {
   getLayoutChild(data: PanelData, frame: DataFrame, frameIndex: number): SceneFlexItem;
 }
 
+type FrameFilterCallback = (f: DataFrame) => boolean;
+
 export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
   public constructor(state: ByFrameRepeaterState) {
     super(state);
@@ -37,15 +39,25 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     });
   }
 
-  private performRepeat(data: PanelData) {
+  private performRepeat(data: PanelData, filterFn: FrameFilterCallback = () => true) {
     const newChildren: SceneFlexItem[] = [];
 
     for (let seriesIndex = 0; seriesIndex < data.series.length; seriesIndex++) {
+      if (!filterFn(data.series[seriesIndex])) {
+        continue;
+      }
       const layoutChild = this.state.getLayoutChild(data, data.series[seriesIndex], seriesIndex);
       newChildren.push(layoutChild);
     }
 
     this.state.body.setState({ children: newChildren });
+  }
+
+  public filterFrame(filterFn: FrameFilterCallback) {
+    const data = sceneGraph.getData(this);
+    if (data.state.data) {
+      this.performRepeat(data.state.data, filterFn);
+    }
   }
 
   public static Component = ({ model }: SceneComponentProps<SceneByFrameRepeater>) => {

--- a/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
@@ -54,7 +54,7 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     this.unfilteredChildren = newChildren;
   }
 
-  public filterFrame = (filterFn: FrameFilterCallback) => {
+  public filterFrames = (filterFn: FrameFilterCallback) => {
     const data = sceneGraph.getData(this).state.data;
     if (!data) {
       return;

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -278,7 +278,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
   private filterValues(filter: string) {
     this.state.body?.forEachChild((child) => {
       if (child instanceof ByFrameRepeater) {
-        child.filterFrame((frame: DataFrame) => getLabelValue(frame).includes(filter));
+        child.filterFrames((frame: DataFrame) => getLabelValue(frame).includes(filter));
       }
     });
   }

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -280,7 +280,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
         <StatusWrapper {...{ isLoading: loading, blockingMessage }}>
           <div className={styles.controls}>
             {body instanceof LayoutSwitcher && <body.Selector model={body} />}
-            {!loading && value && (
+            {!loading && value !== ALL_VARIABLE_VALUE && (
               <SearchInput
                 value={valueFilter}
                 onChange={model.onValueFilterChange}

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -89,16 +89,15 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
         newState.value !== oldState.value ||
         newState.loading !== oldState.loading
       ) {
-        this.updateBody(variable);
+        this.updateBody();
       }
     });
 
     this.updateFields();
-    this.updateBody(variable);
+    this.updateBody();
   }
 
   private updateFields() {
-    const variable = this.getVariable();
     const logsScene = sceneGraph.getAncestor(this, ServiceScene);
 
     this.setState({
@@ -112,7 +111,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
       loading: logsScene.state.loading,
     });
 
-    this.updateBody(variable);
+    this.updateBody();
   }
 
   private getVariable(): CustomVariable {
@@ -127,7 +126,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
   private onReferencedVariableValueChanged() {
     const variable = this.getVariable();
     variable.changeValueTo(ALL_VARIABLE_VALUE);
-    this.updateBody(variable);
+    this.updateBody();
   }
 
   private hideField(field: string) {
@@ -138,7 +137,8 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     this.state.changeFields?.(fields.filter((f) => f.value !== ALL_VARIABLE_VALUE).map((f) => f.value!));
   }
 
-  private updateBody(variable: CustomVariable = this.getVariable()) {
+  private updateBody() {
+    const variable = this.getVariable();
     const stateUpdate: Partial<FieldsBreakdownSceneState> = {
       value: String(variable.state.value),
       blockingMessage: undefined,

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -138,7 +138,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     this.state.changeFields?.(fields.filter((f) => f.value !== ALL_VARIABLE_VALUE).map((f) => f.value!));
   }
 
-  private async updateBody(variable: CustomVariable) {
+  private updateBody(variable: CustomVariable = this.getVariable()) {
     const stateUpdate: Partial<FieldsBreakdownSceneState> = {
       value: String(variable.state.value),
       blockingMessage: undefined,
@@ -267,11 +267,21 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
 
   public onValueFilterChange = (event: ChangeEvent<HTMLInputElement>) => {
     this.setState({ valueFilter: event.target.value });
+    this.filterValues(event.target.value);
   };
 
   public clearValueFilter = () => {
     this.setState({ valueFilter: '' });
+    this.filterValues('');
   };
+
+  private filterValues(filter: string) {
+    this.state.body?.forEachChild((child) => {
+      if (child instanceof ByFrameRepeater) {
+        child.filterFrame((frame: DataFrame) => getLabelValue(frame).includes(filter));
+      }
+    });
+  }
 
   public static Component = ({ model }: SceneComponentProps<FieldsBreakdownScene>) => {
     const { fields, body, loading, value, blockingMessage, valueFilter } = model.useState();

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -147,7 +147,9 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     if (this.state.loading === false && this.state.fields.length === 1) {
       stateUpdate.body = this.buildEmptyLayout();
     } else {
-      stateUpdate.body = variable.hasAllValue() ? this.buildAllLayout(this.state.fields) : buildNormalLayout(variable);
+      stateUpdate.body = variable.hasAllValue()
+        ? this.buildFieldsLayout(this.state.fields)
+        : buildValuesLayout(variable);
     }
 
     this.setState(stateUpdate);
@@ -181,7 +183,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     });
   }
 
-  private buildAllLayout(options: Array<SelectableValue<string>>) {
+  private buildFieldsLayout(options: Array<SelectableValue<string>>) {
     const children: SceneFlexItemLike[] = [];
 
     for (const option of options) {
@@ -348,7 +350,7 @@ function getExpr(field: string) {
 
 const GRID_TEMPLATE_COLUMNS = 'repeat(auto-fit, minmax(400px, 1fr))';
 
-function buildNormalLayout(variable: CustomVariable) {
+function buildValuesLayout(variable: CustomVariable) {
   const tagKey = variable.getValueText();
   const query = buildLokiQuery(getExpr(tagKey), { legendFormat: `{{${tagKey}}}` });
 

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -19,7 +19,7 @@ import {
   SceneVariableSet,
   VariableDependencyConfig,
 } from '@grafana/scenes';
-import { Alert, Button, DrawStyle, Icon, Input, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafana/ui';
+import { Alert, Button, DrawStyle, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafana/ui';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { getFilterBreakdownValueScene } from 'services/fields';
 import { getQueryRunner, setLeverColorOverrides } from 'services/panel';
@@ -37,6 +37,7 @@ import { ByFrameRepeater } from './ByFrameRepeater';
 import { FieldSelector } from './FieldSelector';
 import { LayoutSwitcher } from './LayoutSwitcher';
 import { StatusWrapper } from './StatusWrapper';
+import { SearchInput } from './SearchInput';
 
 export interface FieldsBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -262,9 +263,13 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     variable.changeValueTo(value);
   };
 
-  private onValueFilterChange(event: ChangeEvent<HTMLInputElement>) {
+  public onValueFilterChange = (event: ChangeEvent<HTMLInputElement>) => {
     this.setState({ valueFilter: event.target.value });
-  }
+  };
+
+  public clearValueFilter = () => {
+    this.setState({ valueFilter: '' });
+  };
 
   public static Component = ({ model }: SceneComponentProps<FieldsBreakdownScene>) => {
     const { fields, body, loading, value, blockingMessage, valueFilter } = model.useState();
@@ -276,10 +281,10 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
           <div className={styles.controls}>
             {body instanceof LayoutSwitcher && <body.Selector model={body} />}
             {!loading && value && (
-              <Input
+              <SearchInput
                 value={valueFilter}
                 onChange={model.onValueFilterChange}
-                prefix={<Icon name="search" />}
+                onClear={model.clearValueFilter}
                 placeholder="Search for value"
               />
             )}

--- a/src/Components/ServiceScene/Breakdowns/SearchInput.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SearchInput.tsx
@@ -1,0 +1,25 @@
+import { css } from '@emotion/css';
+import { Icon, Input } from '@grafana/ui';
+import React, { HTMLProps } from 'react';
+
+interface Props extends HTMLProps<HTMLInputElement> {
+  onClear(): void;
+}
+
+export const SearchInput = ({ value, onChange, placeholder, onClear }: Props) => {
+  return (
+    <Input
+      value={value}
+      onChange={onChange}
+      suffix={value ? <Icon onClick={onClear} name={'x'} className={styles.clearIcon} /> : undefined}
+      prefix={<Icon name="search" />}
+      placeholder={placeholder}
+    />
+  );
+};
+
+const styles = {
+  clearIcon: css({
+    cursor: 'pointer',
+  }),
+};

--- a/src/Components/ServiceScene/Breakdowns/SearchInput.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SearchInput.tsx
@@ -11,7 +11,7 @@ export const SearchInput = ({ value, onChange, placeholder, onClear }: Props) =>
     <Input
       value={value}
       onChange={onChange}
-      suffix={value ? <Icon onClick={onClear} name={'x'} className={styles.clearIcon} /> : undefined}
+      suffix={value ? <Icon onClick={onClear} name="times" className={styles.clearIcon} /> : undefined}
       prefix={<Icon name="search" />}
       placeholder={placeholder}
     />


### PR DESCRIPTION
Part of https://github.com/grafana/explore-logs/issues/400
Closes https://github.com/grafana/explore-logs/issues/433

This PR adds filtering to fields values. This filtering has been implemented using `ByFrameRepeater`, and the approach was based on reusing panel instances to prevent unnecessary work and, in particular, flickering while writing.

Additionally, adds a `SearchInput` component with some basic behaviors to share in other places where we want a filter.

Demo:

https://github.com/grafana/explore-logs/assets/1069378/60a1ffed-d07a-4b6b-9322-187c35978e71

