### PR TITLE
Reduce line limit used for field in patterns to 1k

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
@@ -14,7 +14,7 @@ interface PatternNameLabelProps {
   pattern: string;
 }
 
-const LINE_LIMIT = 2000;
+const LINE_LIMIT = 1000;
 
 export const PatternNameLabel = ({ exploration, pattern }: PatternNameLabelProps) => {
   const patternIndices = extractPatternIndices(pattern);


### PR DESCRIPTION
This is mostly for consistency. (We could make the editable by the user in the future)