### PR TITLE
fix(routing): fix routing with url encoded values

### DIFF
--- a/src/services/routing.ts
+++ b/src/services/routing.ts
@@ -24,23 +24,12 @@ export enum PageSlugs {
   fields = 'fields',
 }
 
-export function encodeParameter(parameter: string): string {
-  return encodeURIComponent(parameter.replace(/\//g, '---'));
-}
-
-export function decodeParameter(parameter: string): string {
-  return decodeURIComponent(parameter).replace(/---/g, '/');
-}
-
 export const ROUTES = {
   explore: () => prefixRoute(PageSlugs.explore),
-  logs: (service: string) => prefixRoute(`${PageSlugs.explore}/service/${encodeParameter(service)}/${PageSlugs.logs}`),
-  fields: (service: string) =>
-    prefixRoute(`${PageSlugs.explore}/service/${encodeParameter(service)}/${PageSlugs.fields}`),
-  patterns: (service: string) =>
-    prefixRoute(`${PageSlugs.explore}/service/${encodeParameter(service)}/${PageSlugs.patterns}`),
-  labels: (service: string) =>
-    prefixRoute(`${PageSlugs.explore}/service/${encodeParameter(service)}/${PageSlugs.labels}`),
+  logs: (service: string) => prefixRoute(`${PageSlugs.explore}/service/${service}/${PageSlugs.logs}`),
+  fields: (service: string) => prefixRoute(`${PageSlugs.explore}/service/${service}/${PageSlugs.fields}`),
+  patterns: (service: string) => prefixRoute(`${PageSlugs.explore}/service/${service}/${PageSlugs.patterns}`),
+  labels: (service: string) => prefixRoute(`${PageSlugs.explore}/service/${service}/${PageSlugs.labels}`),
 };
 
 export const ROUTE_DEFINITIONS: Record<keyof typeof PageSlugs, string> = {

--- a/src/services/routing.ts
+++ b/src/services/routing.ts
@@ -24,16 +24,17 @@ export enum PageSlugs {
   fields = 'fields',
 }
 
+export function replaceSlash(parameter: string): string {
+  return parameter.replace(/\//g, '-');
+}
+
 export const ROUTES = {
   explore: () => prefixRoute(PageSlugs.explore),
-  logs: (service: string) =>
-    prefixRoute(`${PageSlugs.explore}/service/${service.replace(/\//g, '-')}/${PageSlugs.logs}`),
-  fields: (service: string) =>
-    prefixRoute(`${PageSlugs.explore}/service/${service.replace(/\//g, '-')}/${PageSlugs.fields}`),
+  logs: (service: string) => prefixRoute(`${PageSlugs.explore}/service/${replaceSlash(service)}/${PageSlugs.logs}`),
+  fields: (service: string) => prefixRoute(`${PageSlugs.explore}/service/${replaceSlash(service)}/${PageSlugs.fields}`),
   patterns: (service: string) =>
-    prefixRoute(`${PageSlugs.explore}/service/${service.replace(/\//g, '-')}/${PageSlugs.patterns}`),
-  labels: (service: string) =>
-    prefixRoute(`${PageSlugs.explore}/service/${service.replace(/\//g, '-')}/${PageSlugs.labels}`),
+    prefixRoute(`${PageSlugs.explore}/service/${replaceSlash(service)}/${PageSlugs.patterns}`),
+  labels: (service: string) => prefixRoute(`${PageSlugs.explore}/service/${replaceSlash(service)}/${PageSlugs.labels}`),
 };
 
 export const ROUTE_DEFINITIONS: Record<keyof typeof PageSlugs, string> = {

--- a/src/services/routing.ts
+++ b/src/services/routing.ts
@@ -26,10 +26,14 @@ export enum PageSlugs {
 
 export const ROUTES = {
   explore: () => prefixRoute(PageSlugs.explore),
-  logs: (service: string) => prefixRoute(`${PageSlugs.explore}/service/${service}/${PageSlugs.logs}`),
-  fields: (service: string) => prefixRoute(`${PageSlugs.explore}/service/${service}/${PageSlugs.fields}`),
-  patterns: (service: string) => prefixRoute(`${PageSlugs.explore}/service/${service}/${PageSlugs.patterns}`),
-  labels: (service: string) => prefixRoute(`${PageSlugs.explore}/service/${service}/${PageSlugs.labels}`),
+  logs: (service: string) =>
+    prefixRoute(`${PageSlugs.explore}/service/${service.replace(/\//g, '-')}/${PageSlugs.logs}`),
+  fields: (service: string) =>
+    prefixRoute(`${PageSlugs.explore}/service/${service.replace(/\//g, '-')}/${PageSlugs.fields}`),
+  patterns: (service: string) =>
+    prefixRoute(`${PageSlugs.explore}/service/${service.replace(/\//g, '-')}/${PageSlugs.patterns}`),
+  labels: (service: string) =>
+    prefixRoute(`${PageSlugs.explore}/service/${service.replace(/\//g, '-')}/${PageSlugs.labels}`),
 };
 
 export const ROUTE_DEFINITIONS: Record<keyof typeof PageSlugs, string> = {


### PR DESCRIPTION
Links with URL encoded values for e.g. `:service` would get double URL encoded and thus don't match any of our defined routes.

This PR just removes the unnecessary additionally routing.

Fixes #517