### PR TITLE
docs: Update metadata with canonical URLs

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,9 +1,10 @@
 ---
 title: Explore Logs
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/
 description: Learn about the new experience for browsing your Loki logs without writing queries.
 weight: 100
 hero:
-  title: Explore Logs
+  title: Explore Logs 
   level: 1
   width: 100
   height: 100

--- a/docs/sources/access/_index.md
+++ b/docs/sources/access/_index.md
@@ -1,5 +1,6 @@
 ---
-description: Access and installation guide for Explore Logs.
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/access/
+description: Describes how to access Explore Logs in Grafana Cloud and the different installation methods for self-hosted Grafana.
 keywords:
   - Logs
   - Explore
@@ -29,13 +30,15 @@ To access Explore Logs:
 
 ## Installation
 
+If you are not using Grafana Cloud, you can install Explore Logs in your Grafana environment.
+
 ### Install via Plugins catalog
 
 For Enterprise and OSS Grafana users, you can install Explore Logs via the [Grafana Plugins catalog](https://grafana-dev.com/grafana/plugins/grafana-lokiexplore-app/).
 
 1. Open [https://grafana-dev.com/grafana/plugins/grafana-lokiexplore-app/](https://grafana-dev.com/grafana/plugins/grafana-lokiexplore-app/) in a web browser
-1. Open the **Installation** tab
-1. Follow the instructions to install the app
+1. Open the **Installation** tab.
+1. Follow the instructions to install the app.
 
 ### Install in Loki
 

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -1,5 +1,6 @@
 ---
-description: Get set up and take a tour of Explore Logs.
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/get-started/
+description: Provides a guided tour of the features in Explore Logs.
 keywords:
   - Logs
   - Explore

--- a/docs/sources/labels-and-fields/_index.md
+++ b/docs/sources/labels-and-fields/_index.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/labels-and-fields/
 description: Learn how breaking logs down by Labels and Fields can help you find the signal in the noise.
 keywords:
   - Logs
@@ -7,7 +8,7 @@ keywords:
   - Analysis
 menuTitle: Labels and Fields
 title: Labels and Fields
-weight: 400
+weight: 500
 ---
 
 # Labels and Fields

--- a/docs/sources/ordering/_index.md
+++ b/docs/sources/ordering/_index.md
@@ -1,5 +1,6 @@
 ---
-description: Learn about sorting and ordering data in Explore Logs
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/ordering/ 
+description: Learn about sorting and ordering data in Explore Logs.
 keywords:
   - Logs
   - Log Patterns

--- a/docs/sources/patterns/_index.md
+++ b/docs/sources/patterns/_index.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/patterns/
 description: Use Log patterns to detect and analyze types of log lines.
 keywords:
   - Logs
@@ -10,7 +11,7 @@ keywords:
   - Analysis
 menuTitle: Log patterns
 title: Log patterns
-weight: 500
+weight: 600
 ---
 
 # Log patterns

--- a/docs/sources/troubleshooting/_index.md
+++ b/docs/sources/troubleshooting/_index.md
@@ -1,5 +1,6 @@
 ---
-description: Solve common issues when working with Explore Logs.
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/troubleshooting/
+description: Describes how to solve common issues when working with Explore Logs.
 keywords:
   - Logs
   - Explore


### PR DESCRIPTION
Fixes #608 by adding `canonical:` to the metadata and setting to the Grafana URL for search engine optimization.
Also updated some descriptions and page weights.