### PR TITLE
Header: tighten top space

### DIFF
--- a/src/Components/IndexScene/GiveFeedbackButton.tsx
+++ b/src/Components/IndexScene/GiveFeedbackButton.tsx
@@ -33,6 +33,7 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     wrapper: css({
       display: 'flex',
+      whiteSpace: 'nowrap',
     }),
     feedback: css({
       alignSelf: 'center',

--- a/src/Components/IndexScene/LayoutScene.tsx
+++ b/src/Components/IndexScene/LayoutScene.tsx
@@ -63,7 +63,7 @@ function getStyles(theme: GrafanaTheme2) {
     container: css({
       flexGrow: 1,
       display: 'flex',
-      gap: theme.spacing(2),
+      gap: theme.spacing(1),
       minHeight: '100%',
       flexDirection: 'column',
       padding: theme.spacing(2),

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -419,9 +419,9 @@ export class LogsActionBar extends SceneObjectBase<LogsActionBarState> {
     };
 
     return (
-      <Box paddingY={1}>
+      <Box paddingY={0}>
         <div className={styles.actions}>
-          <Stack gap={2}>
+          <Stack gap={1}>
             <GoToExploreButton exploration={exploration} />
           </Stack>
         </div>


### PR DESCRIPTION
Fixes https://github.com/grafana/explore-logs/issues/448

Adjusting gaps and margins in the top part. Additionally, preventing the `give feedback` button from wrapping.

![Demo](https://github.com/grafana/explore-logs/assets/1069378/9c88902d-516b-47c0-848b-d7621dd683f5)

https://github.com/grafana/explore-logs/assets/1069378/299d7a8a-c1a7-455a-a705-c9a6ab93de4c

