### PR TITLE
Tests: fix async updates in tests

### DIFF
--- a/src/Components/IndexScene/PatternControls.test.tsx
+++ b/src/Components/IndexScene/PatternControls.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PatternControls } from './PatternControls';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AppliedPattern } from './IndexScene';
 
@@ -36,7 +36,7 @@ describe('PatternControls', () => {
     const onRemove = jest.fn();
     render(<PatternControls patterns={[{ pattern: patterns[0], type: 'include' }]} onRemove={onRemove} />);
 
-    await userEvent.click(screen.getByLabelText('Remove pattern'));
+    await act(() => userEvent.click(screen.getByLabelText('Remove pattern')));
     expect(onRemove).toHaveBeenCalledTimes(1);
   });
 

--- a/src/Components/ServiceScene/LineFilter.test.tsx
+++ b/src/Components/ServiceScene/LineFilter.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { LineFilter } from './LineFilter';
 import userEvent from '@testing-library/user-event';
 import { CustomVariable, SceneVariableSet } from '@grafana/scenes';
@@ -26,7 +26,7 @@ describe('LineFilter', () => {
   test('Updates the variable with the user input', async () => {
     render(<scene.Component model={scene} />);
 
-    await userEvent.type(screen.getByPlaceholderText('Search in log lines'), 'some text');
+    await act(() => userEvent.type(screen.getByPlaceholderText('Search in log lines'), 'some text'));
 
     expect(await screen.findByDisplayValue('some text')).toBeInTheDocument();
     expect(lineFilterVariable.getValue()).toBe('|~ `(?i)some text`');
@@ -35,7 +35,7 @@ describe('LineFilter', () => {
   test('Escapes the regular expression in the variable', async () => {
     render(<scene.Component model={scene} />);
 
-    await userEvent.type(screen.getByPlaceholderText('Search in log lines'), '(characters');
+    await act(() => userEvent.type(screen.getByPlaceholderText('Search in log lines'), '(characters'));
 
     expect(await screen.findByDisplayValue('(characters')).toBeInTheDocument();
     expect(lineFilterVariable.getValue()).toBe('|~ `(?i)\\(characters`');


### PR DESCRIPTION
This PR fixes errors that pollute Jest output, such as:

```
console.error
      Warning: An update to PatternTag inside a test was not wrapped in act(...).
      
      When testing, code that causes React state updates should be wrapped into act(...):
      
      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */
```