### PR TITLE
Patterns: Show UI message when time range is too old to show patterns

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
@@ -42,6 +42,8 @@ export type PatternFrame = {
   status?: 'include' | 'exclude';
 };
 
+const PATTERNS_MAX_AGE_HOURS = 3;
+
 export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSceneState> {
   constructor(state: Partial<PatternsBreakdownSceneState>) {
     super({
@@ -65,7 +67,7 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
     const logsByServiceScene = sceneGraph.getAncestor(model, ServiceScene);
     const { patterns } = logsByServiceScene.useState();
     const styles = useStyles2(getStyles);
-    const timeRangeTooOld = dateTime().diff(timeRange.to, 'hours');
+    const timeRangeTooOld = dateTime().diff(timeRange.to, 'hours') >= PATTERNS_MAX_AGE_HOURS;
 
     return (
       <div className={styles.container}>

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import React from 'react';
 
-import { DataFrame, FieldType, GrafanaTheme2 } from '@grafana/data';
+import { DataFrame, dateTime, FieldType, GrafanaTheme2 } from '@grafana/data';
 import {
   CustomVariable,
   SceneComponentProps,
@@ -12,14 +12,14 @@ import {
   SceneObjectState,
   SceneVariableSet,
 } from '@grafana/scenes';
-import { Text, TextLink, useStyles2 } from '@grafana/ui';
+import { Text, useStyles2 } from '@grafana/ui';
 import { StatusWrapper } from 'Components/ServiceScene/Breakdowns/StatusWrapper';
-import { GrotError } from 'Components/GrotError';
 import { VAR_LABEL_GROUP_BY } from 'services/variables';
 import { LokiPattern, ServiceScene } from '../../ServiceScene';
 import { IndexScene } from '../../../IndexScene/IndexScene';
 import { PatternsFrameScene } from './PatternsFrameScene';
 import { PatternsViewTextSearch } from './PatternsViewTextSearch';
+import { PatternsNotDetected, PatternsTooOld } from './PatternsNotDetected';
 
 export interface PatternsBreakdownSceneState extends SceneObjectState {
   body?: SceneFlexLayout;
@@ -61,9 +61,12 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
   // parent render
   public static Component = ({ model }: SceneComponentProps<PatternsBreakdownScene>) => {
     const { body, loading, blockingMessage } = model.useState();
+    const { value: timeRange } = sceneGraph.getTimeRange(model).useState();
     const logsByServiceScene = sceneGraph.getAncestor(model, ServiceScene);
     const { patterns } = logsByServiceScene.useState();
     const styles = useStyles2(getStyles);
+    const timeRangeTooOld = dateTime().diff(timeRange.to, 'hours');
+
     return (
       <div className={styles.container}>
         <StatusWrapper {...{ isLoading: loading, blockingMessage }}>
@@ -80,22 +83,9 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
               </Text>
             </div>
           )}
-          {!loading && patterns?.length === 0 && (
-            <GrotError>
-              <div>
-                <p>
-                  <strong>Sorry, we could not detect any patterns.</strong>
-                </p>
-                <p>
-                  Check back later or reach out to the team in the{' '}
-                  <TextLink href="https://slack.grafana.com/" external>
-                    Grafana Labs community Slack channel
-                  </TextLink>
-                </p>
-                <p>Patterns let you detect similar log lines to include or exclude from your search.</p>
-              </div>
-            </GrotError>
-          )}
+
+          {!loading && patterns?.length === 0 && timeRangeTooOld && <PatternsTooOld />}
+          {!loading && patterns?.length === 0 && !timeRangeTooOld && <PatternsNotDetected />}
           {!loading && patterns && patterns.length > 0 && (
             <div className={styles.content}>{body && <body.Component model={body} />}</div>
           )}

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
@@ -42,7 +42,7 @@ export type PatternFrame = {
   status?: 'include' | 'exclude';
 };
 
-const PATTERNS_MAX_AGE_HOURS = 3;
+export const PATTERNS_MAX_AGE_HOURS = 3;
 
 export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSceneState> {
   constructor(state: Partial<PatternsBreakdownSceneState>) {

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsNotDetected.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsNotDetected.tsx
@@ -26,7 +26,7 @@ export function PatternsTooOld() {
     <GrotError>
       <div>
         <p>
-          <strong>Sorry, patterns are currently only available for the most recent 2 hours of data.</strong>
+          <strong>Patterns are only available for the most recent 2 hours of data.</strong>
         </p>
         <p>
           See the{' '}

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsNotDetected.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsNotDetected.tsx
@@ -26,7 +26,7 @@ export function PatternsTooOld() {
     <GrotError>
       <div>
         <p>
-          <strong>Patterns are only available for the most recent 2 hours of data.</strong>
+          <strong>Patterns are only available for the most recent 3 hours of data.</strong>
         </p>
         <p>
           See the{' '}

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsNotDetected.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsNotDetected.tsx
@@ -1,0 +1,44 @@
+import { GrotError } from '../../../GrotError';
+import { TextLink } from '@grafana/ui';
+import React from 'react';
+
+export function PatternsNotDetected() {
+  return (
+    <GrotError>
+      <div>
+        <p>
+          <strong>Sorry, we could not detect any patterns.</strong>
+        </p>
+        <p>
+          Check back later or reach out to the team in the{' '}
+          <TextLink href="https://slack.grafana.com/" external>
+            Grafana Labs community Slack channel
+          </TextLink>
+        </p>
+        <p>Patterns let you detect similar log lines to include or exclude from your search.</p>
+      </div>
+    </GrotError>
+  );
+}
+
+export function PatternsTooOld() {
+  return (
+    <GrotError>
+      <div>
+        <p>
+          <strong>Sorry, patterns are currently only available for the most recent 2 hours of data.</strong>
+        </p>
+        <p>
+          See the{' '}
+          <TextLink
+            href="https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/patterns/"
+            external
+          >
+            patterns docs
+          </TextLink>{' '}
+          for more info.
+        </p>
+      </div>
+    </GrotError>
+  );
+}

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsNotDetected.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsNotDetected.tsx
@@ -1,6 +1,7 @@
 import { GrotError } from '../../../GrotError';
 import { TextLink } from '@grafana/ui';
 import React from 'react';
+import { PATTERNS_MAX_AGE_HOURS } from './PatternsBreakdownScene';
 
 export function PatternsNotDetected() {
   return (
@@ -26,7 +27,7 @@ export function PatternsTooOld() {
     <GrotError>
       <div>
         <p>
-          <strong>Patterns are only available for the most recent 3 hours of data.</strong>
+          <strong>Patterns are only available for the most recent {PATTERNS_MAX_AGE_HOURS} hours of data.</strong>
         </p>
         <p>
           See the{' '}


### PR DESCRIPTION
Users have expressed frustration when patterns disappear when looking for non-recent logs.
Let's add a UI state and link to the docs that specify how long patterns are around.