### PR TITLE
Logs panel: overflow fix

### DIFF
--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -255,9 +255,13 @@ const styles = {
     '.show-on-hover': {
       display: 'none',
     },
-    // A components withing the Logs viz sets contain, which creates a new containing block that is not body which breaks the popover menu
-    'section > div': css({
+
+    // Hack to select internal div
+    'section > div[class$="panel-content"]': css({
+      // A components withing the Logs viz sets contain, which creates a new containing block that is not body which breaks the popover menu
       contain: 'none',
+      // Prevent overflow from spilling out of parent container
+      overflow: 'auto',
     }),
   }),
 };

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -19,6 +19,12 @@ test.describe('explore services breakdown page', () => {
     await expect(page).toHaveURL(/broadcast/);
   });
 
+  test('logs panel should have panel-content class suffix', async ({ page }) => {
+    await explorePage.serviceBreakdownSearch.click();
+    await explorePage.serviceBreakdownSearch.fill('broadcast');
+    await expect(page.getByTestId('data-testid Panel header Logs').locator('[class$="panel-content"]')).toBeVisible();
+  });
+
   test('should filter table panel on text search', async ({ page }) => {
     const initialText = await page.getByTestId(testIds.table.wrapper).allTextContents()
     await explorePage.serviceBreakdownSearch.click();


### PR DESCRIPTION
Fixes https://github.com/grafana/explore-logs/issues/475

Note:
While this works, it's pretty hacky targeting panel internals, and using internal css class suffix isn't great.