### PR TITLE
feat: serve service histograms from aggregated metrics

### DIFF
--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -113,37 +113,6 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     return panel;
   }
 
-  // private hasSingleServiceSelector(): boolean {
-  //   const fields = sceneGraph.lookupVariable(VAR_FIELDS, this) as AdHocFiltersVariable;
-  //   const patterns = sceneGraph.lookupVariable(VAR_PATTERNS, this) as CustomVariable;
-  //   const lineFilter = sceneGraph.lookupVariable(VAR_LINE_FILTER, this) as CustomVariable;
-
-  //   if (fields.state.filters.length !== 0 || patterns.state.value !== '') {
-  //     return false;
-  //   }
-
-  //   const labels = sceneGraph.lookupVariable(VAR_LABELS, this) as AdHocFiltersVariable;
-  //   if (labels.state.filters.length > 1) {
-  //     return false;
-  //   }
-
-  //   const filter = (lineFilter.state.value as string).trim();
-  //   if (labels.state.filters[0].key === SERVICE_NAME) {
-  //     if (filter === '|~ `(?i)`' || !filter) {
-  //       return true;
-  //     }
-  //   }
-
-  //   return false;
-  // }
-
-  // private service(): string {
-  //   const labels = sceneGraph.lookupVariable(VAR_LABELS, this) as AdHocFiltersVariable;
-  //   const filters = labels?.state.filters ?? [];
-
-  //   return filters.find((filter) => filter.key === SERVICE_NAME)?.value ?? '';
-  // }
-
   private extendTimeSeriesLegendBus = (context: PanelContext) => {
     const originalOnToggleSeriesVisibility = context.onToggleSeriesVisibility;
 

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -31,6 +31,7 @@ import {
   VAR_LABELS,
   VAR_LEVELS,
   VAR_PATTERNS,
+  SERVICE_NAME,
 } from 'services/variables';
 import {
   buildFieldsBreakdownActionScene,
@@ -42,7 +43,6 @@ import { GoToExploreButton } from './GoToExploreButton';
 import { buildLogsListScene } from './LogsListScene';
 import { testIds } from 'services/testIds';
 import { sortLabelsByCardinality } from 'services/filters';
-import { SERVICE_NAME } from 'Components/ServiceSelectionScene/ServiceSelectionScene';
 import { getMetadataService } from '../../services/metadata';
 import { navigateToDrilldownPage, navigateToIndex } from '../../services/navigate';
 import { areArraysEqual } from '../../services/comparison';

--- a/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
+++ b/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
@@ -13,8 +13,8 @@ import {
 import { Button } from '@grafana/ui';
 import { VariableHide } from '@grafana/schema';
 import { addToFavoriteServicesInStorage } from 'services/store';
-import { getDataSourceVariable, getLabelsVariable } from 'services/variables';
-import { SERVICE_NAME, ServiceSelectionScene } from './ServiceSelectionScene';
+import { getDataSourceVariable, getLabelsVariable, SERVICE_NAME } from 'services/variables';
+import { ServiceSelectionScene } from './ServiceSelectionScene';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { FilterOp } from 'services/filters';
 import { navigateToInitialPageAfterServiceSelection } from '../../services/navigate';

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -58,9 +58,9 @@ interface ServiceSelectionSceneState extends SceneObjectState {
   serviceLevel: Map<string, string[]>;
 }
 
-function getMetricExpression(service: string) {
-  return `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`;
-}
+// function getMetricExpression(service: string) {
+//   return `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`;
+// }
 
 function getLogExpression(service: string, levelFilter: string) {
   return `{${SERVICE_NAME}=\`${service}\`}${levelFilter}`;
@@ -288,11 +288,15 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       .setTitle(service)
       .setData(
         getQueryRunner(
-          buildLokiQuery(getMetricExpression(service), {
-            legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}`,
-            splitDuration,
-            refId: `ts-${service}`,
-          })
+          // buildLokiQuery(getMetricExpression(service), {
+          //   legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}`,
+          //   splitDuration,
+          //   refId: `ts-${service}`,
+          // })
+          buildLokiQuery(
+            `sum by (${LEVEL_VARIABLE_VALUE}) (sum_over_time({__aggregated_metric__=\`${service}\`} | logfmt | unwrap count [$__auto]))`,
+            { legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}`, splitDuration, refId: `ts-${service}` }
+          )
         )
       )
       .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })

--- a/src/services/variables.ts
+++ b/src/services/variables.ts
@@ -23,6 +23,7 @@ export const EXPLORATION_DS = { uid: VAR_DATASOURCE_EXPR };
 export const ALL_VARIABLE_VALUE = '$__all';
 export const LEVEL_VARIABLE_VALUE = 'detected_level';
 export const PATTERNS_TEXT_FILTER = 'patternsFilter';
+export const SERVICE_NAME = 'service_name';
 
 export function getPatternsVariable(scene: SceneObject) {
   const variable = sceneGraph.lookupVariable(VAR_PATTERNS, scene);


### PR DESCRIPTION
This depends on https://github.com/grafana/loki/pull/13621. Once that is merged, this change allows us to query those aggregated metrics to serve the service landing page histograms.