### PR TITLE
Labels: Infinite loading state when detected_labels are empty on load

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -107,9 +107,18 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     const variable = this.getVariable();
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
 
+    console.log('serviceScene.state.labels', serviceScene.state.labels);
+
     // Need to update labels with current state
-    if (serviceScene.state.labels) {
+    if (serviceScene.state.labels?.length) {
       this.updateLabels(serviceScene.state.labels);
+    } else {
+      this.updateLabels(serviceScene.state.labels);
+      // If the labels aren't undefined, clear the loading state
+      this.setState({
+        loading: false,
+        error: true,
+      });
     }
 
     this._subs.add(serviceScene.subscribeToState(this.onServiceStateChange));

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -311,12 +311,8 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
       }
     );
 
-    if (!detectedLabels || !Array.isArray(detectedLabels)) {
-      return;
-    }
-
     const labels = detectedLabels
-      .sort((a, b) => sortLabelsByCardinality(a, b))
+      ?.sort((a, b) => sortLabelsByCardinality(a, b))
       .filter((label) => label.label !== LEVEL_VARIABLE_VALUE);
 
     if (JSON.stringify(labels) !== JSON.stringify(this.state.labels)) {

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -12,7 +12,7 @@ export type DetectedLabel = {
 };
 
 export type DetectedLabelsResponse = {
-  detectedLabels: DetectedLabel[];
+  detectedLabels?: DetectedLabel[];
 };
 
 interface ExtratedFields {

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -82,41 +82,19 @@ test.describe('explore services breakdown page', () => {
     }));
 
     await page.getByTestId(testIds.exploreServiceDetails.tabLabels).click();
-    expect(page.getByTestId('Spinner')).not.toBeVisible()
-    expect(page.getByText('The labels are not available at this moment.')).not.toBeVisible()
-    expect(page.getByTestId('data-testid Panel header cluster')).toBeVisible()
+    await expect(page.getByTestId('Spinner')).not.toBeVisible()
+    await expect(page.getByText('The labels are not available at this moment.')).not.toBeVisible()
+    await expect(page.getByTestId('data-testid Panel header cluster')).toBeVisible()
   })
 
   test('detected_labels that returns no labels should show empty state', async({page}) => {
     await page.route(/detected_labels/, (route) => route.fulfill({
       status: 200,
-      body: '[]'
+      body: '{}'
     }));
     await page.getByTestId(testIds.exploreServiceDetails.tabLabels).click();
-    expect(page.getByTestId('Spinner')).not.toBeVisible()
-    expect(page.getByText('The labels are not available at this moment.')).toBeVisible()
-
-    await page.route(/detected_labels/, (route) => route.fulfill({
-      status: 200,
-      body: JSON.stringify({
-        "detectedLabels": [
-          {
-            "label": "cluster",
-            "cardinality": 4
-          },
-          {
-            "label": "pod",
-            "cardinality": 40
-          }
-        ]
-      })
-    }));
-
-    await page.reload()
-    await page.getByTestId(testIds.exploreServiceDetails.tabLabels).click();
-    expect(page.getByTestId('Spinner')).not.toBeVisible()
-    expect(page.getByText('The labels are not available at this moment.')).not.toBeVisible()
-    expect(page.getByTestId('data-testid Panel header cluster')).toBeVisible()
+    await expect(page.getByTestId('Spinner')).not.toBeVisible()
+    await expect(page.getByText('The labels are not available at this moment.')).toBeVisible()
   })
 
   test('should select a label, update filters, open in explore', async ({ page }) => {


### PR DESCRIPTION
So this fix might want to wait until after we have updated the detected_labels API to return single cardinality values, right now we show single-cardinality fields in the UI if the user has selected a label that reduces the cardinality to 1, because we don't update the detected_labels state when the array is empty.