### PR TITLE
fix(workflow): remove unsupported characters from workflow id

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           credentials_json: ${{ env.GCP_UPLOAD_ARTIFACTS_KEY }}
 
-      - id: 'move release to main'
+      - name: 'move release to main'
         run: mv ${{ steps.build-release.outputs.archive }} ${{ steps.metadata.outputs.archive }}
 
       - id: 'upload-to-gcs'


### PR DESCRIPTION
Yea, well. 
![image](https://github.com/grafana/explore-logs/assets/8092184/44c27507-9f65-4c1c-a390-5eec36bbc890)

"Alphanumeric" does not include spaces. Just moving from `id` to `name` now which is fine. Validated the workflow with the [actionlint playground.](https://rhysd.github.io/actionlint/)