### PR TITLE
Service views: Prevent extra queries

### DIFF
--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -214,7 +214,6 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     if (newState.data?.state === LoadingState.Done) {
       const frame = newState.data?.series[0];
       if (frame) {
-        console.log('serviceScene');
         const res = updateParserFromDataFrame(frame, this);
         const fields = res.fields.filter((f) => !disabledFields.includes(f)).sort((a, b) => a.localeCompare(b));
         if (JSON.stringify(fields) !== JSON.stringify(this.state.fields)) {

--- a/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
+++ b/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
@@ -28,21 +28,25 @@ export interface SelectServiceButtonState extends SceneObjectState {
 function setParserIfFrameExistsForService(service: string, sceneRef: SceneObject) {
   const serviceSelectionScene = sceneGraph.getAncestor(sceneRef, ServiceSelectionScene);
 
-  const theChildWeWant = serviceSelectionScene.state.body.state.children.find((child) => {
-    if (child instanceof SceneCSSGridItem) {
-      const body = child.state.body;
+  const gridItem: SceneCSSGridItem | SceneObject | undefined = serviceSelectionScene.state.body.state.children.find(
+    (child) => {
+      if (child instanceof SceneCSSGridItem) {
+        const body = child.state.body;
 
-      // The query runner is only defined for the logs panel
-      const queryRunner = body?.state.$data as SceneQueryRunner | undefined;
-      return queryRunner?.state?.queries?.find((query) => {
-        return query.refId === `logs-${service}`;
-      });
+        // The query runner is only defined for the logs panel
+        const queryRunner = body?.state.$data;
+        if (queryRunner instanceof SceneQueryRunner) {
+          return queryRunner?.state?.queries?.find((query) => {
+            return query.refId === `logs-${service}`;
+          });
+        }
+      }
+      return false;
     }
-    return false;
-  }) as SceneCSSGridItem | undefined;
+  );
 
-  if (theChildWeWant) {
-    const body = theChildWeWant.state.body as VizPanel;
+  if (gridItem && gridItem instanceof SceneCSSGridItem) {
+    const body = gridItem.state.body as VizPanel;
     const frame = body.state.$data?.state.data?.series[0];
 
     if (frame) {

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -59,11 +59,11 @@ interface ServiceSelectionSceneState extends SceneObjectState {
   serviceLevel: Map<string, string[]>;
 }
 
-function getTsExpr(service: string) {
+function getMetricExpression(service: string) {
   return `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`;
 }
 
-function getExpr(service: string, levelFilter: string) {
+function getLogExpression(service: string, levelFilter: string) {
   return `{${SERVICE_NAME}=\`${service}\`}${levelFilter}`;
 }
 
@@ -289,7 +289,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       .setTitle(service)
       .setData(
         getQueryRunner(
-          buildLokiQuery(getTsExpr(service), {
+          buildLokiQuery(getMetricExpression(service), {
             legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}`,
             splitDuration,
             refId: `ts-${service}`,
@@ -346,7 +346,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
         .setHoverHeader(true)
         .setData(
           getQueryRunner(
-            buildLokiQuery(getExpr(service, levelFilter), {
+            buildLokiQuery(getLogExpression(service, levelFilter), {
               maxLines: 100,
               refId: `logs-${service}`,
             })

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -59,6 +59,14 @@ interface ServiceSelectionSceneState extends SceneObjectState {
   serviceLevel: Map<string, string[]>;
 }
 
+function getTsExpr(service: string) {
+  return `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`;
+}
+
+function getExpr(service: string, levelFilter: string) {
+  return `{${SERVICE_NAME}=\`${service}\`}${levelFilter}`;
+}
+
 export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionSceneState> {
   protected _variableDependency = new VariableDependencyConfig(this, {
     // We want to subscribe to changes in datasource variables and update the top services when the datasource changes
@@ -214,26 +222,22 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       this.state.body.setState({ children: [] });
     } else {
       // If we have services to query, build the layout with the services. Children is an array of layouts for each service (1 row with 2 columns - timeseries and logs panel)
-      const children = [];
+      const children: SceneCSSGridItem[] = [];
       const timeRange = sceneGraph.getTimeRange(this).state.value;
       for (const service of this.state.servicesToQuery) {
         // for each service, we create a layout with timeseries and logs panel
         children.push(this.buildServiceLayout(service, timeRange), this.buildServiceLogsLayout(service));
       }
       this.state.body.setState({
-        children: [
-          new SceneCSSGridLayout({
-            children,
-            isLazy: true,
-            templateColumns: 'repeat(auto-fit, minmax(500px, 1fr) minmax(300px, 70vw))',
-            autoRows: '200px',
-            md: {
-              templateColumns: '1fr',
-              rowGap: 1,
-              columnGap: 1,
-            },
-          }),
-        ],
+        children,
+        isLazy: true,
+        templateColumns: 'repeat(auto-fit, minmax(500px, 1fr) minmax(300px, 70vw))',
+        autoRows: '200px',
+        md: {
+          templateColumns: '1fr',
+          rowGap: 1,
+          columnGap: 1,
+        },
       });
     }
   }
@@ -285,10 +289,11 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       .setTitle(service)
       .setData(
         getQueryRunner(
-          buildLokiQuery(
-            `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`,
-            { legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}`, splitDuration, refId: `ts-${service}` }
-          )
+          buildLokiQuery(getTsExpr(service), {
+            legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}`,
+            splitDuration,
+            refId: `ts-${service}`,
+          })
         )
       )
       .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
@@ -341,7 +346,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
         .setHoverHeader(true)
         .setData(
           getQueryRunner(
-            buildLokiQuery(`{${SERVICE_NAME}=\`${service}\`}${levelFilter}`, {
+            buildLokiQuery(getExpr(service, levelFilter), {
               maxLines: 100,
               refId: `logs-${service}`,
             })

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -44,7 +44,7 @@ export function extractParserAndFieldsFromDataFrame(data: DataFrame) {
     }, {}) || {}
   );
 
-  const linesField = data.fields.find((f) => f.name === 'Line');
+  const linesField = data.fields.find((f) => f.name === 'Line' || f.name === 'body');
   result.type = linesField?.values[0]?.[0] === '{' ? 'json' : 'logfmt';
 
   return result;

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -1,10 +1,11 @@
 import { DataFrame, PanelData } from '@grafana/data';
 import { DrawStyle, StackingMode } from '@grafana/ui';
-import { PanelBuilders, SceneCSSGridItem, SceneDataNode } from '@grafana/scenes';
+import { PanelBuilders, SceneCSSGridItem, SceneDataNode, SceneObject } from '@grafana/scenes';
 import { getColorByIndex } from './scenes';
 import { AddToFiltersButton } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
 import { VAR_FIELDS, VAR_LABELS } from './variables';
 import { setLeverColorOverrides } from './panel';
+import { getLogsFormatVariable } from './variableGetters';
 
 export type DetectedLabel = {
   label: string;
@@ -15,13 +16,25 @@ export type DetectedLabelsResponse = {
   detectedLabels: DetectedLabel[];
 };
 
-interface ExtratedFields {
+interface ExtractedFields {
   type: 'logfmt' | 'json';
   fields: string[];
 }
 
+export function updateParserFromDataFrame(frame: DataFrame, sceneRef: SceneObject): ExtractedFields {
+  const variable = getLogsFormatVariable(sceneRef);
+  const res = extractParserAndFieldsFromDataFrame(frame);
+  const newType = res.type ? ` | ${res.type}` : '';
+  if (variable.getValue() !== newType) {
+    console.log('actually updating fmt', newType);
+    variable.changeValueTo(newType);
+  }
+
+  return res;
+}
+
 export function extractParserAndFieldsFromDataFrame(data: DataFrame) {
-  const result: ExtratedFields = { type: 'logfmt', fields: [] };
+  const result: ExtractedFields = { type: 'logfmt', fields: [] };
   const labelTypesField = data.fields.find((f) => f.name === 'labelTypes');
   result.fields = Object.keys(
     labelTypesField?.values.reduce((acc: Record<string, boolean>, value: Record<string, string>) => {

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -26,7 +26,6 @@ export function updateParserFromDataFrame(frame: DataFrame, sceneRef: SceneObjec
   const res = extractParserAndFieldsFromDataFrame(frame);
   const newType = res.type ? ` | ${res.type}` : '';
   if (variable.getValue() !== newType) {
-    console.log('actually updating fmt', newType);
     variable.changeValueTo(newType);
   }
 

--- a/src/services/variableGetters.ts
+++ b/src/services/variableGetters.ts
@@ -1,0 +1,10 @@
+import { CustomVariable, sceneGraph, SceneObject } from '@grafana/scenes';
+import { VAR_LOGS_FORMAT } from './variables';
+
+export function getLogsFormatVariable(sceneRef: SceneObject) {
+  const variable = sceneGraph.lookupVariable(VAR_LOGS_FORMAT, sceneRef);
+  if (!(variable instanceof CustomVariable)) {
+    throw new Error('Logs format variable not found');
+  }
+  return variable;
+}


### PR DESCRIPTION
There are two sets of extra queries that are being run that this PR attempts to fix.
1. When selecting a service, after updating the services variable, for every SceneQueryRunner loaded in the grid layout, we currently re-query, but add in the selected service, leading to a bunch of queries that return nothing, and look like ```{service_name=`mimir-distributor`, service_name=`just-selected-service`}```. Currently you will get 2 of these queries re-run for every single service that you have scrolled to, sometimes leading to dozens or hundreds queries being blasted out when landing on the ServiceScene

This PR simply clears the body of the service selection scene before navigation, which clears out all of the SceneQueryRunners which would have otherwise re-queried on change of the ad-hoc filter variable.

2. On loading the ServiceScene after selecting a service, we run the logs-volume query, and then check the log lines to see if we want to use json or logfmt parser, and then re-run the query with the parser. 

This PR checks the dataframe we have in the services scene, and updates the parser variable before clearing out the body state for the fix in 1 (since we don't use a parser in the service selection scene, it shouldn't trigger a re-query), IFF we have already queried the logs for the given service. If the user uses the dropdown, or the log panel query errored, or failed, then we'll fall-back to running the queries twice on load of the service scene.
