### PR TITLE
Value breakdowns: maintain filters between value changes

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/BreakdownSearchScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/BreakdownSearchScene.tsx
@@ -14,7 +14,6 @@ export class BreakdownSearchScene extends SceneObjectBase<BreakdownSearchSceneSt
     super({
       filter: '',
     });
-    console.log('new search');
   }
 
   public static Component = ({ model }: SceneComponentProps<BreakdownSearchScene>) => {

--- a/src/Components/ServiceScene/Breakdowns/BreakdownSearchScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/BreakdownSearchScene.tsx
@@ -47,6 +47,11 @@ export class BreakdownSearchScene extends SceneObjectBase<BreakdownSearchSceneSt
     this.filterValues('');
   };
 
+  public reset = () => {
+    this.setState({ filter: '' });
+    recentFilters[this.cacheKey] = '';
+  };
+
   private filterValues(filter: string) {
     if (this.parent instanceof LabelBreakdownScene || this.parent instanceof FieldsBreakdownScene) {
       recentFilters[this.cacheKey] = filter;

--- a/src/Components/ServiceScene/Breakdowns/BreakdownSearchScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/BreakdownSearchScene.tsx
@@ -14,11 +14,15 @@ export interface BreakdownSearchSceneState extends SceneObjectState {
   filter?: string;
 }
 
+const recentFilters: Record<string, string> = {};
+
 export class BreakdownSearchScene extends SceneObjectBase<BreakdownSearchSceneState> {
-  constructor() {
+  private cacheKey: string;
+  constructor(cacheKey: string) {
     super({
-      filter: '',
+      filter: recentFilters[cacheKey] ?? '',
     });
+    this.cacheKey = cacheKey;
   }
 
   public static Component = ({ model }: SceneComponentProps<BreakdownSearchScene>) => {
@@ -45,6 +49,7 @@ export class BreakdownSearchScene extends SceneObjectBase<BreakdownSearchSceneSt
 
   private filterValues(filter: string) {
     if (this.parent instanceof LabelBreakdownScene || this.parent instanceof FieldsBreakdownScene) {
+      recentFilters[this.cacheKey] = filter;
       const body = this.parent.state.body;
       body?.forEachChild((child) => {
         if (child instanceof ByFrameRepeater && child.state.body.isActive) {

--- a/src/Components/ServiceScene/Breakdowns/BreakdownSearchScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/BreakdownSearchScene.tsx
@@ -4,6 +4,11 @@ import { ByFrameRepeater } from './ByFrameRepeater';
 import { SearchInput } from './SearchInput';
 import { LabelBreakdownScene } from './LabelBreakdownScene';
 import { FieldsBreakdownScene } from './FieldsBreakdownScene';
+import { BusEventBase } from '@grafana/data';
+
+export class BreakdownSearchReset extends BusEventBase {
+  public static type = 'breakdown-search-reset';
+}
 
 export interface BreakdownSearchSceneState extends SceneObjectState {
   filter?: string;

--- a/src/Components/ServiceScene/Breakdowns/BreakdownSearchScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/BreakdownSearchScene.tsx
@@ -1,12 +1,9 @@
 import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import React, { ChangeEvent } from 'react';
 import { ByFrameRepeater } from './ByFrameRepeater';
-import { DataFrame } from '@grafana/data';
 import { SearchInput } from './SearchInput';
 import { LabelBreakdownScene } from './LabelBreakdownScene';
 import { FieldsBreakdownScene } from './FieldsBreakdownScene';
-import { fuzzySearch } from '../../../services/search';
-import { getLabelValueFromDataFrame } from 'services/levels';
 
 export interface BreakdownSearchSceneState extends SceneObjectState {
   filter?: string;
@@ -17,6 +14,7 @@ export class BreakdownSearchScene extends SceneObjectBase<BreakdownSearchSceneSt
     super({
       filter: '',
     });
+    console.log('new search');
   }
 
   public static Component = ({ model }: SceneComponentProps<BreakdownSearchScene>) => {
@@ -46,30 +44,9 @@ export class BreakdownSearchScene extends SceneObjectBase<BreakdownSearchSceneSt
       const body = this.parent.state.body;
       body?.forEachChild((child) => {
         if (child instanceof ByFrameRepeater && child.state.body.isActive) {
-          let haystack: string[] = [];
-
-          child.iterateFrames((frames, seriesIndex) => {
-            const labelValue = getLabelValue(frames[seriesIndex]);
-            haystack.push(labelValue);
-          });
-          fuzzySearch(haystack, filter, (data) => {
-            if (data && data[0]) {
-              // We got search results
-              child.filterFrames((frame: DataFrame) => {
-                const label = getLabelValue(frame);
-                return data[0].includes(label);
-              });
-            } else {
-              // reset search
-              child.filterFrames(() => true);
-            }
-          });
+          child.filterByString(filter);
         }
       });
     }
   }
-}
-
-export function getLabelValue(frame: DataFrame) {
-  return getLabelValueFromDataFrame(frame) ?? 'No labels';
 }

--- a/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
@@ -9,10 +9,14 @@ import {
   SceneComponentProps,
   SceneByFrameRepeater,
   SceneLayout,
+  SceneFlexLayout,
+  SceneReactObject,
 } from '@grafana/scenes';
 import { sortSeries } from 'services/sorting';
 import { fuzzySearch } from '../../../services/search';
 import { getLabelValue } from './SortByScene';
+import { Alert } from '@grafana/ui';
+import { css } from '@emotion/css';
 
 interface ByFrameRepeaterState extends SceneObjectState {
   body: SceneLayout;
@@ -105,6 +109,7 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
   };
 
   filterByString = (filter: string) => {
+    this.filter = filter;
     let haystack: string[] = [];
 
     this.iterateFrames((frames, seriesIndex) => {
@@ -133,7 +138,11 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
       }
     });
 
-    this.state.body.setState({ children: newChildren });
+    if (newChildren.length === 0) {
+      this.state.body.setState({ children: [buildNoResultsScene(this.filter)] });
+    } else {
+      this.state.body.setState({ children: newChildren });
+    }
   };
 
   public static Component = ({ model }: SceneComponentProps<SceneByFrameRepeater>) => {
@@ -141,3 +150,28 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     return <body.Component model={body} />;
   };
 }
+
+function buildNoResultsScene(filter: string) {
+  return new SceneFlexLayout({
+    direction: 'row',
+    children: [
+      new SceneFlexItem({
+        body: new SceneReactObject({
+          reactNode: (
+            <div>
+              <Alert title="" severity="info" className={styles.noResultsAlert}>
+                <p>No values found matching &ldquo;{filter}&rdquo;.</p>
+              </Alert>
+            </div>
+          ),
+        }),
+      }),
+    ],
+  });
+}
+
+const styles = {
+  noResultsAlert: css({
+    minWidth: '50vw',
+  }),
+};

--- a/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
@@ -32,18 +32,18 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
   private sortBy: string;
   private direction: string;
   private sortedSeries: DataFrame[] = [];
-  private filter: string;
+  private getFilter: () => string;
   public constructor({
     sortBy,
     direction,
-    filter = '',
+    getFilter,
     ...state
-  }: ByFrameRepeaterState & { sortBy: string; direction: string; filter: string }) {
+  }: ByFrameRepeaterState & { sortBy: string; direction: string; getFilter: () => string }) {
     super(state);
 
     this.sortBy = sortBy;
     this.direction = direction;
-    this.filter = filter;
+    this.getFilter = getFilter;
 
     this.addActivationHandler(() => {
       const data = sceneGraph.getData(this);
@@ -83,9 +83,9 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     this.sortedSeries = sortedSeries;
     this.unfilteredChildren = newChildren;
 
-    if (this.filter) {
+    if (this.getFilter()) {
       this.state.body.setState({ children: [] });
-      this.filterByString(this.filter);
+      this.filterByString(this.getFilter());
     } else {
       this.state.body.setState({ children: newChildren });
     }
@@ -102,7 +102,6 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
   };
 
   filterByString = (filter: string) => {
-    this.filter = filter;
     let haystack: string[] = [];
 
     this.iterateFrames((frames, seriesIndex) => {
@@ -132,7 +131,7 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     });
 
     if (newChildren.length === 0) {
-      this.state.body.setState({ children: [buildNoResultsScene(this.filter, this.clearFilter)] });
+      this.state.body.setState({ children: [buildNoResultsScene(this.getFilter(), this.clearFilter)] });
     } else {
       this.state.body.setState({ children: newChildren });
     }

--- a/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
@@ -51,13 +51,13 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
       this._subs.add(
         data.subscribeToState((data) => {
           if (data.data?.state === LoadingState.Done) {
-            this.performRepeat(data.data, 'sub');
+            this.performRepeat(data.data);
           }
         })
       );
 
       if (data.state.data) {
-        this.performRepeat(data.state.data, 'data');
+        this.performRepeat(data.state.data);
       }
     });
   }
@@ -67,12 +67,11 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     this.sortBy = sortBy;
     this.direction = direction;
     if (data.state.data) {
-      this.performRepeat(data.state.data, 'sort');
+      this.performRepeat(data.state.data);
     }
   };
 
-  private performRepeat(data: PanelData, source = 'unknown') {
-    console.log('performRepeat', source);
+  private performRepeat(data: PanelData) {
     const newChildren: SceneFlexItem[] = [];
     const sortedSeries = sortSeries(data.series, this.sortBy, this.direction);
 
@@ -103,7 +102,6 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
   };
 
   filterByString = (filter: string) => {
-    console.log('filterByString');
     this.filter = filter;
     let haystack: string[] = [];
 
@@ -126,7 +124,6 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
   };
 
   public filterFrames = (filterFn: FrameFilterCallback) => {
-    console.log('filterFrames');
     const newChildren: SceneFlexItem[] = [];
     this.iterateFrames((frames, seriesIndex) => {
       if (filterFn(frames[seriesIndex])) {

--- a/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
@@ -158,9 +158,9 @@ function buildNoResultsScene(filter: string) {
       new SceneFlexItem({
         body: new SceneReactObject({
           reactNode: (
-            <div>
+            <div className={styles.alertContainer}>
               <Alert title="" severity="info" className={styles.noResultsAlert}>
-                <p>No values found matching &ldquo;{filter}&rdquo;.</p>
+                No values found matching &ldquo;{filter}&rdquo;
               </Alert>
             </div>
           ),
@@ -171,7 +171,14 @@ function buildNoResultsScene(filter: string) {
 }
 
 const styles = {
+  alertContainer: css({
+    flexGrow: 1,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  }),
   noResultsAlert: css({
-    minWidth: '50vw',
+    minWidth: '30vw',
+    flexGrow: 0,
   }),
 };

--- a/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
@@ -64,12 +64,6 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
 
   public sort = (sortBy: string, direction: string) => {
     const data = sceneGraph.getData(this);
-    // Do not re-calculate when only the direction changes
-    if (sortBy === this.sortBy && this.direction !== direction) {
-      this.direction = direction;
-      this.state.body.setState({ children: this.state.body.state.children.reverse() });
-      return;
-    }
     this.sortBy = sortBy;
     this.direction = direction;
     if (data.state.data) {

--- a/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
@@ -15,8 +15,9 @@ import {
 import { sortSeries } from 'services/sorting';
 import { fuzzySearch } from '../../../services/search';
 import { getLabelValue } from './SortByScene';
-import { Alert } from '@grafana/ui';
+import { Alert, Button } from '@grafana/ui';
 import { css } from '@emotion/css';
+import { BreakdownSearchReset } from './BreakdownSearchScene';
 
 interface ByFrameRepeaterState extends SceneObjectState {
   body: SceneLayout;
@@ -139,10 +140,14 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     });
 
     if (newChildren.length === 0) {
-      this.state.body.setState({ children: [buildNoResultsScene(this.filter)] });
+      this.state.body.setState({ children: [buildNoResultsScene(this.filter, this.clearFilter)] });
     } else {
       this.state.body.setState({ children: newChildren });
     }
+  };
+
+  public clearFilter = () => {
+    this.publishEvent(new BreakdownSearchReset(), true);
   };
 
   public static Component = ({ model }: SceneComponentProps<SceneByFrameRepeater>) => {
@@ -151,7 +156,7 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
   };
 }
 
-function buildNoResultsScene(filter: string) {
+function buildNoResultsScene(filter: string, clearFilter: () => void) {
   return new SceneFlexLayout({
     direction: 'row',
     children: [
@@ -161,6 +166,9 @@ function buildNoResultsScene(filter: string) {
             <div className={styles.alertContainer}>
               <Alert title="" severity="info" className={styles.noResultsAlert}>
                 No values found matching &ldquo;{filter}&rdquo;
+                <Button className={styles.clearButton} onClick={clearFilter}>
+                  Clear filter
+                </Button>
               </Alert>
             </div>
           ),
@@ -180,5 +188,8 @@ const styles = {
   noResultsAlert: css({
     minWidth: '30vw',
     flexGrow: 0,
+  }),
+  clearButton: css({
+    marginLeft: '1.5rem',
   }),
 };

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -281,8 +281,9 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
   }
 
   private buildFieldsLayout(options: Array<SelectableValue<string>>) {
-    const children: SceneFlexItemLike[] = [];
+    this.state.search.reset();
 
+    const children: SceneFlexItemLike[] = [];
     for (const option of options) {
       const { value: optionValue } = option;
       if (optionValue === ALL_VARIABLE_VALUE || !optionValue) {

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -38,7 +38,7 @@ import { ByFrameRepeater } from './ByFrameRepeater';
 import { FieldSelector } from './FieldSelector';
 import { LayoutSwitcher } from './LayoutSwitcher';
 import { StatusWrapper } from './StatusWrapper';
-import { BreakdownSearchScene } from './BreakdownSearchScene';
+import { BreakdownSearchReset, BreakdownSearchScene } from './BreakdownSearchScene';
 import { getLabelValue, SortByScene, SortCriteriaChanged } from './SortByScene';
 import { getSortByPreference } from 'services/store';
 import { GrotError } from '../../GrotError';
@@ -85,7 +85,12 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
   private onActivate() {
     const variable = this.getVariable();
 
-    this.subscribeToEvent(SortCriteriaChanged, this.handleSortByChange);
+    this._subs.add(
+      this.subscribeToEvent(BreakdownSearchReset, () => {
+        this.state.search.clearValueFilter();
+      })
+    );
+    this._subs.add(this.subscribeToEvent(SortCriteriaChanged, this.handleSortByChange));
 
     sceneGraph.getAncestor(this, ServiceScene)!.subscribeToState((newState, oldState) => {
       if (newState.fields !== oldState.fields) {

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -347,7 +347,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     const query = buildLokiQuery(getExpr(tagKey), { legendFormat: `{{${tagKey}}}` });
 
     const { sortBy, direction } = getSortByPreference('fields', ReducerID.stdDev, 'desc');
-    const filter = this.state.search.state.filter ?? '';
+    const getFilter = () => this.state.search.state.filter ?? '';
 
     return new LayoutSwitcher({
       $data: getQueryRunner(query),
@@ -387,7 +387,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
           ),
           sortBy,
           direction,
-          filter,
+          getFilter,
         }),
         new ByFrameRepeater({
           body: new SceneCSSGridLayout({
@@ -409,7 +409,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
           ),
           sortBy,
           direction,
-          filter,
+          getFilter,
         }),
       ],
     });

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -73,7 +73,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
         }),
       loading: true,
       sort: new SortByScene({ target: 'fields' }),
-      search: new BreakdownSearchScene(),
+      search: new BreakdownSearchScene('fields'),
       value: state.value ?? ALL_VARIABLE_VALUE,
       ...state,
     });

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -33,7 +33,7 @@ import { FieldSelector } from './FieldSelector';
 import { LayoutSwitcher } from './LayoutSwitcher';
 import { StatusWrapper } from './StatusWrapper';
 import { getLabelOptions, sortLabelsByCardinality } from 'services/filters';
-import { BreakdownSearchScene } from './BreakdownSearchScene';
+import { BreakdownSearchReset, BreakdownSearchScene } from './BreakdownSearchScene';
 import { getSortByPreference } from 'services/store';
 import { getLabelValue, SortByScene, SortCriteriaChanged } from './SortByScene';
 
@@ -72,7 +72,12 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
   }
 
   private onActivate() {
-    this.subscribeToEvent(SortCriteriaChanged, this.handleSortByChange);
+    this._subs.add(
+      this.subscribeToEvent(BreakdownSearchReset, () => {
+        this.state.search.clearValueFilter();
+      })
+    );
+    this._subs.add(this.subscribeToEvent(SortCriteriaChanged, this.handleSortByChange));
 
     const variable = this.getVariable();
 

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -74,7 +74,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
         }),
       loading: true,
       sort: new SortByScene({ target: 'labels' }),
-      search: new BreakdownSearchScene(),
+      search: new BreakdownSearchScene('labels'),
       value: state.value,
     });
 
@@ -203,8 +203,6 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     stateUpdate.body = variable.hasAllValue()
       ? buildLabelsLayout(variableState.options)
       : buildLabelValuesLayout(variableState, this);
-
-    stateUpdate.search = new BreakdownSearchScene();
 
     this.setState(stateUpdate);
   }

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -361,7 +361,7 @@ function buildLabelValuesLayout(variableState: CustomConstantVariableState, scen
 
   const body = bodyOpts.build();
   const { sortBy, direction } = getSortByPreference('labels', ReducerID.stdDev, 'desc');
-  const filter = scene.state.search.state.filter ?? '';
+  const getFilter = () => scene.state.search.state.filter ?? '';
 
   return new LayoutSwitcher({
     $data: getQueryRunner(query),
@@ -400,7 +400,7 @@ function buildLabelValuesLayout(variableState: CustomConstantVariableState, scen
         ),
         sortBy,
         direction,
-        filter,
+        getFilter,
       }),
       new ByFrameRepeater({
         body: new SceneCSSGridLayout({
@@ -421,7 +421,7 @@ function buildLabelValuesLayout(variableState: CustomConstantVariableState, scen
         ),
         sortBy,
         direction,
-        filter,
+        getFilter,
       }),
     ],
   });

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -33,9 +33,9 @@ import { FieldSelector } from './FieldSelector';
 import { LayoutSwitcher } from './LayoutSwitcher';
 import { StatusWrapper } from './StatusWrapper';
 import { getLabelOptions, sortLabelsByCardinality } from 'services/filters';
-import { BreakdownSearchScene, getLabelValue } from './BreakdownSearchScene';
+import { BreakdownSearchScene } from './BreakdownSearchScene';
 import { getSortByPreference } from 'services/store';
-import { SortByScene, SortCriteriaChanged } from './SortByScene';
+import { getLabelValue, SortByScene, SortCriteriaChanged } from './SortByScene';
 
 export interface LabelBreakdownSceneState extends SceneObjectState {
   body?: LayoutSwitcher;
@@ -173,9 +173,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
       error: false,
     };
 
-    stateUpdate.body = variable.hasAllValue() ? buildLabelsLayout(options) : buildLabelValuesLayout(variable);
-
-    stateUpdate.search = new BreakdownSearchScene();
+    stateUpdate.body = variable.hasAllValue() ? buildLabelsLayout(options) : buildLabelValuesLayout(variable, this);
 
     this.setState(stateUpdate);
   }
@@ -312,7 +310,7 @@ function getExpr(tagKey: string) {
 
 const GRID_TEMPLATE_COLUMNS = 'repeat(auto-fit, minmax(400px, 1fr))';
 
-function buildLabelValuesLayout(variable: CustomVariable) {
+function buildLabelValuesLayout(variable: CustomVariable, scene: LabelBreakdownScene) {
   const tagKey = variable.getValueText();
   const query = buildLokiQuery(getExpr(tagKey), { legendFormat: `{{${tagKey}}}` });
 
@@ -328,6 +326,7 @@ function buildLabelValuesLayout(variable: CustomVariable) {
 
   const body = bodyOpts.build();
   const { sortBy, direction } = getSortByPreference('labels', ReducerID.stdDev, 'desc');
+  const filter = scene.state.search.state.filter ?? '';
 
   return new LayoutSwitcher({
     $data: getQueryRunner(query),
@@ -366,6 +365,7 @@ function buildLabelValuesLayout(variable: CustomVariable) {
         ),
         sortBy,
         direction,
+        filter,
       }),
       new ByFrameRepeater({
         body: new SceneCSSGridLayout({
@@ -386,6 +386,7 @@ function buildLabelValuesLayout(variable: CustomVariable) {
         ),
         sortBy,
         direction,
+        filter,
       }),
     ],
   });

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -201,7 +201,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     };
 
     stateUpdate.body = variable.hasAllValue()
-      ? buildLabelsLayout(variableState.options)
+      ? buildLabelsLayout(variableState.options, this)
       : buildLabelValuesLayout(variableState, this);
 
     this.setState(stateUpdate);
@@ -289,9 +289,10 @@ function getStyles(theme: GrafanaTheme2) {
   };
 }
 
-function buildLabelsLayout(options: VariableValueOption[]) {
-  const children: SceneFlexItemLike[] = [];
+function buildLabelsLayout(options: VariableValueOption[], scene: LabelBreakdownScene) {
+  scene.state.search.reset();
 
+  const children: SceneFlexItemLike[] = [];
   for (const option of options) {
     const { value } = option;
     const optionValue = String(value);


### PR DESCRIPTION
Summary of changes:
- Moved the filtering code from `BreakdownSearchScene` to `ByFrameRepeater`.
- Added the previously used filter to `ByFrameRepeater`
- `ByFrameRepeater` if has a filter, applies it after "repeating".
- Added a missing UI state for when there are no values matching your search:
  ![message](https://github.com/user-attachments/assets/b709d160-6acb-4339-b201-fd9c6341dbe1)

Closes https://github.com/grafana/explore-logs/issues/559