### PR TITLE
Revert "feat(detected-fields): use `1000` as the `line_limit`"

### DIFF
--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -199,7 +199,6 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
         query: expression,
         from: timeRange.from.utc().toISOString(),
         to: timeRange.to.utc().toISOString(),
-        line_limit: 1000,
       });
 
       this.setState({


### PR DESCRIPTION
Reverts grafana/explore-logs#525

Hoping to be able to revert https://github.com/grafana/explore-logs/pull/518 after this is reverted.