### PR TITLE
fix(service-name-op): hide operator on `service_name`

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -161,16 +161,7 @@ function getVariableSet(initialDS?: string, initialFilters?: AdHocVariableFilter
     key: 'adhoc_service_filter',
   });
 
-  filterVariable._getOperators = () => {
-    // Only allow equal operator if there is only one filter
-    if (filterVariable.state.filters.length === 1) {
-      return [
-        {
-          label: FilterOp.Equal,
-          value: FilterOp.Equal,
-        },
-      ];
-    }
+  filterVariable._getOperators = function () {
     return operators;
   };
 

--- a/src/Components/IndexScene/LayoutScene.tsx
+++ b/src/Components/IndexScene/LayoutScene.tsx
@@ -117,6 +117,15 @@ function getStyles(theme: GrafanaTheme2) {
           },
         },
       },
+      // the `service_name` filter is a special case where we want to hide the operator
+      '[data-testid="AdHocFilter-service_name"]': {
+        'div[class*="input-wrapper"]:first-child': {
+          display: 'none',
+        },
+        'div[class*="input-wrapper"]:nth-child(2)': {
+          marginLeft: 0,
+        },
+      },
 
       ['div >[title="Add filter"]']: {
         border: 0,

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -252,7 +252,7 @@ test.describe('explore services breakdown page', () => {
   });
 
   test('should update a filter and run new logs', async ({ page }) => {
-    await page.getByTestId('AdHocFilter-service_name').getByRole('img').nth(2).click();
+    await page.getByTestId('AdHocFilter-service_name').getByRole('img').nth(1).click();
     await page.getByText('mimir-distributor').click();
 
     // open logs panel


### PR DESCRIPTION
It's not pretty, but it works...
Hiding the operator for `service_name`, as this one should always be an `equal` operator.