### PR TITLE
no need to say it's documentation

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -41,7 +41,7 @@ cards:
 Explore Logs is currently in [public preview](/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
 {{< /admonition >}}
 
-# Explore Logs documentation
+# Explore Logs
 
 ![A new way to look at your logs](images/explore-logs-hero-banner.png)
 ![Screenshot of Explore Logs landing page](images/explore-logs-features.jpeg)

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,9 +1,9 @@
 ---
-title: Explore Logs
-description: Documentation for Explore Logs
+title: Explore Logs (Public preview)
+description: Documentation for Explore Logs (Public preview)
 weight: 100
 hero:
-  title: Explore Logs
+  title: Explore Logs (Public preview)
   level: 1
   width: 100
   height: 100


### PR DESCRIPTION
we say 'Explore Logs documentation' but it's obvious it's documentation.