### PR TITLE
fix(lazy-load): add missing `isLazy` prop

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -261,11 +261,13 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
       active: 'grid',
       layouts: [
         new SceneCSSGridLayout({
+          isLazy: true,
           templateColumns: GRID_TEMPLATE_COLUMNS,
           autoRows: '200px',
           children: children,
         }),
         new SceneCSSGridLayout({
+          isLazy: true,
           templateColumns: '1fr',
           autoRows: '200px',
           children: children.map((child) => child.clone()),

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -281,11 +281,13 @@ function buildLabelsLayout(options: Array<SelectableValue<string>>) {
     active: 'grid',
     layouts: [
       new SceneCSSGridLayout({
+        isLazy: true,
         templateColumns: GRID_TEMPLATE_COLUMNS,
         autoRows: '200px',
         children: children,
       }),
       new SceneCSSGridLayout({
+        isLazy: true,
         templateColumns: '1fr',
         autoRows: '200px',
         children: children.map((child) => child.clone()),


### PR DESCRIPTION
Fixes the missing lazy loading in fields and label breakdowns by adding the missing `isLazy` property.