### PR TITLE
feat(pattern-tokens): add better visibility to pattern tokens

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
@@ -112,7 +112,6 @@ function getStyles(theme: GrafanaTheme2) {
 
       '&:hover': {
         textDecoration: 'underline',
-        // somehow this needs 3px when hovered
         textUnderlineOffset: '3px',
         backgroundColor: theme.colors.emphasize(theme.colors.background.primary, 0.2),
       },

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
@@ -108,13 +108,13 @@ function getStyles(theme: GrafanaTheme2) {
     pattern: css({
       cursor: 'pointer',
       textDecoration: 'underline dotted',
-      'text-underline-offset': '2px',
+      textUnderlineOffset: '2px',
       backgroundColor: theme.colors.emphasize(theme.colors.background.primary, 0.1),
 
       '&:hover': {
         textDecoration: 'underline',
         // somehow this needs 3px when hovered
-        'text-underline-offset': '3px',
+        textUnderlineOffset: '3px',
         backgroundColor: theme.colors.emphasize(theme.colors.background.primary, 0.2),
       },
     }),

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
@@ -111,8 +111,6 @@ function getStyles(theme: GrafanaTheme2) {
       margin: '0 2px',
 
       '&:hover': {
-        textDecoration: 'underline',
-        textUnderlineOffset: '3px',
         backgroundColor: theme.colors.emphasize(theme.colors.background.primary, 0.2),
       },
     }),

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
@@ -1,13 +1,14 @@
 import React, { useMemo, useRef, useState } from 'react';
 import { AdHocFiltersVariable, sceneGraph } from '@grafana/scenes';
-import { Spinner, Toggletip } from '@grafana/ui';
+import { Spinner, Toggletip, useStyles2 } from '@grafana/ui';
 import { getLokiDatasource } from 'services/scenes';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
 import { VAR_LABELS } from 'services/variables';
 import { buildLokiQuery } from 'services/query';
 import { PatternFieldLabelStats } from './PatternFieldLabelStats';
-import { LoadingState, LogLabelStatsModel, TimeRange } from '@grafana/data';
+import { GrafanaTheme2, LoadingState, LogLabelStatsModel, TimeRange } from '@grafana/data';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
+import { css } from '@emotion/css';
 
 interface PatternNameLabelProps {
   exploration: IndexScene;
@@ -20,6 +21,7 @@ export const PatternNameLabel = ({ exploration, pattern }: PatternNameLabelProps
   const patternIndices = extractPatternIndices(pattern);
   const [stats, setStats] = useState<LogLabelStatsModel[][] | undefined>(undefined);
   const [statsError, setStatsError] = useState(false);
+  const styles = useStyles2(getStyles);
 
   // Refs to store the previous values of query and timeRange
   const previousQueryRef = useRef<string | null>(null);
@@ -92,7 +94,7 @@ export const PatternNameLabel = ({ exploration, pattern }: PatternNameLabelProps
                 </>
               }
             >
-              <span style={{ cursor: 'pointer', textDecoration: 'underline dotted' }}>&lt;_&gt;</span>
+              <span className={styles.pattern}>&lt;_&gt;</span>
             </Toggletip>
           )}
         </span>
@@ -100,6 +102,24 @@ export const PatternNameLabel = ({ exploration, pattern }: PatternNameLabelProps
     </div>
   );
 };
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    pattern: css({
+      cursor: 'pointer',
+      textDecoration: 'underline dotted',
+      'text-underline-offset': '2px',
+      backgroundColor: theme.colors.emphasize(theme.colors.background.primary, 0.1),
+
+      '&:hover': {
+        textDecoration: 'underline',
+        // somehow this needs 3px when hovered
+        'text-underline-offset': '3px',
+        backgroundColor: theme.colors.emphasize(theme.colors.background.primary, 0.2),
+      },
+    }),
+  };
+}
 
 // Convert the result to statistics data structure
 function convertResultToStats(result: any, fieldCount: number): LogLabelStatsModel[][] {

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
@@ -107,9 +107,8 @@ function getStyles(theme: GrafanaTheme2) {
   return {
     pattern: css({
       cursor: 'pointer',
-      textDecoration: 'underline dotted',
-      textUnderlineOffset: '2px',
       backgroundColor: theme.colors.emphasize(theme.colors.background.primary, 0.1),
+      margin: '0 2px',
 
       '&:hover': {
         textDecoration: 'underline',


### PR DESCRIPTION
Especially when there are a lot of patterns and a lot of tokens, the dotted underline is not enough to find those tokens. This PR adds a different background colour to those tokens, and emphasises that on hover.

![image](https://github.com/user-attachments/assets/e906968d-fd8f-4b48-99ef-4eb465d09327)


On hover:
![image](https://github.com/user-attachments/assets/dc1ff5d6-ba4d-41f9-844f-4acfb5b3dc80)
