### PR TITLE
feat(lazy-loading): use own implementation of `LazyLoader`

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -6,7 +6,6 @@ import {
   CustomVariable,
   PanelBuilders,
   SceneComponentProps,
-  SceneCSSGridItem,
   SceneCSSGridLayout,
   SceneFlexItem,
   SceneFlexItemLike,
@@ -39,6 +38,7 @@ import { StatusWrapper } from './StatusWrapper';
 import { BreakdownSearchScene, getLabelValue } from './BreakdownSearchScene';
 import { SortByScene, SortCriteriaChanged } from './SortByScene';
 import { getSortByPreference } from 'services/store';
+import { LazySceneCSSGridItem } from './LazySceneCSSGridItem';
 
 export interface FieldsBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -229,7 +229,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
           .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
           .setOverrides(setLeverColorOverrides);
       }
-      const gridItem = new SceneCSSGridItem({
+      const gridItem = new LazySceneCSSGridItem({
         body: body.build(),
       });
 
@@ -252,13 +252,11 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
       active: 'grid',
       layouts: [
         new SceneCSSGridLayout({
-          isLazy: true,
           templateColumns: GRID_TEMPLATE_COLUMNS,
           autoRows: '200px',
           children: children,
         }),
         new SceneCSSGridLayout({
-          isLazy: true,
           templateColumns: '1fr',
           autoRows: '200px',
           children: children.map((child) => child.clone()),

--- a/src/Components/ServiceScene/Breakdowns/LazyLoader.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LazyLoader.tsx
@@ -1,0 +1,83 @@
+import React, { ForwardRefExoticComponent, useImperativeHandle, useRef, useState } from 'react';
+import { useEffectOnce } from 'react-use';
+
+import { uniqueId } from 'lodash';
+
+export function useUniqueId(): string {
+  const idRefLazy = useRef<string | undefined>(undefined);
+  idRefLazy.current ??= uniqueId();
+  return idRefLazy.current;
+}
+
+export interface Props extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange' | 'children'> {
+  children: React.ReactNode | (({ isInView }: { isInView: boolean }) => React.ReactNode);
+  key: string;
+  isHidden?: boolean;
+  onLoad?: () => void;
+  onChange?: (isInView: boolean) => void;
+}
+
+export interface LazyLoaderType extends ForwardRefExoticComponent<Props> {
+  addCallback: (id: string, c: (e: IntersectionObserverEntry) => void) => void;
+  callbacks: Record<string, (e: IntersectionObserverEntry) => void>;
+  observer: IntersectionObserver;
+}
+
+export const LazyLoader: LazyLoaderType = React.forwardRef<HTMLDivElement, Props>(
+  ({ children, onLoad, onChange, isHidden, ...rest }, ref) => {
+    const id = useUniqueId();
+    const [loaded, setLoaded] = useState(false);
+    const [isInView, setIsInView] = useState(false);
+    const innerRef = useRef<HTMLDivElement>(null);
+
+    useImperativeHandle(ref, () => innerRef.current!);
+
+    useEffectOnce(() => {
+      LazyLoader.addCallback(id, (entry) => {
+        if (!loaded && entry.isIntersecting) {
+          setLoaded(true);
+          onLoad?.();
+        }
+
+        setIsInView(entry.isIntersecting);
+        onChange?.(entry.isIntersecting);
+      });
+
+      const wrapperEl = innerRef.current;
+
+      if (wrapperEl) {
+        LazyLoader.observer.observe(wrapperEl);
+      }
+
+      return () => {
+        delete LazyLoader.callbacks[id];
+        wrapperEl && LazyLoader.observer.unobserve(wrapperEl);
+        if (Object.keys(LazyLoader.callbacks).length === 0) {
+          LazyLoader.observer.disconnect();
+        }
+      };
+    });
+
+    if (isHidden) {
+      return null;
+    }
+
+    return (
+      <div id={id} ref={innerRef} {...rest}>
+        {loaded && (typeof children === 'function' ? children({ isInView }) : children)}
+      </div>
+    );
+  }
+) as LazyLoaderType;
+
+LazyLoader.displayName = 'LazyLoader';
+LazyLoader.callbacks = {} as Record<string, (e: IntersectionObserverEntry) => void>;
+LazyLoader.addCallback = (id: string, c: (e: IntersectionObserverEntry) => void) => (LazyLoader.callbacks[id] = c);
+LazyLoader.observer = new IntersectionObserver(
+  (entries) => {
+    for (const entry of entries) {
+      LazyLoader.callbacks[entry.target.id](entry);
+    }
+  },
+  { rootMargin: '100px' }
+);

--- a/src/Components/ServiceScene/Breakdowns/LazySceneCSSGridItem.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LazySceneCSSGridItem.tsx
@@ -1,0 +1,53 @@
+import React, { CSSProperties, useMemo } from 'react';
+import { SceneComponentProps, SceneCSSGridItem, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import { LazyLoader } from 'Components/ServiceScene/Breakdowns/LazyLoader';
+import { CSSObject, css } from '@emotion/css';
+
+export interface SceneCSSGridItemPlacement {
+  /**
+   * True when the item should rendered but not visible.
+   * Useful for conditional display of layout items
+   */
+  isHidden?: boolean;
+  /**
+   * Useful for making content span across multiple rows or columns
+   */
+  gridColumn?: CSSProperties['gridColumn'];
+  gridRow?: CSSProperties['gridRow'];
+}
+
+export interface SceneCSSGridItemState extends SceneCSSGridItemPlacement, SceneObjectState {
+  body: SceneObject | undefined;
+}
+interface SceneCSSGridItemRenderProps<T> extends SceneComponentProps<T> {
+  parentState?: SceneCSSGridItemPlacement;
+}
+
+export class LazySceneCSSGridItem extends SceneObjectBase<SceneCSSGridItemState> {
+  public static Component = ({ model, parentState }: SceneCSSGridItemRenderProps<SceneCSSGridItem>) => {
+    const { body, isHidden } = model.useState();
+    const style = useItemStyle(model.state);
+    if (!body || isHidden) {
+      return null;
+    }
+    return (
+      <LazyLoader isHidden={isHidden} key={model.state.key!} className={style}>
+        <SceneCSSGridItem.Component key={model.state.key} model={model} parentState={model.state} />
+      </LazyLoader>
+    );
+  };
+}
+
+function useItemStyle(state: SceneCSSGridItemState) {
+  return useMemo(() => {
+    const style: CSSObject = {};
+
+    style.gridColumn = state.gridColumn || 'unset';
+    style.gridRow = state.gridRow || 'unset';
+    // Needed for VizPanel
+    style.position = 'relative';
+    style.display = 'grid';
+
+    return css(style);
+  }, [state]);
+}


### PR DESCRIPTION
This will hide lazyloaded but hidden fields for now to prevent situations like https://play.grafana.org/a/grafana-lokiexplore-app/explore/service/tempo-distributor/fields?var-fields=&var-filters=service_name%7C%3D%7Ctempo-distributor&var-ds=ddhr3fttaw8aod&var-patterns=&var-lineFilter=&var-logsFormat=%20%7C%20logfmt&mode=service_details&urlColumns=%5B%5D&visualizationType=%22logs%22&var-labelBy=$__all&var-fieldBy=$__all&patterns=%5B%5D