### PR TITLE
Table: Remove link to log line feature

### DIFF
--- a/src/Components/Table/LineActionIcons.tsx
+++ b/src/Components/Table/LineActionIcons.tsx
@@ -48,7 +48,6 @@ export function LineActionIcons(props: { rowIndex: number; value: unknown }) {
   const theme = useTheme2();
   const styles = getStyles(theme);
   const { logsFrame } = useQueryContext();
-  // const logId = logsFrame?.idField?.values[props.rowIndex];
   const lineValue = logsFrame?.bodyField.values[props.rowIndex];
   const [isInspecting, setIsInspecting] = useState(false);
   return (

--- a/src/Components/Table/LineActionIcons.tsx
+++ b/src/Components/Table/LineActionIcons.tsx
@@ -2,10 +2,8 @@ import { ClipboardButton, IconButton, Modal, useTheme2 } from '@grafana/ui';
 import React, { useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
-import { SelectedTableRow } from 'Components/Table/LogLineCellComponent';
 import { useQueryContext } from 'Components/Table/Context/QueryContext';
 import { testIds } from '../../services/testIds';
-import { locationService } from '@grafana/runtime';
 
 export enum UrlParameterType {
   SelectedLine = 'selectedLine',
@@ -49,8 +47,8 @@ export const getStyles = (theme: GrafanaTheme2, bgColor?: string) => ({
 export function LineActionIcons(props: { rowIndex: number; value: unknown }) {
   const theme = useTheme2();
   const styles = getStyles(theme);
-  const { logsFrame, timeRange } = useQueryContext();
-  const logId = logsFrame?.idField?.values[props.rowIndex];
+  const { logsFrame } = useQueryContext();
+  // const logId = logsFrame?.idField?.values[props.rowIndex];
   const lineValue = logsFrame?.bodyField.values[props.rowIndex];
   const [isInspecting, setIsInspecting] = useState(false);
   return (
@@ -68,38 +66,6 @@ export function LineActionIcons(props: { rowIndex: number; value: unknown }) {
             name="eye"
             onClick={() => setIsInspecting(true)}
             tabIndex={0}
-          />
-        </div>
-        <div className={styles.inspect}>
-          <ClipboardButton
-            className={styles.clipboardButton}
-            icon="share-alt"
-            variant="secondary"
-            fill="text"
-            size="md"
-            tooltip="Copy link to log line"
-            tooltipPlacement="top"
-            tabIndex={0}
-            getText={() => {
-              const location = locationService.getLocation();
-              const searchParams = new URLSearchParams(location.search);
-              if (searchParams && timeRange) {
-                const selectedLine: SelectedTableRow = {
-                  row: props.rowIndex,
-                  id: logId,
-                };
-
-                searchParams.set(UrlParameterType.From, timeRange.from.toISOString());
-                searchParams.set(UrlParameterType.To, timeRange.to.toISOString());
-                searchParams.set(UrlParameterType.SelectedLine, JSON.stringify(selectedLine));
-
-                // @todo can encoding + as %20 break other stuff? Can label names or values have + in them that we don't want encoded? Should we just update values?
-                // + encoding for whitespace is for application/x-www-form-urlencoded, which appears to be the default encoding for URLSearchParams, replacing + with %20 to keep urls meant for the browser from breaking
-                const searchString = searchParams.toString().replace(/\+/g, '%20');
-                return window.location.origin + location.pathname + '?' + searchString;
-              }
-              return '';
-            }}
           />
         </div>
       </div>

--- a/src/Components/Table/LogsTableHeader.tsx
+++ b/src/Components/Table/LogsTableHeader.tsx
@@ -40,7 +40,7 @@ const getStyles = (theme: GrafanaTheme2, isFirstColumn: boolean, isLine: boolean
   }),
   wrapper: css({
     display: 'flex',
-    marginLeft: isFirstColumn ? '56px' : '6px',
+    marginLeft: isFirstColumn ? '30px' : '6px',
     // Body has extra padding then other columns
     width: isLine ? 'calc(100% + 6px)' : '100%',
 

--- a/src/Components/Table/Table.tsx
+++ b/src/Components/Table/Table.tsx
@@ -421,7 +421,7 @@ function getInitialFieldWidth(
   const maxWidth = numberOfFields <= 2 ? tableWidth : Math.min(tableWidth / 2);
 
   // First field gets icons, and a little extra width
-  const extraPadding = fieldIndex === 0 ? 50 : 0;
+  const extraPadding = fieldIndex === 0 ? 30 : 0;
 
   // Time fields have consistent widths
   if (field.type === FieldType.time) {


### PR DESCRIPTION
Removing the link to log line feature as it's a bit buggy right now.

Revert this out after https://github.com/grafana/explore-logs/pull/568 and the scrollTo bug are fixed.