### PR TITLE
chore: use `package-plugin` action to not include release steps

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: grafana/plugin-actions/build-plugin@main
+      - uses: grafana/plugin-actions/package-plugin@d9fbd8428ec5e1e6914db1d16f3003089c29d6df
         id: build-release
         with:
           policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}


### PR DESCRIPTION
This uses the `package-plugin` action, that does not include creating a GitHub release, which currently breaks in our `release-main.yaml` workflow.