### PR TITLE
fix(ds-selection): change precedence of selected datasources

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -62,7 +62,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
       $timeRange: state.$timeRange ?? new SceneTimeRange({}),
       $variables:
         state.$variables ??
-        getVariableSet('grafanacloud-logs' ?? getLastUsedDataSourceFromStorage(), state.initialFilters),
+        getVariableSet(getLastUsedDataSourceFromStorage() ?? 'grafanacloud-logs', state.initialFilters),
       controls: state.controls ?? [
         new VariableValueSelectors({ layout: 'vertical' }),
         new SceneControlsSpacer(),


### PR DESCRIPTION
This PR fixes the behavior that would always default to the `grafanacloud-logs` datasource and would never actually use the datasource saved in localstorage.