### PR TITLE
chore: autoenable plugin when installed

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -3,6 +3,7 @@
   "type": "app",
   "name": "Logs",
   "id": "grafana-lokiexplore-app",
+  "autoEnabled": true,
   "info": {
     "keywords": ["app", "loki", "explore", "logs"],
     "description": "Query-less exploration of log data stored in Loki",


### PR DESCRIPTION
FYI, as discussed, this will auto enable the plugin once installed.

https://grafana.com/developers/plugin-tools/reference/plugin-json#:~:text=supports%20annotation%20queries.-,autoEnabled,-boolean