### PR TITLE
Labels: Improve query performance

### DIFF
--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -39,6 +39,7 @@ import { NoVolumeError } from './NoVolumeError';
 import { getLabelsFromSeries, toggleLevelFromFilter } from 'services/levels';
 import { isFetchError } from '@grafana/runtime';
 import { ServiceFieldSelector } from '../ServiceScene/Breakdowns/FieldSelector';
+import { LEVEL_NAME } from '../Table/constants';
 
 export const SERVICE_NAME = 'service_name';
 
@@ -326,7 +327,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       if (level === 'logs') {
         level = '';
       }
-      return `detected_level=\`${level}\``;
+      return `${LEVEL_NAME}=\`${level}\``;
     });
     return ` | ${filters.join(' or ')} `;
   };

--- a/src/services/getVariables.ts
+++ b/src/services/getVariables.ts
@@ -1,0 +1,18 @@
+import { VAR_LABELS } from './variables';
+import { AdHocFiltersVariable, sceneGraph, SceneObject } from '@grafana/scenes';
+import { IndexScene } from '../Components/IndexScene/IndexScene';
+
+/**
+ * Helper function to grab the labels variable
+ * @param scene
+ */
+export const getLabelsVariable = (scene: SceneObject) => {
+  const indexScene = sceneGraph.getAncestor(scene, IndexScene);
+  const variables = sceneGraph.getVariables(indexScene);
+  const labelsVariable = variables.state.variables.find((variable) => variable.state.name === VAR_LABELS);
+
+  if (!(labelsVariable instanceof AdHocFiltersVariable)) {
+    throw new Error(`${VAR_LABELS} variable not found`);
+  }
+  return labelsVariable;
+};

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -1,5 +1,5 @@
 import { DataFrame } from '@grafana/data';
-import { SceneDataTransformer, SceneQueryRunner } from '@grafana/scenes';
+import { SceneDataTransformer, SceneQueryRunner, SceneVariables } from '@grafana/scenes';
 import { map, Observable } from 'rxjs';
 import { LokiQuery } from './query';
 import { EXPLORATION_DS } from './variables';
@@ -53,7 +53,7 @@ export function sortLevelTransformation() {
   };
 }
 
-export function getQueryRunner(query: LokiQuery) {
+export function getQueryRunner(query: LokiQuery, variablesOverride?: SceneVariables) {
   // if there's a legendFormat related to any `level` like label, we want to
   // sort the output equally. That's purposefully not `LEVEL_VARIABLE_VALUE`,
   // such that the `detected_level` graph looks the same as a graph for the
@@ -63,6 +63,7 @@ export function getQueryRunner(query: LokiQuery) {
       $data: new SceneQueryRunner({
         datasource: EXPLORATION_DS,
         queries: [query],
+        $variables: variablesOverride,
       }),
       transformations: [sortLevelTransformation],
     });
@@ -71,5 +72,6 @@ export function getQueryRunner(query: LokiQuery) {
   return new SceneQueryRunner({
     datasource: EXPLORATION_DS,
     queries: [query],
+    $variables: variablesOverride,
   });
 }


### PR DESCRIPTION
Removes parsers and parser filters from the queries in the labels breakdowns, to improve performance of those queries.

Note:
This PR introduced custom variable overrides when instantiating the SceneQueryRunner. This allows for adding additional stream selectors that aren't currently in the UI state, in this case to exclude labels that have empty values.

Fixes: https://github.com/grafana/explore-logs/issues/626

This might conflict with https://github.com/grafana/explore-logs/pull/611 a bit, as that PR wants to introduce the empty values back in, but this PR should be the priority to help keep loki load down.
