### PR TITLE
Value breakdown: refactor sorting options and add changepoint detection sorting

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,10 +4,13 @@ const { grafanaESModules, nodeModulesToTransform } = require('./.config/jest/uti
 // generally used by snapshots, but can affect specific tests
 process.env.TZ = 'UTC';
 
+const config = require('./.config/jest.config');
+
 module.exports = {
   // Jest configuration provided by Grafana scaffolding
-  ...require('./.config/jest.config'),
+  ...config,
   moduleNameMapper: {
+    ...config.moduleNameMapper,
     '@bsull/augurs': '@bsull/augurs/augurs.js',
   },
   transformIgnorePatterns: [nodeModulesToTransform([...grafanaESModules, '@bsull/augurs'])],

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,5 @@ process.env.TZ = 'UTC';
 module.exports = {
   // Jest configuration provided by Grafana scaffolding
   ...require('./.config/jest.config'),
+  moduleDirectories: ['public', 'node_modules'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+const { grafanaESModules, nodeModulesToTransform } = require('./.config/jest/utils');
+
 // force timezone to UTC to allow tests to work regardless of local timezone
 // generally used by snapshots, but can affect specific tests
 process.env.TZ = 'UTC';
@@ -5,5 +7,8 @@ process.env.TZ = 'UTC';
 module.exports = {
   // Jest configuration provided by Grafana scaffolding
   ...require('./.config/jest.config'),
-  moduleDirectories: ['public', 'node_modules'],
+  moduleNameMapper: {
+    '@bsull/augurs': '@bsull/augurs/augurs.js',
+  },
+  transformIgnorePatterns: [nodeModulesToTransform([...grafanaESModules, '@bsull/augurs'])],
 };

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.13",
   "description": "Query less exploration of log data stored in Loki",
   "scripts": {
-    "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
-    "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "typecheck": "tsc --noEmit",
@@ -73,6 +73,7 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@bsull/augurs": "^0.2.0",
     "@emotion/css": "^11.10.6",
     "@grafana/data": "^11.0.0",
     "@grafana/runtime": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@grafana/data": "^11.0.0",
     "@grafana/runtime": "^11.0.0",
     "@grafana/scenes": "5.2.0",
+    "@grafana/scenes-ml": "^0.2.0",
     "@grafana/ui": "^11.0.0",
     "@playwright/test": "^1.43.1",
     "@types/react-table": "^7.7.20",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@grafana/data": "^11.0.0",
     "@grafana/runtime": "^11.0.0",
     "@grafana/scenes": "5.2.0",
-    "@grafana/scenes-ml": "^0.2.0",
     "@grafana/ui": "^11.0.0",
     "@playwright/test": "^1.43.1",
     "@types/react-table": "^7.7.20",

--- a/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
@@ -80,8 +80,6 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
       dataFrame: dataFrame,
     }));
 
-    console.log(seriesCalcs);
-
     seriesCalcs.sort((a, b) => {
       if (a.value && b.value) {
         return b.value - a.value;
@@ -100,7 +98,11 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     const fields = data.fields.filter((f) => f.type === FieldType.number);
 
     const dataPoints = fields[0].values.length;
-    const samplingStep = Math.floor(dataPoints / 100) || 1;
+    let samplingStep = Math.floor(dataPoints / 100) || 1;
+    if (samplingStep > 1) {
+      // Avoiding "big" steps for more accuracy
+      samplingStep = Math.ceil(samplingStep / 2);
+    }
 
     const sample = fields[0].values.filter((_, i) => i % samplingStep === 0);
 

--- a/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
@@ -21,7 +21,6 @@ type FrameFilterCallback = (frame: DataFrame) => boolean;
 type FrameIterateCallback = (frames: DataFrame[], seriesIndex: number) => void;
 
 export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
-  public changepointDetector = ChangepointDetector.defaultArgpcp();
   private unfilteredChildren: SceneFlexItem[];
   private sortBy: string;
   private direction: string;
@@ -68,7 +67,7 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
   private getSortedSeries = (data: PanelData) => {
     const reducer = (dataFrame: DataFrame) => {
       if (this.sortBy === 'changepoint') {
-        return this.changePointsValue(dataFrame);
+        return this.calculateChangepointsValue(dataFrame);
       }
       const fieldReducer = fieldReducers.get(this.sortBy);
       const value =
@@ -95,10 +94,10 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     return seriesCalcs.map(({ dataFrame }) => dataFrame);
   };
 
-  private changePointsValue = (data: DataFrame) => {
+  private calculateChangepointsValue = (data: DataFrame) => {
     const fields = data.fields.filter((f) => f.type === FieldType.number);
     const values = new Float64Array(fields[0].values);
-    const points = this.changepointDetector.detectChangepoints(values);
+    const points = ChangepointDetector.defaultArgpcp().detectChangepoints(values);
     return points.indices.length;
   };
 

--- a/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
@@ -100,7 +100,7 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     const fields = data.fields.filter((f) => f.type === FieldType.number);
 
     const dataPoints = fields[0].values.length;
-    const samplingStep = Math.floor(dataPoints / Math.pow(10, dataPoints.toString().length - 1));
+    const samplingStep = Math.floor(dataPoints / 100) || 1;
 
     const sample = fields[0].values.filter((_, i) => i % samplingStep === 0);
 

--- a/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
@@ -80,6 +80,8 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
       dataFrame: dataFrame,
     }));
 
+    console.log(seriesCalcs);
+
     seriesCalcs.sort((a, b) => {
       if (a.value && b.value) {
         return b.value - a.value;
@@ -96,8 +98,15 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
 
   private calculateChangepointsValue = (data: DataFrame) => {
     const fields = data.fields.filter((f) => f.type === FieldType.number);
-    const values = new Float64Array(fields[0].values);
+
+    const dataPoints = fields[0].values.length;
+    const samplingStep = Math.floor(dataPoints / Math.pow(10, dataPoints.toString().length - 1));
+
+    const sample = fields[0].values.filter((_, i) => i % samplingStep === 0);
+
+    const values = new Float64Array(sample);
     const points = ChangepointDetector.defaultArgpcp().detectChangepoints(values);
+
     return points.indices.length;
   };
 

--- a/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
@@ -24,6 +24,7 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
   private unfilteredChildren: SceneFlexItem[];
   private sortBy: string;
   private direction: string;
+  private sortedSeries: DataFrame[] = [];
   public constructor({ sortBy, direction, ...state }: ByFrameRepeaterState & { sortBy: string; direction: string }) {
     super(state);
 
@@ -73,6 +74,7 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
       newChildren.push(layoutChild);
     }
 
+    this.sortedSeries = sortedSeries;
     this.state.body.setState({ children: newChildren });
     this.unfilteredChildren = newChildren;
   }
@@ -82,9 +84,8 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     if (!data) {
       return;
     }
-    const sortedSeries = sortSeries(data.series, this.sortBy, this.direction);
-    for (let seriesIndex = 0; seriesIndex < sortedSeries.length; seriesIndex++) {
-      callback(sortedSeries, seriesIndex);
+    for (let seriesIndex = 0; seriesIndex < this.sortedSeries.length; seriesIndex++) {
+      callback(this.sortedSeries, seriesIndex);
     }
   };
 

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.test.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.test.tsx
@@ -14,7 +14,7 @@ describe('SortByScene', () => {
   test('Sorts by standard deviation by default', () => {
     render(<scene.Component model={scene} />);
 
-    expect(screen.getByText('StdDev')).toBeInTheDocument();
+    expect(screen.getByText('Relevance')).toBeInTheDocument();
     expect(screen.getByText('Desc')).toBeInTheDocument();
   });
 
@@ -45,6 +45,6 @@ describe('SortByScene', () => {
 
     await waitFor(() => select(screen.getByLabelText('Sort direction'), 'Asc', { container: document.body }));
 
-    expect(eventSpy).toHaveBeenCalledWith(new SortCriteriaChanged('stdDev', 'asc'), true);
+    expect(eventSpy).toHaveBeenCalledWith(new SortCriteriaChanged('changepoint', 'asc'), true);
   });
 });

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -1,8 +1,8 @@
 import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import React from 'react';
-import { BusEventBase, DataFrame, ReducerID, SelectableValue } from '@grafana/data';
+import { BusEventBase, DataFrame, ReducerID, SelectableValue, fieldReducers } from '@grafana/data';
 import { getLabelValueFromDataFrame } from 'services/levels';
-import { InlineField, Select, StatsPicker } from '@grafana/ui';
+import { InlineField, Select } from '@grafana/ui';
 import { getSortByPreference, setSortByPreference } from 'services/store';
 
 export interface SortBySceneState extends SceneObjectState {
@@ -19,8 +19,22 @@ export class SortCriteriaChanged extends BusEventBase {
 }
 
 export class SortByScene extends SceneObjectBase<SortBySceneState> {
+  public sortingOptions = [
+    {
+      value: 'changepoint',
+      label: 'Automatic',
+      description: 'Best-effort identification of the most relevant time series',
+    },
+    {
+      value: ReducerID.stdDev,
+      label: 'Standard deviation',
+      description: 'Standard deviation of all values in a field',
+    },
+    ...fieldReducers.selectOptions([], (ext) => ext.id !== ReducerID.stdDev).options,
+  ];
+
   constructor(state: Pick<SortBySceneState, 'target'>) {
-    const { sortBy, direction } = getSortByPreference(state.target, ReducerID.stdDev, 'desc');
+    const { sortBy, direction } = getSortByPreference(state.target, 'changepoint', 'desc');
     super({
       target: state.target,
       sortBy,
@@ -28,13 +42,13 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
     });
   }
 
-  public onCriteriaChange = (criteria: string[]) => {
-    if (!criteria.length) {
+  public onCriteriaChange = (criteria: SelectableValue<string>) => {
+    if (!criteria.value) {
       return;
     }
-    this.setState({ sortBy: criteria[0] });
-    setSortByPreference(this.state.target, criteria[0], this.state.direction);
-    this.publishEvent(new SortCriteriaChanged(criteria[0], this.state.direction), true);
+    this.setState({ sortBy: criteria.value });
+    setSortByPreference(this.state.target, criteria.value, this.state.direction);
+    this.publishEvent(new SortCriteriaChanged(criteria.value, this.state.direction), true);
   };
 
   public onDirectionChange = (direction: SelectableValue<string>) => {
@@ -48,6 +62,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
 
   public static Component = ({ model }: SceneComponentProps<SortByScene>) => {
     const { sortBy, direction } = model.useState();
+    const value = model.sortingOptions.find(({ value }) => value === sortBy);
     return (
       <>
         <InlineField>
@@ -73,13 +88,13 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
           htmlFor="sort-by-criteria"
           tooltip="Calculate a derived quantity from the values in your time series and sort by this criteria. Defaults to standard deviation."
         >
-          <StatsPicker
-            placeholder="Choose criteria"
-            stats={[sortBy]}
-            allowMultiple={false}
-            onChange={model.onCriteriaChange}
-            defaultStat={ReducerID.stdDev}
+          <Select
+            value={value}
             width={18}
+            isSearchable={true}
+            options={model.sortingOptions}
+            placeholder={'Choose criteria'}
+            onChange={model.onCriteriaChange}
             inputId="sort-by-criteria"
           />
         </InlineField>

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -23,11 +23,11 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
     {
       value: 'changepoint',
       label: 'Auto',
-      description: 'Best-effort identification of the most relevant time series',
+      description: 'Best-effort identification of the most relevant graphs',
     },
     {
       value: ReducerID.stdDev,
-      label: 'Standard deviation',
+      label: 'Dispersion',
       description: 'Standard deviation of all values in a field',
     },
     ...fieldReducers.selectOptions([], (ext) => ext.id !== ReducerID.stdDev).options,

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -22,8 +22,8 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
   public sortingOptions = [
     {
       value: 'changepoint',
-      label: 'Auto',
-      description: 'Best-effort identification of the most relevant graphs',
+      label: 'Relevance',
+      description: 'Most relevant time series first',
     },
     {
       value: ReducerID.stdDev,

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -22,7 +22,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
   public sortingOptions = [
     {
       value: 'changepoint',
-      label: 'Automatic',
+      label: 'Auto',
       description: 'Best-effort identification of the most relevant time series',
     },
     {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,8 @@
 import { AppPlugin } from '@grafana/data';
 import { App } from 'Components/App';
+import init from '@bsull/augurs';
+
+// eslint-disable-next-line no-console
+init().then(() => console.debug('Grafana ML initialized'));
 
 export const plugin = new AppPlugin<{}>().setRootPage(App);

--- a/src/services/sorting.test.ts
+++ b/src/services/sorting.test.ts
@@ -1,0 +1,50 @@
+import { toDataFrame, FieldType, ReducerID } from '@grafana/data';
+import { sortSeries } from './sorting';
+
+const frameA = toDataFrame({
+  fields: [
+    { name: 'Time', type: FieldType.time, values: [0] },
+    {
+      name: 'Value',
+      type: FieldType.number,
+      values: [0, 1, 0],
+    },
+  ],
+});
+const frameB = toDataFrame({
+  fields: [
+    { name: 'Time', type: FieldType.time, values: [0] },
+    {
+      name: 'Value',
+      type: FieldType.number,
+      values: [1, 1, 1],
+    },
+  ],
+});
+const frameC = toDataFrame({
+  fields: [
+    { name: 'Time', type: FieldType.time, values: [0] },
+    {
+      name: 'Value',
+      type: FieldType.number,
+      values: [100, 9999, 100],
+    },
+  ],
+});
+
+describe('sortSeries', () => {
+  test('Sorts series by standard deviation, descending', () => {
+    const series = [frameA, frameB, frameC];
+    const sortedSeries = [frameC, frameA, frameB];
+
+    const result = sortSeries(series, ReducerID.stdDev, 'desc');
+    expect(result).toEqual(sortedSeries);
+  });
+  test('Sorts series by standard deviation, ascending', () => {
+    const series = [frameA, frameB, frameC];
+    const sortedSeries = [frameB, frameA, frameC];
+
+    const result = sortSeries(series, ReducerID.stdDev, 'asc');
+    expect(result).toEqual(sortedSeries);
+  });
+});

--- a/src/services/sorting.ts
+++ b/src/services/sorting.ts
@@ -1,0 +1,50 @@
+import { ChangepointDetector } from '@bsull/augurs';
+import { DataFrame, FieldType, doStandardCalcs, fieldReducers } from '@grafana/data';
+
+export const sortSeries = (series: DataFrame[], sortBy: string, direction: string) => {
+  const reducer = (dataFrame: DataFrame) => {
+    if (sortBy === 'changepoint') {
+      return calculateDataFrameChangepoints(dataFrame);
+    }
+    const fieldReducer = fieldReducers.get(sortBy);
+    const value =
+      fieldReducer.reduce?.(dataFrame.fields[1], true, true) ?? doStandardCalcs(dataFrame.fields[1], true, true);
+    return value[sortBy] ?? 0;
+  };
+
+  const seriesCalcs = series.map((dataFrame) => ({
+    value: reducer(dataFrame),
+    dataFrame: dataFrame,
+  }));
+
+  seriesCalcs.sort((a, b) => {
+    if (a.value && b.value) {
+      return b.value - a.value;
+    }
+    return 0;
+  });
+
+  if (direction === 'asc') {
+    seriesCalcs.reverse();
+  }
+
+  return seriesCalcs.map(({ dataFrame }) => dataFrame);
+};
+
+export const calculateDataFrameChangepoints = (data: DataFrame) => {
+  const fields = data.fields.filter((f) => f.type === FieldType.number);
+
+  const dataPoints = fields[0].values.length;
+  let samplingStep = Math.floor(dataPoints / 100) || 1;
+  if (samplingStep > 1) {
+    // Avoiding "big" steps for more accuracy
+    samplingStep = Math.ceil(samplingStep / 2);
+  }
+
+  const sample = fields[0].values.filter((_, i) => i % samplingStep === 0);
+
+  const values = new Float64Array(sample);
+  const points = ChangepointDetector.defaultArgpcp().detectChangepoints(values);
+
+  return points.indices.length;
+};

--- a/src/services/sorting.ts
+++ b/src/services/sorting.ts
@@ -18,7 +18,7 @@ export const sortSeries = (series: DataFrame[], sortBy: string, direction: strin
   }));
 
   seriesCalcs.sort((a, b) => {
-    if (a.value && b.value) {
+    if (a.value !== undefined && b.value !== undefined) {
       return b.value - a.value;
     }
     return 0;
@@ -35,6 +35,7 @@ export const calculateDataFrameChangepoints = (data: DataFrame) => {
   const fields = data.fields.filter((f) => f.type === FieldType.number);
 
   const dataPoints = fields[0].values.length;
+
   let samplingStep = Math.floor(dataPoints / 100) || 1;
   if (samplingStep > 1) {
     // Avoiding "big" steps for more accuracy

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,0 +1,15 @@
+import type { Configuration } from 'webpack';
+import { merge } from 'webpack-merge';
+import grafanaConfig from './.config/webpack/webpack.config';
+
+const config = async (env): Promise<Configuration> => {
+  const baseConfig = await grafanaConfig(env);
+  return merge(baseConfig, {
+    experiments: {
+      // Required to load WASM modules.
+      asyncWebAssembly: true,
+    },
+  });
+};
+
+export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,6 +327,11 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-7.0.1.tgz#457233b0a18741b7711855044102b82bae7a070b"
   integrity sha512-URg8UM6lfC9ZYqFipItRSxYJdgpU5d2Z4KnjsJ+rj6tgAmGme7E+PQNCiud8g0HDaZKMovu2qjfa0f5Ge0Vlsg==
 
+"@bsull/augurs@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@bsull/augurs/-/augurs-0.2.0.tgz#71fcec248493cb9ee2d473dd4b8a8bb1c320932e"
+  integrity sha512-HyxFkWxHgSgvCuiCyan9JqWaMbEvgVGAryoorkZ/fbwV1SV0J+fuVgaGCRfzYH15lVGR3fFWVjhYY0zZfjKHng==
+
 "@commitlint/cli@^19.2.2":
   version "19.2.2"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-19.2.2.tgz#7b6d78596dcf6d716942b147aa07c04c4ee126df"
@@ -811,6 +816,14 @@
     lodash "4.17.21"
     rxjs "7.8.1"
     tslib "2.6.2"
+
+"@grafana/scenes-ml@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@grafana/scenes-ml/-/scenes-ml-0.2.0.tgz#aaaadcb242934a8d83ba0633119d3a42ba60f922"
+  integrity sha512-p0QDFtn2iyuNFUn4CR01RIvU09YnpuXllgYZjkcnKeLvOjPY0iwJesnyE9VkYgEhcVQ31k30KgRutv8wlR0alw==
+  dependencies:
+    "@bsull/augurs" "0.2.0"
+    date-fns "^3.6.0"
 
 "@grafana/scenes@5.2.0":
   version "5.2.0"
@@ -3594,7 +3607,7 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-date-fns@3.6.0:
+date-fns@3.6.0, date-fns@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
   integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,11 +327,6 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-7.0.1.tgz#457233b0a18741b7711855044102b82bae7a070b"
   integrity sha512-URg8UM6lfC9ZYqFipItRSxYJdgpU5d2Z4KnjsJ+rj6tgAmGme7E+PQNCiud8g0HDaZKMovu2qjfa0f5Ge0Vlsg==
 
-"@bsull/augurs@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@bsull/augurs/-/augurs-0.2.0.tgz#71fcec248493cb9ee2d473dd4b8a8bb1c320932e"
-  integrity sha512-HyxFkWxHgSgvCuiCyan9JqWaMbEvgVGAryoorkZ/fbwV1SV0J+fuVgaGCRfzYH15lVGR3fFWVjhYY0zZfjKHng==
-
 "@commitlint/cli@^19.2.2":
   version "19.2.2"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-19.2.2.tgz#7b6d78596dcf6d716942b147aa07c04c4ee126df"
@@ -816,14 +811,6 @@
     lodash "4.17.21"
     rxjs "7.8.1"
     tslib "2.6.2"
-
-"@grafana/scenes-ml@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@grafana/scenes-ml/-/scenes-ml-0.2.0.tgz#aaaadcb242934a8d83ba0633119d3a42ba60f922"
-  integrity sha512-p0QDFtn2iyuNFUn4CR01RIvU09YnpuXllgYZjkcnKeLvOjPY0iwJesnyE9VkYgEhcVQ31k30KgRutv8wlR0alw==
-  dependencies:
-    "@bsull/augurs" "0.2.0"
-    date-fns "^3.6.0"
 
 "@grafana/scenes@5.2.0":
   version "5.2.0"
@@ -3607,7 +3594,7 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-date-fns@3.6.0, date-fns@^3.6.0:
+date-fns@3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
   integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,6 +327,11 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-7.0.1.tgz#457233b0a18741b7711855044102b82bae7a070b"
   integrity sha512-URg8UM6lfC9ZYqFipItRSxYJdgpU5d2Z4KnjsJ+rj6tgAmGme7E+PQNCiud8g0HDaZKMovu2qjfa0f5Ge0Vlsg==
 
+"@bsull/augurs@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@bsull/augurs/-/augurs-0.2.0.tgz#71fcec248493cb9ee2d473dd4b8a8bb1c320932e"
+  integrity sha512-HyxFkWxHgSgvCuiCyan9JqWaMbEvgVGAryoorkZ/fbwV1SV0J+fuVgaGCRfzYH15lVGR3fFWVjhYY0zZfjKHng==
+
 "@commitlint/cli@^19.2.2":
   version "19.2.2"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-19.2.2.tgz#7b6d78596dcf6d716942b147aa07c04c4ee126df"


### PR DESCRIPTION
This PR introduces some minor improvements to the sorting options, but the main change is the integration of https://github.com/grafana/augurs .

Changes:
- Added changepoint detection as a sorting option (currently the default option, renamed as "Relevance").
- From the previous list of reducers/sorting options, moved stdDev to the second place and renamed it to "Dispersion".

Demo:

https://github.com/grafana/explore-logs/assets/1069378/50fe77f6-1a5a-4b27-887e-9591907a18be

### Notes

Currently a work in progress/POC.