### PR TITLE
Services: Add autocomplete search

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldSelector.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldSelector.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { useState } from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { ActionMeta, AsyncSelect, Icon, InlineField, InputActionMeta, Select, useStyles2 } from '@grafana/ui';
+import { ActionMeta, Icon, InlineField, InputActionMeta, Select, useStyles2 } from '@grafana/ui';
 
 type FieldSelectorProps = {
   options: Array<SelectableValue<string>>;
@@ -32,16 +32,17 @@ export function FieldSelector({ options, value, onChange, label }: FieldSelector
   );
 }
 
-export function AsyncFieldSelector({ options, value, onChange, label, selectOption }: AsyncFieldSelectorProps) {
+export function ServiceFieldSelector({ options, value, onChange, label, selectOption }: AsyncFieldSelectorProps) {
   const styles = useStyles2(getStyles);
   const [selected, setSelected] = useState(false);
   const [customOption, setCustomOption] = useState<SelectableValue<string>>();
-  const allOptions = customOption ? [customOption, ...options] : options;
+  const allOptions =
+    customOption && value && customOption.value?.includes(value) ? [customOption, ...options] : options;
   const selectedOption = allOptions?.find((opt) => opt.value === value);
 
   return (
     <InlineField grow={true} label={label}>
-      <AsyncSelect
+      <Select
         placeholder={'Search services'}
         options={allOptions}
         isClearable={true}

--- a/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
+++ b/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
@@ -4,6 +4,7 @@ import {
   AdHocFiltersVariable,
   SceneComponentProps,
   sceneGraph,
+  SceneObject,
   SceneObjectBase,
   SceneObjectState,
 } from '@grafana/scenes';
@@ -20,6 +21,32 @@ export interface SelectServiceButtonState extends SceneObjectState {
   service: string;
 }
 
+export function selectService(service: string, sceneRef: SceneObject) {
+  const variable = sceneGraph.lookupVariable(VAR_LABELS, sceneRef);
+  if (!(variable instanceof AdHocFiltersVariable)) {
+    return;
+  }
+
+  reportAppInteraction(USER_EVENTS_PAGES.service_selection, USER_EVENTS_ACTIONS.service_selection.service_selected, {
+    service: service,
+  });
+
+  variable.setState({
+    filters: [
+      ...variable.state.filters.filter((f) => f.key !== SERVICE_NAME),
+      {
+        key: SERVICE_NAME,
+        operator: FilterOp.Equal,
+        value: service,
+      },
+    ],
+    hide: VariableHide.hideLabel,
+  });
+  const ds = sceneGraph.lookupVariable(VAR_DATASOURCE, sceneRef)?.getValue();
+  addToFavoriteServicesInStorage(ds, service);
+  navigateToBreakdown(ROUTES.logs(service));
+}
+
 export class SelectServiceButton extends SceneObjectBase<SelectServiceButtonState> {
   public onClick = () => {
     const variable = sceneGraph.lookupVariable(VAR_LABELS, this);
@@ -30,25 +57,7 @@ export class SelectServiceButton extends SceneObjectBase<SelectServiceButtonStat
     if (!this.state.service) {
       return;
     }
-
-    reportAppInteraction(USER_EVENTS_PAGES.service_selection, USER_EVENTS_ACTIONS.service_selection.service_selected, {
-      service: this.state.service,
-    });
-
-    variable.setState({
-      filters: [
-        ...variable.state.filters.filter((f) => f.key !== SERVICE_NAME),
-        {
-          key: SERVICE_NAME,
-          operator: FilterOp.Equal,
-          value: this.state.service,
-        },
-      ],
-      hide: VariableHide.hideLabel,
-    });
-    const ds = sceneGraph.lookupVariable(VAR_DATASOURCE, this)?.getValue();
-    addToFavoriteServicesInStorage(ds, this.state.service);
-    navigateToBreakdown(ROUTES.logs(this.state.service));
+    selectService(this.state.service, this);
   };
 
   public static Component = ({ model }: SceneComponentProps<SelectServiceButton>) => {

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -38,7 +38,7 @@ import { ConfigureVolumeError } from './ConfigureVolumeError';
 import { NoVolumeError } from './NoVolumeError';
 import { getLabelsFromSeries, toggleLevelFromFilter } from 'services/levels';
 import { isFetchError } from '@grafana/runtime';
-import { AsyncFieldSelector } from '../ServiceScene/Breakdowns/FieldSelector';
+import { ServiceFieldSelector } from '../ServiceScene/Breakdowns/FieldSelector';
 
 export const SERVICE_NAME = 'service_name';
 
@@ -369,7 +369,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
             {!isServicesByVolumeLoading && <>Showing {servicesToQuery?.length ?? 0} services</>}
           </div>
           <Field className={styles.searchField}>
-            <AsyncFieldSelector
+            <ServiceFieldSelector
               value={searchQuery}
               onChange={onSearchChange}
               selectOption={(value: string) => {

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -354,7 +354,6 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
     // searchQuery is used to keep track of the search query in input field
     const [searchQuery, setSearchQuery] = useState('');
     const onSearchChange = (serviceName: string | undefined) => {
-      // console.log('onChange', serviceName)
       setSearchQuery(serviceName ?? '');
       model.onSearchServicesChange(serviceName ?? '');
     };
@@ -377,7 +376,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
               }}
               label="Service"
               options={
-                servicesByVolume?.map((serviceName) => ({
+                servicesToQuery?.map((serviceName) => ({
                   value: serviceName,
                   label: serviceName,
                 })) ?? []


### PR DESCRIPTION
Updates the UX of the services search. Results are now autocompleted, and new services are fetched as the user types into the dropdown.
Selecting an option in the dropdown will automatically take you to the service view, and typing a partial match and exiting the dropdown will add a custom option with a filter icon, showing that the user is filtering services matching the search text.

Fixes: https://github.com/grafana/explore-logs/issues/375

<img width="1728" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/88cc0721-081d-4976-9dfb-eaa13b5d4d7f">
<img width="664" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/30be5af7-e231-4e97-ae2f-6e777d7c6734">
<img width="1728" alt="image" src="https://github.com/grafana/explore-logs/assets/109082771/ff8e075d-5431-4abc-83b9-dce908707330">

