### PR TITLE
Label queries: remove unneccessary filters and parsers in query expression

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -427,6 +427,7 @@ typeurl
 udpa
 ufuzzy
 ugorji
+unsub
 unsubs
 Unsubscribable
 urfave

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -25,7 +25,7 @@ import { DetectedLabel, getFilterBreakdownValueScene } from 'services/fields';
 import { getQueryRunner, setLeverColorOverrides } from 'services/panel';
 import { buildLokiQuery } from 'services/query';
 import { ValueSlugs } from 'services/routing';
-import { getLokiDatasource } from 'services/scenes';
+import { getLokiDatasource, isDefined } from 'services/scenes';
 import {
   ALL_VARIABLE_VALUE,
   VAR_LABEL_GROUP_BY,
@@ -384,8 +384,8 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
       fieldExpressionToAdd = `| ${LEVEL_VARIABLE_VALUE} != ""`;
     }
     const streamSelectors = [...labelsVariable.state.filters, labelExpressionToAdd]
-      .filter((f) => !!f)
-      .map((f) => `${f!.key}${f!.operator}\`${f!.value}\``)
+      .filter(isDefined)
+      .map((f) => `${f.key}${f.operator}\`${f.value}\``)
       .join(',');
 
     const fields = fieldsVariable.state.filters;

--- a/src/services/scenes.ts
+++ b/src/services/scenes.ts
@@ -58,3 +58,7 @@ export function getAdHocFiltersVariable(variableName: string, sceneObject: Scene
   }
   return variable;
 }
+
+export function isDefined<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}


### PR DESCRIPTION
This change looks larger than it is. I moved the `buildLabelsLayout` and `buildLabelValuesLayout` into the class, so I can access a sceneObject from `getExpr`.

In `getExpr` you will find the important change: https://github.com/grafana/explore-logs/compare/svennergr/better-label-queries?expand=1#diff-0c7c5b52164d9762335a7b37b5b4822ed449d0a60ea4dd765c8ee29efad26ae1R367-R390

We now create the stream selector expression in the app, to add filtering for only existing items. To prevent the parser from being added, we check for `fields.length` and only add the parser if we have a fields filter expression.