### PR TITLE
E2E: reduce test flake

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig<PluginOptions>({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 2 : 1,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -33,10 +33,12 @@ export default defineConfig<PluginOptions>({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
 
-    video: {
-      mode: 'on-first-retry',
-    }
+    // Turn on when debugging local tests
+    // video: {
+    //   mode: 'on',
+    // }
   },
+  expect: { timeout: 15000 },
 
   /* Configure projects for major browsers */
   projects: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig<PluginOptions>({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 1,
+  retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/src/services/testIds.ts
+++ b/src/services/testIds.ts
@@ -25,6 +25,7 @@ export const testIds = {
     buttonExcludedPattern: 'data-testid button-excluded-pattern',
   },
   logsPanelHeader: {
+    header: 'data-testid Panel header Logs',
     radio: 'data-testid radio-button',
   },
   table: {

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -261,6 +261,9 @@ test.describe('explore services breakdown page', () => {
     await page.getByTestId('AdHocFilter-service_name').getByRole('img').nth(1).click();
     await page.getByText('mimir-distributor').click();
 
+    // Assert the panel is done loading before going on
+    await expect(page.getByTestId(testIds.logsPanelHeader.header).getByLabel('Panel loading bar')).not.toBeVisible()
+
     // open logs panel
     await page.getByTitle('See log details').nth(1).click();
 


### PR DESCRIPTION
Increasing expect timeout, some loki queries were taking longer then 5s locally, I assume this might be responsible for some of the flake in CI as well.

Also adding an assertion in a test that the loading state is undefined before opening the logs panel, were some executions that would run before the dataframe came back.