### PR TITLE
Sorting: update options and add alphabetical order

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -147,6 +147,9 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
   }
 
   private handleSortByChange = (event: SortCriteriaChanged) => {
+    if (event.target !== 'fields') {
+      return;
+    }
     if (this.state.body instanceof LayoutSwitcher) {
       this.state.body.state.layouts.forEach((layout) => {
         if (layout instanceof ByFrameRepeater) {

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -105,6 +105,9 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
   }
 
   private handleSortByChange = (event: SortCriteriaChanged) => {
+    if (event.target !== 'labels') {
+      return;
+    }
     if (this.state.body instanceof LayoutSwitcher) {
       this.state.body.state.layouts.forEach((layout) => {
         if (layout instanceof ByFrameRepeater) {

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.test.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.test.tsx
@@ -35,7 +35,7 @@ describe('SortByScene', () => {
 
     await waitFor(() => select(screen.getByLabelText('Sort by'), 'Highest spike', { container: document.body }));
 
-    expect(eventSpy).toHaveBeenCalledWith(new SortCriteriaChanged('max', 'desc'), true);
+    expect(eventSpy).toHaveBeenCalledWith(new SortCriteriaChanged('fields', 'max', 'desc'), true);
   });
 
   test('Reports criteria changes', async () => {
@@ -45,6 +45,6 @@ describe('SortByScene', () => {
 
     await waitFor(() => select(screen.getByLabelText('Sort direction'), 'Asc', { container: document.body }));
 
-    expect(eventSpy).toHaveBeenCalledWith(new SortCriteriaChanged('changepoint', 'asc'), true);
+    expect(eventSpy).toHaveBeenCalledWith(new SortCriteriaChanged('fields', 'changepoint', 'asc'), true);
   });
 });

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.test.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.test.tsx
@@ -19,12 +19,12 @@ describe('SortByScene', () => {
   });
 
   test('Retrieves stored sorting preferences', () => {
-    setSortByPreference('fields', 'diff', 'asc');
+    setSortByPreference('fields', 'alphabetical', 'asc');
 
     scene = new SortByScene({ target: 'fields' });
     render(<scene.Component model={scene} />);
 
-    expect(screen.getByText('Difference')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText('Asc')).toBeInTheDocument();
   });
 
@@ -33,9 +33,9 @@ describe('SortByScene', () => {
 
     render(<scene.Component model={scene} />);
 
-    await waitFor(() => select(screen.getByLabelText('Sort by'), 'Last', { container: document.body }));
+    await waitFor(() => select(screen.getByLabelText('Sort by'), 'Highest spike', { container: document.body }));
 
-    expect(eventSpy).toHaveBeenCalledWith(new SortCriteriaChanged('last', 'desc'), true);
+    expect(eventSpy).toHaveBeenCalledWith(new SortCriteriaChanged('max', 'desc'), true);
   });
 
   test('Reports criteria changes', async () => {

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -26,12 +26,12 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
         {
           value: 'changepoint',
           label: 'Most relevant',
-          description: 'Smart ordering of graphs based on the data',
+          description: 'Smart ordering of graphs based on the most significant spikes in the data',
         },
         {
           value: ReducerID.stdDev,
           label: 'Widest spread',
-          description: 'Prioritize graphs that have changed the most',
+          description: 'Prioritize graphs that have changed the most (standard deviation)',
         },
         {
           value: 'alphabetical',

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -41,12 +41,12 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
         {
           value: ReducerID.max,
           label: 'Highest spike',
-          description: 'Show graphs with the highest values first (max)',
+          description: 'Sort graphs by the highest values (max)',
         },
         {
           value: ReducerID.min,
           label: 'Lowest dip',
-          description: 'Show graphs with the smallest values first (min)',
+          description: 'Sort graphs by the smallest values (min)',
         },
       ],
     },

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -31,7 +31,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
         {
           value: ReducerID.stdDev,
           label: 'Widest spread',
-          description: 'Sort graphs by deviation from the average value (standard deviation)',
+          description: 'Sort graphs by deviation from the average value',
         },
         {
           value: 'alphabetical',

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -12,7 +12,7 @@ export interface SortBySceneState extends SceneObjectState {
 }
 
 export class SortCriteriaChanged extends BusEventBase {
-  constructor(public sortBy: string, public direction: string) {
+  constructor(public target: 'fields' | 'labels', public sortBy: string, public direction: string) {
     super();
   }
   public static type = 'sort-criteria-changed';
@@ -71,7 +71,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
     }
     this.setState({ sortBy: criteria.value });
     setSortByPreference(this.state.target, criteria.value, this.state.direction);
-    this.publishEvent(new SortCriteriaChanged(criteria.value, this.state.direction), true);
+    this.publishEvent(new SortCriteriaChanged(this.state.target, criteria.value, this.state.direction), true);
   };
 
   public onDirectionChange = (direction: SelectableValue<string>) => {
@@ -80,7 +80,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
     }
     this.setState({ direction: direction.value });
     setSortByPreference(this.state.target, this.state.sortBy, direction.value);
-    this.publishEvent(new SortCriteriaChanged(this.state.sortBy, direction.value), true);
+    this.publishEvent(new SortCriteriaChanged(this.state.target, this.state.sortBy, direction.value), true);
   };
 
   public static Component = ({ model }: SceneComponentProps<SortByScene>) => {

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -27,8 +27,23 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
     },
     {
       value: ReducerID.stdDev,
-      label: 'Dispersion',
-      description: 'Standard deviation of all values in a field',
+      label: 'Widest spread',
+      description: 'Prioritize graphs that have changed the most',
+    },
+    {
+      value: 'alphabetical',
+      label: 'Name',
+      description: 'Alphabetical order',
+    },
+    {
+      value: ReducerID.max,
+      label: 'Highest spike',
+      description: 'Show graphs with the highest values first (max)',
+    },
+    {
+      value: ReducerID.min,
+      label: 'Lowest dip',
+      description: 'Show graphs with the smallest values first (min)',
     },
     ...fieldReducers.selectOptions([], filterReducerOptions).options,
   ];
@@ -105,17 +120,10 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
 
 const ENABLED_PERCENTILES = ['p1', 'p10', 'p25', 'p50', 'p75', 'p90', 'p99'];
 function filterReducerOptions(ext: FieldReducerInfo) {
-  if (ext.id === ReducerID.stdDev) {
-    return false;
-  }
   if (ext.id >= 'p1' && ext.id <= 'p99') {
     return ENABLED_PERCENTILES.includes(ext.id);
   }
-  // Do not offer all* reducers
-  if (ext.id.startsWith('all') || ext.description?.startsWith('All') || ext.name.includes('*')) {
-    return false;
-  }
-  return true;
+  return false;
 }
 
 export function getLabelValue(frame: DataFrame) {

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -31,7 +31,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
         {
           value: ReducerID.stdDev,
           label: 'Widest spread',
-          description: 'Prioritize graphs that have changed the most (standard deviation)',
+          description: 'Sort graphs by deviation from the average value (standard deviation)',
         },
         {
           value: 'alphabetical',

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -21,31 +21,39 @@ export class SortCriteriaChanged extends BusEventBase {
 export class SortByScene extends SceneObjectBase<SortBySceneState> {
   public sortingOptions = [
     {
-      value: 'changepoint',
-      label: 'Most relevant',
-      description: 'Smart ordering of graphs based on the data',
+      label: '',
+      options: [
+        {
+          value: 'changepoint',
+          label: 'Most relevant',
+          description: 'Smart ordering of graphs based on the data',
+        },
+        {
+          value: ReducerID.stdDev,
+          label: 'Widest spread',
+          description: 'Prioritize graphs that have changed the most',
+        },
+        {
+          value: 'alphabetical',
+          label: 'Name',
+          description: 'Alphabetical order',
+        },
+        {
+          value: ReducerID.max,
+          label: 'Highest spike',
+          description: 'Show graphs with the highest values first (max)',
+        },
+        {
+          value: ReducerID.min,
+          label: 'Lowest dip',
+          description: 'Show graphs with the smallest values first (min)',
+        },
+      ],
     },
     {
-      value: ReducerID.stdDev,
-      label: 'Widest spread',
-      description: 'Prioritize graphs that have changed the most',
+      label: 'Percentiles',
+      options: [...fieldReducers.selectOptions([], filterReducerOptions).options],
     },
-    {
-      value: 'alphabetical',
-      label: 'Name',
-      description: 'Alphabetical order',
-    },
-    {
-      value: ReducerID.max,
-      label: 'Highest spike',
-      description: 'Show graphs with the highest values first (max)',
-    },
-    {
-      value: ReducerID.min,
-      label: 'Lowest dip',
-      description: 'Show graphs with the smallest values first (min)',
-    },
-    ...fieldReducers.selectOptions([], filterReducerOptions).options,
   ];
 
   constructor(state: Pick<SortBySceneState, 'target'>) {
@@ -77,7 +85,8 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
 
   public static Component = ({ model }: SceneComponentProps<SortByScene>) => {
     const { sortBy, direction } = model.useState();
-    const value = model.sortingOptions.find(({ value }) => value === sortBy);
+    const group = model.sortingOptions.find((group) => group.options.find((option) => option.value === sortBy));
+    const value = group?.options.find((option) => option.value === sortBy);
     return (
       <>
         <InlineField>
@@ -105,7 +114,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
         >
           <Select
             value={value}
-            width={18}
+            width={20}
             isSearchable={true}
             options={model.sortingOptions}
             placeholder={'Choose criteria'}
@@ -118,7 +127,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
   };
 }
 
-const ENABLED_PERCENTILES = ['p1', 'p10', 'p25', 'p50', 'p75', 'p90', 'p99'];
+const ENABLED_PERCENTILES = ['p10', 'p25', 'p75', 'p90', 'p99'];
 function filterReducerOptions(ext: FieldReducerInfo) {
   if (ext.id >= 'p1' && ext.id <= 'p99') {
     return ENABLED_PERCENTILES.includes(ext.id);

--- a/src/services/sorting.test.ts
+++ b/src/services/sorting.test.ts
@@ -8,6 +8,9 @@ const frameA = toDataFrame({
       name: 'Value',
       type: FieldType.number,
       values: [0, 1, 0],
+      labels: {
+        test: 'C',
+      },
     },
   ],
 });
@@ -18,6 +21,9 @@ const frameB = toDataFrame({
       name: 'Value',
       type: FieldType.number,
       values: [1, 1, 1],
+      labels: {
+        test: 'A',
+      },
     },
   ],
 });
@@ -28,6 +34,9 @@ const frameC = toDataFrame({
       name: 'Value',
       type: FieldType.number,
       values: [100, 9999, 100],
+      labels: {
+        test: 'B',
+      },
     },
   ],
 });
@@ -45,6 +54,20 @@ describe('sortSeries', () => {
     const sortedSeries = [frameB, frameA, frameC];
 
     const result = sortSeries(series, ReducerID.stdDev, 'asc');
+    expect(result).toEqual(sortedSeries);
+  });
+  test('Sorts series alphabetically, ascending', () => {
+    const series = [frameA, frameB, frameC];
+    const sortedSeries = [frameB, frameC, frameA];
+
+    const result = sortSeries(series, 'alphabetical', 'asc');
+    expect(result).toEqual(sortedSeries);
+  });
+  test('Sorts series alphabetically, ascending', () => {
+    const series = [frameA, frameB, frameC];
+    const sortedSeries = [frameA, frameC, frameB];
+
+    const result = sortSeries(series, 'alphabetical', 'desc');
     expect(result).toEqual(sortedSeries);
   });
 });

--- a/src/services/sorting.ts
+++ b/src/services/sorting.ts
@@ -1,7 +1,12 @@
 import { ChangepointDetector } from '@bsull/augurs';
 import { DataFrame, FieldType, doStandardCalcs, fieldReducers } from '@grafana/data';
+import { getLabelValueFromDataFrame } from './levels';
 
 export const sortSeries = (series: DataFrame[], sortBy: string, direction: string) => {
+  if (sortBy === 'alphabetical') {
+    return sortSeriesByName(series, direction);
+  }
+
   const reducer = (dataFrame: DataFrame) => {
     if (sortBy === 'changepoint') {
       return calculateDataFrameChangepoints(dataFrame);
@@ -48,4 +53,20 @@ export const calculateDataFrameChangepoints = (data: DataFrame) => {
   const points = ChangepointDetector.defaultArgpcp().detectChangepoints(values);
 
   return points.indices.length;
+};
+
+export const sortSeriesByName = (series: DataFrame[], direction: string) => {
+  const sortedSeries = [...series];
+  sortedSeries.sort((a, b) => {
+    const valueA = getLabelValueFromDataFrame(a);
+    const valueB = getLabelValueFromDataFrame(b);
+    if (!valueA || !valueB) {
+      return 0;
+    }
+    return valueA?.localeCompare(valueB) ?? 0;
+  });
+  if (direction === 'desc') {
+    sortedSeries.reverse();
+  }
+  return sortedSeries;
 };


### PR DESCRIPTION
Closes https://github.com/grafana/explore-logs/issues/574

- Made select input wider
- Added a "target" for the sorting event (so we know if we sorted fields or labels)
- Updated sorting options and descriptions

Available options:

**Most relevant**: Smart ordering of graphs based on the most significant spikes in the data
**Widest spread**: Sort graphs by deviation from the average value
**Name**: Alphabetical order
**Highest spike**: Show graphs with the highest values first (max)
**Lowest dip**: Show graphs with the smallest values first (min)
**10th %**: 10th percentile value
**25th %**: 25th percentile value
**75th %**: 75th percentile value
**90th %**: 90th percentile value
**99th %**: 99th percentile value

![2024-07-12 11 58 23](https://github.com/user-attachments/assets/7e7fb3a5-fa58-4435-a830-75c22050c7bb)
