### PR TITLE
chore: include sorting preference in breakdown tracking

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -338,6 +338,9 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     }
 
     const variable = this.getVariable();
+    variable.changeValueTo(value);
+
+    const { sortBy, direction } = getSortByPreference('fields', ReducerID.stdDev, 'desc');
     reportAppInteraction(
       USER_EVENTS_PAGES.service_details,
       USER_EVENTS_ACTIONS.service_details.select_field_in_breakdown_clicked,
@@ -345,10 +348,10 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
         field: value,
         previousField: variable.getValueText(),
         view: 'fields',
+        sortBy,
+        sortByDirection: direction,
       }
     );
-
-    variable.changeValueTo(value);
   };
 
   public static Component = ({ model }: SceneComponentProps<FieldsBreakdownScene>) => {

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -186,6 +186,8 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     }
 
     const variable = this.getVariable();
+    variable.changeValueTo(value);
+
     const { sortBy, direction } = getSortByPreference('labels', ReducerID.stdDev, 'desc');
     reportAppInteraction(
       USER_EVENTS_PAGES.service_details,
@@ -198,8 +200,6 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
         sortByDirection: direction,
       }
     );
-
-    variable.changeValueTo(value);
   };
 
   public static Component = ({ model }: SceneComponentProps<LabelBreakdownScene>) => {

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -186,6 +186,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     }
 
     const variable = this.getVariable();
+    const { sortBy, direction } = getSortByPreference('labels', ReducerID.stdDev, 'desc');
     reportAppInteraction(
       USER_EVENTS_PAGES.service_details,
       USER_EVENTS_ACTIONS.service_details.select_field_in_breakdown_clicked,
@@ -193,6 +194,8 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
         label: value,
         previousLabel: variable.getValueText(),
         view: 'labels',
+        sortBy,
+        sortByDirection: direction,
       }
     );
 


### PR DESCRIPTION
Quick addition to track sorting preferences, and not only changes to sorting preferences. The idea is to have a sense of that sorting preferences and direction users keep.