### PR TITLE
chore: rename `Detected Fields` to `Fields`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Once the docker container started, navigate to http://localhost:3000/a/grafana-l
    - By clicking and dragging the time range you want to see on any time series visualization.
 5. Services are shown based on the volume of logs, and you can search for the service you want through the Search service input.
 6. Select the service you would like to explore. This takes you to the Service page.
-7. Filter logs based on strings, labels, detected fields, or detected patterns.
+7. Filter logs based on strings, labels, fields, or detected patterns.
 
 <img src="src/img/service_logs.png" alt="app"/>
 

--- a/src/Components/Pages.tsx
+++ b/src/Components/Pages.tsx
@@ -109,9 +109,6 @@ export function makeBreakdownPage(
 }
 
 function slugToBreadcrumbTitle(slug: PageSlugs) {
-  if (slug === 'fields') {
-    return 'Detected fields';
-  }
   // capitalize first letter
   return slug.charAt(0).toUpperCase() + slug.slice(1);
 }

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -83,7 +83,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     this.subscribeToEvent(SortCriteriaChanged, this.handleSortByChange);
 
     sceneGraph.getAncestor(this, ServiceScene)!.subscribeToState((newState, oldState) => {
-      if (newState.detectedFields !== oldState.detectedFields) {
+      if (newState.fields !== oldState.fields) {
         this.updateFields();
       }
     });
@@ -108,7 +108,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     this.setState({
       fields: [
         { label: 'All', value: ALL_VARIABLE_VALUE },
-        ...(logsScene.state.detectedFields ?? []).map((f) => ({
+        ...(logsScene.state.fields ?? []).map((f) => ({
           label: f,
           value: f,
         })),
@@ -184,7 +184,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
             reactNode: (
               <div>
                 <Alert title="" severity="warning">
-                  No detected fields. Please{' '}
+                  We did not find any fields for the given timerange. Please{' '}
                   <a
                     className={emptyStateStyles.link}
                     href="https://forms.gle/1sYWCTPvD72T1dPH9"

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -60,11 +60,11 @@ type MakeOptional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 export interface ServiceSceneState extends SceneObjectState {
   body: SceneFlexLayout;
 
-  detectedFields?: string[];
+  fields?: string[];
   labels?: string[];
   patterns?: LokiPattern[];
 
-  detectedFieldsCount?: number;
+  fieldsCount?: number;
 
   loading?: boolean;
 }
@@ -197,10 +197,10 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
       const frame = newState.data?.series[0];
       if (frame) {
         const res = extractParserAndFieldsFromDataFrame(frame);
-        const detectedFields = res.fields.filter((f) => !disabledFields.includes(f)).sort((a, b) => a.localeCompare(b));
-        if (JSON.stringify(detectedFields) !== JSON.stringify(this.state.detectedFields)) {
+        const fields = res.fields.filter((f) => !disabledFields.includes(f)).sort((a, b) => a.localeCompare(b));
+        if (JSON.stringify(fields) !== JSON.stringify(this.state.fields)) {
           this.setState({
-            detectedFields,
+            fields: fields,
             loading: false,
           });
         }
@@ -210,13 +210,13 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
         }
       } else {
         this.setState({
-          detectedFields: [],
+          fields: [],
           loading: false,
         });
       }
     } else if (newState.data?.state === LoadingState.Error) {
       this.setState({
-        detectedFields: [],
+        fields: [],
         loading: false,
       });
     }
@@ -302,7 +302,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
           ...body.state.children.slice(0, 1),
           breakdownViewDef.getScene((vals) => {
             if (breakdownViewDef.value === 'fields') {
-              this.setState({ detectedFieldsCount: vals.length });
+              this.setState({ fieldsCount: vals.length });
             }
           }),
         ],
@@ -332,10 +332,10 @@ const breakdownViewsDefinitions: BreakdownViewDefinition[] = [
     testId: testIds.exploreServiceDetails.tabLabels,
   },
   {
-    displayName: 'Detected fields',
+    displayName: 'Fields',
     value: PageSlugs.fields,
     getScene: (f) => buildFieldsBreakdownActionScene(f),
-    testId: testIds.exploreServiceDetails.tabDetectedFields,
+    testId: testIds.exploreServiceDetails.tabFields,
   },
   {
     displayName: 'Patterns',
@@ -356,9 +356,7 @@ export class LogsActionBar extends SceneObjectBase<LogsActionBarState> {
     const getCounter = (tab: BreakdownViewDefinition, state: ServiceSceneState) => {
       switch (tab.value) {
         case 'fields':
-          return (
-            state.detectedFieldsCount ?? (state.detectedFields?.filter((l) => l !== ALL_VARIABLE_VALUE) ?? []).length
-          );
+          return state.fieldsCount ?? (state.fields?.filter((l) => l !== ALL_VARIABLE_VALUE) ?? []).length;
         case 'patterns':
           return state.patterns?.length;
         case 'labels':

--- a/src/Components/Table/TableTypes.ts
+++ b/src/Components/Table/TableTypes.ts
@@ -15,7 +15,7 @@ export type GenericMeta = {
   type?: 'BODY_FIELD' | 'TIME_FIELD' | 'LINK_FIELD';
   cardinality: number;
   maxLength?: number;
-  detectedFieldType?: FieldType;
+  fieldType?: FieldType;
 };
 
 export type FieldNameMeta = (ActiveFieldMeta | InactiveFieldMeta) & GenericMeta;

--- a/src/services/testIds.ts
+++ b/src/services/testIds.ts
@@ -13,7 +13,7 @@ export const testIds = {
     openExplore: 'data-testid open-explore',
     tabPatterns: 'data-testid tab-patterns',
     tabLogs: 'data-testid tab-logs',
-    tabDetectedFields: 'data-testid tab-detected-fields',
+    tabFields: 'data-testid tab-fields',
     tabLabels: 'data-testid tab-labels',
     buttonRemovePattern: 'data-testid button-remove-pattern',
     buttonFilterInclude: 'data-testid button-filter-include',

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -75,7 +75,7 @@ test.describe('explore services breakdown page', () => {
   });
 
   test('should exclude a label, update filters, open log panel', async ({ page }) => {
-    await page.getByTestId(testIds.exploreServiceDetails.tabDetectedFields).click();
+    await page.getByTestId(testIds.exploreServiceDetails.tabFields).click();
     await page.getByTestId('data-testid Panel header err').getByRole('button', { name: 'Select' }).click();
     await page.getByRole('button', { name: 'Exclude' }).nth(0).click();
     await expect(page.getByTestId(testIds.exploreServiceDetails.searchLogs)).toBeVisible();
@@ -85,8 +85,8 @@ test.describe('explore services breakdown page', () => {
   });
 
 
-  test('should select a detected field, update filters, open log panel', async ({ page }) => {
-    await page.getByTestId(testIds.exploreServiceDetails.tabDetectedFields).click();
+  test('should select a field, update filters, open log panel', async ({ page }) => {
+    await page.getByTestId(testIds.exploreServiceDetails.tabFields).click();
     await page.getByTestId('data-testid Panel header err').getByRole('button', { name: 'Select' }).click();
     await page.getByRole('button', { name: 'Include' }).nth(0).click();
     // Should see the logs panel full of errors


### PR DESCRIPTION
This PR renames all occurrences of `Detected Fields` to `Fields`. Especially with structured metadata this will tab will not only serve "detected" fields, but also structured metadata.

