### PR TITLE
Add workflow that syncs documentation to the website repository on pushes to main

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -1,0 +1,37 @@
+name: publish-technical-documentation-next
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/sources/**"
+  workflow_dispatch:
+jobs:
+  sync:
+    if: github.repository == 'grafana/explore-logs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone website-sync Action
+        # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
+        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
+        # GitHub administrator to update the organization secret.
+        # The IT helpdesk can update the organization secret.
+        run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync
+
+      - name: Publish to website repository (next)
+        uses: ./.github/actions/website-sync
+        id: publish-next
+        with:
+          repository: grafana/website
+          branch: master
+          host: github.com
+          # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
+          # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
+          # GitHub administrator to update the organization secret.
+          # The IT helpdesk can update the organization secret.
+          github_pat: grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}
+          source_folder: docs/sources
+          target_folder: content/docs/explore-logs/next


### PR DESCRIPTION
We can test and evaluate the Continuous Delivery of documentation to the website repository without publishing it on the website thanks to https://github.com/grafana/website/pull/20393/files which tells Hugo not to render or list any pages under content/docs/explore-logs/.

We can also put in place a similar workflow for publishing versioned releases of documentation after we decide on how those are going to be maintained. `grafana/grafana` uses long-lived version branches for each version and documentation is synced from those branches. `grafana/k6-docs` doesn't need to version documentation alongside the code (because it's a separate repository) and maintains all of its documentation in the `main` branch.