### PR TITLE
UX: add search icon to field/label autocomplete dropdown

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldSelector.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldSelector.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { Select, useStyles2, InlineField } from '@grafana/ui';
+import { Select, useStyles2, InlineField, Icon } from '@grafana/ui';
 
 type Props = {
   options: Array<SelectableValue<string>>;
@@ -13,9 +13,17 @@ type Props = {
 
 export function FieldSelector({ options, value, onChange, label }: Props) {
   const styles = useStyles2(getStyles);
+  const [selected, setSelected] = useState(false);
   return (
     <InlineField label={label}>
-      <Select {...{ options, value }} onChange={(selected) => onChange(selected.value)} className={styles.select} />
+      <Select
+        {...{ options, value }}
+        onOpenMenu={() => setSelected(true)}
+        onCloseMenu={() => setSelected(false)}
+        onChange={(selected) => onChange(selected.value)}
+        className={styles.select}
+        prefix={selected ? undefined : <Icon name={'search'} />}
+      />
     </InlineField>
   );
 }
@@ -24,6 +32,7 @@ function getStyles(theme: GrafanaTheme2) {
   return {
     select: css({
       maxWidth: theme.spacing(64),
+      minWidth: theme.spacing(20),
     }),
   };
 }


### PR DESCRIPTION
Just a small helper in the UI to let users know they can search by label name.

Main:
<img width="169" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/83476e53-5887-46d2-9761-5ae2b30886fb">

This PR:
<img width="498" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/626282bd-4f26-496a-871b-4c463dcbc71d">

This PR:
<img width="383" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/8abb716d-c4d1-4144-84a5-e35201ce690b">
<img width="531" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/943f6d4e-0371-4b2f-b51c-f5d8d73606f2">

We don't have a lot of flexibility with the search icon already in the base select component, I would like to always show the search icon so users know it's searchable and not just a dropdown. This PR suggests adding the search icon as a prefix that is only visible when the select isn't open.

Also making the dropdown a bit bigger, the ALL value is selected by default and it's easy to miss this element in this state.

Main:
<img width="172" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/d414beff-a1c4-469a-849a-d2cc7660f34f">

This PR: 
<img width="323" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/96aaf604-d24e-45a6-8a8c-5dd5526b6fbe">
