### PR TITLE
Sorting: check for wasm support or use stdDev

### DIFF
--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -58,5 +58,7 @@ export const USER_EVENTS_ACTIONS = {
     logs_popover_line_filter: 'logs_popover_line_filter',
     // Value breakdown sort change
     value_breakdown_sort_change: 'value_breakdown_sort_change',
+    // Wasm not supported
+    wasm_not_supported: 'wasm_not_supported',
   },
 } as const;

--- a/src/services/sorting.ts
+++ b/src/services/sorting.ts
@@ -1,5 +1,5 @@
 import { ChangepointDetector } from '@bsull/augurs';
-import { DataFrame, FieldType, doStandardCalcs, fieldReducers } from '@grafana/data';
+import { DataFrame, FieldType, ReducerID, doStandardCalcs, fieldReducers } from '@grafana/data';
 import { getLabelValueFromDataFrame } from './levels';
 
 export const sortSeries = (series: DataFrame[], sortBy: string, direction: string) => {
@@ -9,7 +9,12 @@ export const sortSeries = (series: DataFrame[], sortBy: string, direction: strin
 
   const reducer = (dataFrame: DataFrame) => {
     if (sortBy === 'changepoint') {
-      return calculateDataFrameChangepoints(dataFrame);
+      if (wasmSupported()) {
+        return calculateDataFrameChangepoints(dataFrame);
+      } else {
+        console.warn('Changepoint not supported, using stdDev');
+        sortBy = ReducerID.stdDev;
+      }
     }
     const fieldReducer = fieldReducers.get(sortBy);
     const value =
@@ -69,4 +74,8 @@ export const sortSeriesByName = (series: DataFrame[], direction: string) => {
     sortedSeries.reverse();
   }
   return sortedSeries;
+};
+
+const wasmSupported = () => {
+  return typeof WebAssembly === 'object';
 };

--- a/src/services/sorting.ts
+++ b/src/services/sorting.ts
@@ -1,6 +1,7 @@
 import { ChangepointDetector } from '@bsull/augurs';
 import { DataFrame, FieldType, ReducerID, doStandardCalcs, fieldReducers } from '@grafana/data';
 import { getLabelValueFromDataFrame } from './levels';
+import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from './analytics';
 
 export const sortSeries = (series: DataFrame[], sortBy: string, direction: string) => {
   if (sortBy === 'alphabetical') {
@@ -13,6 +14,7 @@ export const sortSeries = (series: DataFrame[], sortBy: string, direction: strin
         return calculateDataFrameChangepoints(dataFrame);
       } else {
         console.warn('Changepoint not supported, using stdDev');
+        reportAppInteraction(USER_EVENTS_PAGES.service_details, USER_EVENTS_ACTIONS.service_details.wasm_not_supported);
         sortBy = ReducerID.stdDev;
       }
     }


### PR DESCRIPTION
Wasm may or may not be supported by the browser. When that happens, fall back to stdDev.

![imagen](https://github.com/user-attachments/assets/4a901419-1deb-4a12-a5d5-75e7e6b49bac)
