### PR TITLE
fix(table): fix negative width columns bug

### DIFF
--- a/src/Components/Table/Table.tsx
+++ b/src/Components/Table/Table.tsx
@@ -155,7 +155,7 @@ export const Table = (props: Props) => {
     // This function is building the table dataframe that will be transformed, even though the components within the dataframe (cells, headers) can mutate the dataframe!
     // If we try to update the dataframe whenever the columns are changed (which are rebuilt using this dataframe after being transformed), react will infinitely update frame -> columns -> frame -> ...
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [timeZone, theme, labels]
+    [timeZone, theme, labels, width, replace, setVisible]
   );
 
   // prepare dataFrame


### PR DESCRIPTION
Quick fix: Making sure we re-calculate widths when window width changes. I can only reproduce the bug with legacy dataplane frames for some reason, in this case the frames are always calculating the width at 0 of the table, resulting in negative numbers in the columns which prevents them from rendering on initial page load.