### PR TITLE
chore(release-main): use new `package-plugin` build action

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - svennergr/use-package-plugin-action
     paths-ignore: # Don't run the workflow if only .github/** or docs/** files have been changed
       - '.github/**'
       - 'docs/**'

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -5,9 +5,14 @@ on:
   push:
     branches:
       - main
+      - svennergr/use-package-plugin-action
     paths-ignore: # Don't run the workflow if only .github/** or docs/** files have been changed
       - '.github/**'
       - 'docs/**'
+
+permissions:
+  contents: 'read'
+  id-token: 'write'
 
 jobs:
   build-latest-version:
@@ -20,151 +25,34 @@ jobs:
       upload-folder: ${{ steps.metadata.outputs.upload-folder }}
 
     steps:
-      - uses: tibdex/github-app-token@v1
-        id: get_installation_token
-        with:
-          app_id: ${{ secrets.DB_FE_GITHUB_APP_ID }}
-          installation_id: ${{ secrets.DB_FE_GITHUB_APP_INSTALLATION_ID }}
-          private_key: ${{ secrets.DB_FE_GITHUB_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
+
+      - uses: grafana/plugin-actions/package-plugin@main
+        id: 'package-plugin'
         with:
-          # Latest release of 'main'
-          ref: 'main'
-          token: ${{ steps.get_installation_token.outputs.token }}
-          fetch-depth: 0
+          # see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token to generate it
+          # save the value in your repository secrets
+          policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
 
-      - name: Setup credentials to access Grafana private repositories
-        run: git config --global url.https://${{ steps.get_installation_token.outputs.token }}@github.com/.insteadOf https://github.com/
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
-          node-version: 20
-          cache: 'yarn'
-
-      - name: Setup Go environment
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.21'
-
-      - name: Install utilities
-        run: sudo apt-get install jq
-
-      - name: Restore npm cache
-        id: restore-npm-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            node_modules
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/yarn.lock', '!node_modules/**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-npm-
-
-      - name: Install dependencies on cache miss
-        run: yarn install --frozen-lockfile
-        if: steps.restore-npm-cache.outputs.cache-hit != 'true'
-
-      - name: Save npm cache
-        id: save-npm-cache
-        if: steps.restore-npm-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            node_modules
-          key: ${{ steps.restore-npm-cache.outputs.cache-primary-key }}
-
-      - name: Lint frontend
-        run: npm run lint
-
-      # - name: Test frontend
-      #   run: npm run test:ci
-
-      - name: bump package version
-        run: npm version --no-git-tag-version `npm version --json | jq -r '."grafana-lokiexplore-app"'`-`git rev-parse --short HEAD`
-
-      - name: Build frontend
-        run: npm run build
-
-      - name: Warn missing Grafana API key
-        run: |
-          echo Please generate a Grafana API key: https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/#generate-an-api-key
-          echo Once done please follow the instructions found here: https://github.com/${{github.repository}}/blob/main/README.md#using-github-actions-release-workflow
-        if: ${{ env.GRAFANA_API_KEY == '' }}
-
-      - name: Sign plugin
-        run: npm run sign
-        if: ${{ env.GRAFANA_API_KEY != '' }}
-
-      - name: Get plugin metadata
-        id: metadata
-        run: |
-          export GRAFANA_PLUGIN_ID=$(cat dist/plugin.json | jq -r .id)
-          export GRAFANA_PLUGIN_VERSION=$(cat dist/plugin.json | jq -r .info.version)
-          export GRAFANA_PLUGIN_TYPE=$(cat dist/plugin.json | jq -r .type)
-
-          export GRAFANA_PLUGIN_ARTIFACT_LATEST=${GRAFANA_PLUGIN_ID}-latest.zip
-
-          echo "plugin-id=${GRAFANA_PLUGIN_ID}" >> $GITHUB_OUTPUT
-          echo "plugin-version=${GRAFANA_PLUGIN_VERSION}" >> $GITHUB_OUTPUT
-          echo "plugin-type=${GRAFANA_PLUGIN_TYPE}" >> $GITHUB_OUTPUT
-          echo "archive-latest=${GRAFANA_PLUGIN_ARTIFACT_LATEST}" >> $GITHUB_OUTPUT
-          echo "upload-folder=__to-upload__" >> $GITHUB_OUTPUT
-
-      - name: Create latest zip
-        id: package-plugin
-        run: |
-          mv dist ${{ steps.metadata.outputs.plugin-id }}
-          zip ${{ steps.metadata.outputs.archive-latest }} ${{ steps.metadata.outputs.plugin-id }} -r
-
-          # move assets to upload folder for mass upload
-          mkdir ${{ steps.metadata.outputs.upload-folder }}
-          mv ${{ steps.metadata.outputs.archive-latest }} ${{ steps.metadata.outputs.upload-folder }}/
-
-      - name: Validate plugin
-        run: |
-          git clone https://github.com/grafana/plugin-validator
-          pushd ./plugin-validator/pkg/cmd/plugincheck2
-          go install
-          popd
-          plugincheck2 -config ./plugin-validator/config/default.yaml ${{ steps.metadata.outputs.upload-folder }}/${{ steps.metadata.outputs.archive-latest }}
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: upload-dir
-          path: ${{ steps.metadata.outputs.upload-folder }}
-
-  release-and-upload:
-    runs-on: ubuntu-latest
-    needs: ['build-latest-version']
-    steps:
-      - uses: tibdex/github-app-token@v1
-        id: get_installation_token
-        with:
-          app_id: ${{ secrets.DB_FE_GITHUB_APP_ID }}
-          installation_id: ${{ secrets.DB_FE_GITHUB_APP_INSTALLATION_ID }}
-          private_key: ${{ secrets.DB_FE_GITHUB_APP_PRIVATE_KEY }}
-
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ steps.get_installation_token.outputs.token }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: upload-dir
-          path: ${{ needs.build-latest-version.outputs.upload-folder }}
+          common_secrets: |
+            GCP_UPLOAD_ARTIFACTS_KEY=grafana/integration-artifacts-uploader-service-account:'credentials.json'
 
       - id: 'auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
-          credentials_json: '${{ secrets.GCP_DB_FE_CI_PRIVATE_KEY }}'
+          credentials_json: ${{ env.GCP_UPLOAD_ARTIFACTS_KEY }}
+
+      - name: 'rename versioned archive to main-archive'
+        run: mv ${{ steps.package-plugin.outputs.archive }} ${{ steps.package-plugin.outputs.plugin-id }}-main.zip
 
       - id: 'upload-to-gcs'
-        name: 'Upload assets'
+        name: 'Upload assets to latest'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
-          path: ./${{ needs.build-latest-version.outputs.upload-folder }}
-          destination: 'grafana-lokiexplore-app'
+          path: ./
+          destination: 'integration-artifacts/grafana-lokiexplore-app/'
+          glob: '*.zip'
           parent: false


### PR DESCRIPTION
This PR unifies our release approaches. As tried in https://github.com/grafana/explore-logs/pull/537, with this PR we get the following artefacts:

- Versioned release: https://storage.googleapis.com/integration-artifacts/grafana-lokiexplore-app/grafana-lokiexplore-app-0.0.13.zip
- Latest versioned release: https://storage.googleapis.com/integration-artifacts/grafana-lokiexplore-app/grafana-lokiexplore-app-latest.zip
- Latest main release: https://storage.googleapis.com/integration-artifacts/grafana-lokiexplore-app/grafana-lokiexplore-app-main.zip

This has been tested on this branch successfully: https://github.com/grafana/explore-logs/actions/runs/9887973044