### PR TITLE
Labels: Clear filters in value breakdown when in no-data state

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/ClearVariablesScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ClearVariablesScene.tsx
@@ -1,0 +1,110 @@
+import { GrotError } from '../../GrotError';
+import { Alert, Button } from '@grafana/ui';
+import React from 'react';
+import { css } from '@emotion/css';
+import {
+  AdHocFiltersVariable,
+  CustomVariable,
+  SceneComponentProps,
+  sceneGraph,
+  SceneObject,
+  SceneObjectBase,
+  SceneObjectState,
+  SceneVariable,
+} from '@grafana/scenes';
+import { IndexScene } from '../../IndexScene/IndexScene';
+import { SERVICE_NAME } from '../../ServiceSelectionScene/ServiceSelectionScene';
+
+interface ClearVariablesSceneState extends SceneObjectState {
+  fieldsOnly?: boolean;
+}
+export class ClearVariablesScene extends SceneObjectBase<ClearVariablesSceneState> {
+  private static getVariablesToClear(indexSceneChild: SceneObject): SceneVariable[] {
+    const indexScene = sceneGraph.getAncestor(indexSceneChild, IndexScene);
+    const variables = sceneGraph.getVariables(indexScene);
+    const variablesToClear: SceneVariable[] = [];
+
+    for (const variable of variables.state.variables) {
+      if (
+        variable instanceof AdHocFiltersVariable &&
+        variable.state.filters.filter((filter) => filter.key !== SERVICE_NAME).length
+      ) {
+        variablesToClear.push(variable);
+      }
+    }
+    const fieldsToClear = ClearVariablesScene.getFieldsToClear(indexSceneChild);
+
+    return [...variablesToClear, ...fieldsToClear];
+  }
+
+  private static getFieldsToClear(indexSceneChild: SceneObject): SceneVariable[] {
+    const indexScene = sceneGraph.getAncestor(indexSceneChild, IndexScene);
+    const variables = sceneGraph.getVariables(indexScene);
+    const variablesToClear: SceneVariable[] = [];
+
+    for (const variable of variables.state.variables) {
+      if (variable instanceof CustomVariable && variable.state.value && variable.state.name !== 'logsFormat') {
+        variablesToClear.push(variable);
+      }
+    }
+
+    return variablesToClear;
+  }
+
+  public static getCountOfFieldsToClear(indexSceneChild: SceneObject): number {
+    return ClearVariablesScene.getFieldsToClear(indexSceneChild).length;
+  }
+
+  public static getCountOfVariablesToClear(indexSceneChild: SceneObject): number {
+    const variables = ClearVariablesScene.getVariablesToClear(indexSceneChild);
+    return variables.length;
+  }
+
+  private clearVariables(variablesToClear: SceneVariable[]) {
+    // clear patterns: needs to happen first, or it won't work as patterns is split into a variable and a state, and updating the variable triggers a state update
+    const indexScene = sceneGraph.getAncestor(this, IndexScene);
+    indexScene.setState({
+      patterns: [],
+    });
+
+    variablesToClear.forEach((variable) => {
+      if (variable instanceof AdHocFiltersVariable && variable.state.key === 'adhoc_service_filter') {
+        variable.setState({
+          filters: variable.state.filters.filter((filter) => filter.key === SERVICE_NAME),
+        });
+      } else if (variable instanceof AdHocFiltersVariable) {
+        variable.setState({
+          filters: [],
+        });
+      } else if (variable instanceof CustomVariable) {
+        variable.setState({
+          value: '',
+          text: '',
+        });
+      }
+    });
+  }
+
+  public static Component({ model }: SceneComponentProps<ClearVariablesScene>): React.ReactElement | null {
+    const { fieldsOnly } = model.useState();
+    const variablesToClear = fieldsOnly
+      ? ClearVariablesScene.getFieldsToClear(model)
+      : ClearVariablesScene.getVariablesToClear(model);
+    return (
+      <GrotError>
+        <Alert title="" severity="info">
+          No labels match these filters.{' '}
+          <Button className={styles.button} onClick={() => model.clearVariables(variablesToClear)}>
+            Clear filters
+          </Button>{' '}
+        </Alert>
+      </GrotError>
+    );
+  }
+}
+
+const styles = {
+  button: css({
+    marginLeft: '1.5rem',
+  }),
+};

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -155,7 +155,10 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     } catch (error) {
       console.error(error);
       this.setState({ loading: false, error: true });
+      return;
     }
+
+    console.log('detectedLables', detectedLabels);
 
     if (!detectedLabels || !Array.isArray(detectedLabels)) {
       this.setState({ loading: false, error: true });


### PR DESCRIPTION
Also refactoring things a bit to share the clear-filters scene, and move the label values breakdown to a dedicated scene as well.

Also when in the labels view, you only want to clear fields, patterns, and line filters, as any label filters that remove data would be sent in the detected_labels call, and return no-data view before users can reach the breakdown.

Would be nice to do something when all panels are no-data in the all labels view, but should probably deal with that in another PR before this gets too big

WIP