### PR TITLE
Variables: move variable lookup to getter functions

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -101,22 +101,13 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     }
 
     this.setState(stateUpdate);
-    const patternsVariable = getPatternsVariable(this);
-    if (patternsVariable) {
-      this.updatePatterns(this.state, patternsVariable);
-    }
 
-    const fieldsVariable = getFieldsVariable(this);
-    if (fieldsVariable) {
-      this.syncFieldsWithUrl(fieldsVariable);
-    }
+    this.updatePatterns(this.state, getPatternsVariable(this));
+    this.syncFieldsWithUrl(getFieldsVariable(this));
 
     this._subs.add(
       this.subscribeToState((newState) => {
-        const patternsVariable = getPatternsVariable(this);
-        if (patternsVariable) {
-          this.updatePatterns(newState, patternsVariable);
-        }
+        this.updatePatterns(newState, getPatternsVariable(this));
       })
     );
 

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -8,7 +8,6 @@ import {
   getUrlSyncManager,
   SceneComponentProps,
   SceneControlsSpacer,
-  sceneGraph,
   SceneObject,
   SceneObjectBase,
   SceneObjectState,
@@ -23,6 +22,8 @@ import {
 } from '@grafana/scenes';
 import {
   EXPLORATION_DS,
+  getFieldsVariable,
+  getPatternsVariable,
   VAR_DATASOURCE,
   VAR_FIELDS,
   VAR_LABELS,
@@ -100,20 +101,20 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     }
 
     this.setState(stateUpdate);
-    const patternsVariable = sceneGraph.lookupVariable(VAR_PATTERNS, this);
-    if (patternsVariable instanceof CustomVariable) {
+    const patternsVariable = getPatternsVariable(this);
+    if (patternsVariable) {
       this.updatePatterns(this.state, patternsVariable);
     }
 
-    const fieldsVariable = sceneGraph.lookupVariable(VAR_FIELDS, this);
-    if (fieldsVariable instanceof AdHocFiltersVariable) {
+    const fieldsVariable = getFieldsVariable(this);
+    if (fieldsVariable) {
       this.syncFieldsWithUrl(fieldsVariable);
     }
 
     this._subs.add(
       this.subscribeToState((newState) => {
-        const patternsVariable = sceneGraph.lookupVariable(VAR_PATTERNS, this);
-        if (patternsVariable instanceof CustomVariable) {
+        const patternsVariable = getPatternsVariable(this);
+        if (patternsVariable) {
           this.updatePatterns(newState, patternsVariable);
         }
       })

--- a/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
@@ -4,9 +4,8 @@ import { AdHocVariableFilter, DataFrame } from '@grafana/data';
 import { SceneObjectState, SceneObjectBase, SceneComponentProps, SceneObject, sceneGraph } from '@grafana/scenes';
 import { VariableHide } from '@grafana/schema';
 import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
-import { LEVEL_VARIABLE_VALUE, VAR_FIELDS, VAR_LABELS } from 'services/variables';
+import { getAdHocFiltersVariable, LEVEL_VARIABLE_VALUE, VAR_FIELDS, VAR_LABELS } from 'services/variables';
 import { FilterButton } from 'Components/FilterButton';
-import { getAdHocFiltersVariable } from 'services/scenes';
 import { FilterOp } from 'services/filters';
 import { ServiceScene } from '../ServiceScene';
 

--- a/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
@@ -39,9 +39,6 @@ export function addToFilters(
   }
 
   const variable = getAdHocFiltersVariable(validateVariableNameForField(key, variableName), scene);
-  if (!variable) {
-    return;
-  }
 
   // If the filter exists, filter it
   let filters = variable.state.filters.filter((filter) => {
@@ -110,9 +107,6 @@ export class AddToFiltersButton extends SceneObjectBase<AddToFiltersButtonState>
     }
 
     const variable = getAdHocFiltersVariable(validateVariableNameForField(filter.name, this.state.variableName), this);
-    if (!variable) {
-      return { isIncluded: false, isExcluded: false };
-    }
 
     // Check if the filter is already there
     const filterInSelectedFilters = variable.state.filters.find((f) => {

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -27,6 +27,7 @@ import { getQueryRunner, setLeverColorOverrides } from 'services/panel';
 import { buildLokiQuery } from 'services/query';
 import {
   ALL_VARIABLE_VALUE,
+  getFieldGroupByVariable,
   LOG_STREAM_SELECTOR_EXPR,
   VAR_FIELD_GROUP_BY,
   VAR_FIELDS,
@@ -126,11 +127,10 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
   }
 
   private getVariable(): CustomConstantVariable {
-    const variable = sceneGraph.lookupVariable(VAR_FIELD_GROUP_BY, this)!;
-    if (!(variable instanceof CustomConstantVariable)) {
+    const variable = getFieldGroupByVariable(this);
+    if (!variable) {
       throw new Error('Group by variable not found');
     }
-
     return variable;
   }
 

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -127,11 +127,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
   }
 
   private getVariable(): CustomConstantVariable {
-    const variable = getFieldGroupByVariable(this);
-    if (!variable) {
-      throw new Error('Group by variable not found');
-    }
-    return variable;
+    return getFieldGroupByVariable(this);
   }
 
   private hideField(field: string) {

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import { GrafanaTheme2, ReducerID } from '@grafana/data';
 import {
-  AdHocFiltersVariable,
   PanelBuilders,
   SceneComponentProps,
   SceneCSSGridItem,
@@ -151,12 +150,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
   };
 
   private getVariable(): CustomConstantVariable {
-    const variable = getLabelGroupByVariable(this);
-    if (!variable) {
-      throw new Error('Group by variable not found');
-    }
-
-    return variable;
+    return getLabelGroupByVariable(this);
   }
 
   private handleSortByChange = (event: SortCriteriaChanged) => {
@@ -353,29 +347,9 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     });
   }
 
-  public getLabelsVariable(): AdHocFiltersVariable {
-    const variable = getLabelsVariable(this);
-
-    if (!variable) {
-      throw new Error('Filters variable not found');
-    }
-
-    return variable;
-  }
-
-  public getFieldsVariable(): AdHocFiltersVariable {
-    const variable = getFieldsVariable(this);
-
-    if (!variable) {
-      throw new Error('Filters variable not found');
-    }
-
-    return variable;
-  }
-
   private getExpr(tagKey: string) {
-    const labelsVariable = this.getLabelsVariable();
-    const fieldsVariable = this.getFieldsVariable();
+    const labelsVariable = getLabelsVariable(this);
+    const fieldsVariable = getFieldsVariable(this);
 
     let labelExpressionToAdd;
     let fieldExpressionToAdd = '';

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -34,8 +34,10 @@ import {
   VAR_LINE_FILTER_EXPR,
   VAR_PATTERNS_EXPR,
   LEVEL_VARIABLE_VALUE,
-  VAR_FIELDS,
   VAR_LOGS_FORMAT_EXPR,
+  getLabelGroupByVariable,
+  getLabelsVariable,
+  getFieldsVariable,
 } from 'services/variables';
 import { ByFrameRepeater } from './ByFrameRepeater';
 import { FieldSelector } from './FieldSelector';
@@ -149,8 +151,8 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
   };
 
   private getVariable(): CustomConstantVariable {
-    const variable = sceneGraph.lookupVariable(VAR_LABEL_GROUP_BY, this)!;
-    if (!(variable instanceof CustomConstantVariable)) {
+    const variable = getLabelGroupByVariable(this);
+    if (!variable) {
       throw new Error('Group by variable not found');
     }
 
@@ -352,9 +354,9 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
   }
 
   public getLabelsVariable(): AdHocFiltersVariable {
-    const variable = sceneGraph.lookupVariable(VAR_LABELS, this)!;
+    const variable = getLabelsVariable(this);
 
-    if (!(variable instanceof AdHocFiltersVariable)) {
+    if (!variable) {
       throw new Error('Filters variable not found');
     }
 
@@ -362,9 +364,9 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
   }
 
   public getFieldsVariable(): AdHocFiltersVariable {
-    const variable = sceneGraph.lookupVariable(VAR_FIELDS, this)!;
+    const variable = getFieldsVariable(this);
 
-    if (!(variable instanceof AdHocFiltersVariable)) {
+    if (!variable) {
       throw new Error('Filters variable not found');
     }
 

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
@@ -155,10 +155,10 @@ function extractPatternIndices(pattern: string): number[] {
 }
 
 // Construct the query string based on pattern and other conditions
-function constructQuery(pattern: string, patternIndices: number[], filters: AdHocFiltersVariable | null): string {
+function constructQuery(pattern: string, patternIndices: number[], filters: AdHocFiltersVariable): string {
   let fieldIndex = 1;
   const patternExtractor = pattern.replace(/<_>/g, () => `<field_${fieldIndex++}>`);
-  const filterExpression = filters?.state.filterExpression ?? '';
+  const filterExpression = filters.state.filterExpression;
   const fields = patternIndices.map((_value, index) => `field_${index + 1}`).join(' ,');
   return `${filterExpression} |> \`${pattern}\` | pattern \`${patternExtractor}\` | keep ${fields} | line_format ""`;
 }

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
@@ -3,7 +3,7 @@ import { AdHocFiltersVariable, sceneGraph } from '@grafana/scenes';
 import { Spinner, Toggletip, useStyles2 } from '@grafana/ui';
 import { getLokiDatasource } from 'services/scenes';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
-import { VAR_LABELS } from 'services/variables';
+import { getLabelsVariable } from 'services/variables';
 import { buildLokiQuery } from 'services/query';
 import { PatternFieldLabelStats } from './PatternFieldLabelStats';
 import { GrafanaTheme2, LoadingState, LogLabelStatsModel, TimeRange } from '@grafana/data';
@@ -29,11 +29,7 @@ export const PatternNameLabel = ({ exploration, pattern }: PatternNameLabelProps
 
   const handlePatternClick = async () => {
     reportAppInteraction(USER_EVENTS_PAGES.service_details, USER_EVENTS_ACTIONS.service_details.pattern_field_clicked);
-    const query = constructQuery(
-      pattern,
-      patternIndices,
-      sceneGraph.lookupVariable(VAR_LABELS, exploration) as AdHocFiltersVariable
-    );
+    const query = constructQuery(pattern, patternIndices, getLabelsVariable(exploration));
     const datasource = await getLokiDatasource(exploration);
     const currentTimeRange = sceneGraph.getTimeRange(exploration).state.value;
 
@@ -159,10 +155,10 @@ function extractPatternIndices(pattern: string): number[] {
 }
 
 // Construct the query string based on pattern and other conditions
-function constructQuery(pattern: string, patternIndices: number[], filters: AdHocFiltersVariable): string {
+function constructQuery(pattern: string, patternIndices: number[], filters: AdHocFiltersVariable | null): string {
   let fieldIndex = 1;
   const patternExtractor = pattern.replace(/<_>/g, () => `<field_${fieldIndex++}>`);
-  const filterExpression = filters.state.filterExpression;
+  const filterExpression = filters?.state.filterExpression ?? '';
   const fields = patternIndices.map((_value, index) => `field_${index + 1}`).join(' ,');
   return `${filterExpression} |> \`${pattern}\` | pattern \`${patternExtractor}\` | keep ${fields} | line_format ""`;
 }

--- a/src/Components/ServiceScene/LineFilterScene.tsx
+++ b/src/Components/ServiceScene/LineFilterScene.tsx
@@ -21,7 +21,7 @@ export class LineFilterScene extends SceneObjectBase<LineFilterState> {
   }
 
   private onActivate = () => {
-    const lineFilterValue = this.getVariable().getValue();
+    const lineFilterValue = getLineFilterVariable(this).getValue();
     if (!lineFilterValue) {
       return;
     }
@@ -33,14 +33,6 @@ export class LineFilterScene extends SceneObjectBase<LineFilterState> {
       lineFilter: matches[1].replace(/\\(.)/g, '$1'),
     });
   };
-
-  private getVariable() {
-    const variable = getLineFilterVariable(this);
-    if (!variable) {
-      throw new Error('Logs format variable not found');
-    }
-    return variable;
-  }
 
   updateFilter(lineFilter: string) {
     this.setState({
@@ -54,7 +46,7 @@ export class LineFilterScene extends SceneObjectBase<LineFilterState> {
   };
 
   updateVariable = debounce((search: string) => {
-    const variable = this.getVariable();
+    const variable = getLineFilterVariable(this);
     variable.changeValueTo(`|~ \`(?i)${escapeRegExp(search)}\``);
     reportAppInteraction(
       USER_EVENTS_PAGES.service_details,

--- a/src/Components/ServiceScene/LineFilterScene.tsx
+++ b/src/Components/ServiceScene/LineFilterScene.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/css';
-import { CustomVariable, SceneComponentProps, SceneObjectBase, SceneObjectState, sceneGraph } from '@grafana/scenes';
+import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Field } from '@grafana/ui';
 import { debounce, escapeRegExp } from 'lodash';
 import React, { ChangeEvent } from 'react';
-import { VAR_LINE_FILTER } from 'services/variables';
+import { getLineFilterVariable } from 'services/variables';
 import { testIds } from 'services/testIds';
 import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 import { SearchInput } from './Breakdowns/SearchInput';
@@ -35,8 +35,8 @@ export class LineFilterScene extends SceneObjectBase<LineFilterState> {
   };
 
   private getVariable() {
-    const variable = sceneGraph.lookupVariable(VAR_LINE_FILTER, this);
-    if (!(variable instanceof CustomVariable)) {
+    const variable = getLineFilterVariable(this);
+    if (!variable) {
       throw new Error('Logs format variable not found');
     }
     return variable;

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -21,8 +21,7 @@ import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '..
 import { DataFrame } from '@grafana/data';
 import { addToFilters, FilterType } from './Breakdowns/AddToFiltersButton';
 import { getLabelTypeFromFrame, LabelType } from 'services/fields';
-import { VAR_FIELDS, VAR_LABELS } from 'services/variables';
-import { getAdHocFiltersVariable } from 'services/scenes';
+import { getAdHocFiltersVariable, VAR_FIELDS, VAR_LABELS } from 'services/variables';
 import { locationService } from '@grafana/runtime';
 import { LogOptionsScene } from './LogOptionsScene';
 import { getLogOption } from 'services/store';

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import { GrafanaTheme2, LoadingState } from '@grafana/data';
 import {
-  AdHocFiltersVariable,
   SceneComponentProps,
   SceneFlexItem,
   SceneFlexLayout,
@@ -97,18 +96,8 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     this.addActivationHandler(this.onActivate.bind(this));
   }
 
-  public getLabelsVariable(): AdHocFiltersVariable {
-    const variable = getLabelsVariable(this);
-
-    if (!variable) {
-      throw new Error('Filters variable not found');
-    }
-
-    return variable;
-  }
-
   private setEmptyFiltersRedirection() {
-    const variable = this.getLabelsVariable();
+    const variable = getLabelsVariable(this);
     if (variable.state.filters.length === 0) {
       this.redirectToStart();
       return;
@@ -179,7 +168,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
       return;
     }
 
-    const filterVariable = this.getLabelsVariable();
+    const filterVariable = getLabelsVariable(this);
     if (filterVariable.state.filters.length === 0) {
       return;
     }
@@ -247,11 +236,6 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     const timeRange = sceneGraph.getTimeRange(this).state.value;
     const labels = getLabelsVariable(this);
     const fields = getFieldsVariable(this);
-
-    if (!labels || !fields) {
-      console.error('Labels for fields variable missing');
-      return;
-    }
 
     const excludeLabels = [ALL_VARIABLE_VALUE, LEVEL_VARIABLE_VALUE];
 
@@ -466,7 +450,7 @@ export class LogsActionBar extends SceneObjectBase<LogsActionBarState> {
                     );
                     if (tab.value) {
                       const serviceScene = sceneGraph.getAncestor(model, ServiceScene);
-                      const variable = serviceScene.getLabelsVariable();
+                      const variable = getLabelsVariable(serviceScene);
                       const service = variable.state.filters.find((f) => f.key === SERVICE_NAME);
 
                       if (service?.value) {

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -275,11 +275,6 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     const timeRangeValue = timeRange.state.value;
     const filters = getLabelsVariable(this);
 
-    if (!filters) {
-      console.error('Filters variable not found');
-      return;
-    }
-
     const { detectedLabels } = await ds.getResource<DetectedLabelsResponse>(
       'detected_labels',
       {

--- a/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
+++ b/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import {
-  AdHocFiltersVariable,
   SceneComponentProps,
   SceneCSSGridItem,
   sceneGraph,
@@ -57,9 +56,6 @@ function setParserIfFrameExistsForService(service: string, sceneRef: SceneObject
 
 export function selectService(service: string, sceneRef: SceneObject) {
   const variable = getLabelsVariable(sceneRef);
-  if (!(variable instanceof AdHocFiltersVariable)) {
-    return;
-  }
 
   reportAppInteraction(USER_EVENTS_PAGES.service_selection, USER_EVENTS_ACTIONS.service_selection.service_selected, {
     service: service,
@@ -84,7 +80,7 @@ export function selectService(service: string, sceneRef: SceneObject) {
     ],
     hide: VariableHide.hideLabel,
   });
-  const ds = getDataSourceVariable(sceneRef)?.getValue();
+  const ds = getDataSourceVariable(sceneRef).getValue();
   addToFavoriteServicesInStorage(ds, service);
 
   // In this case, we don't have a ServiceScene created yet, so we call a special function to navigate there for the first time
@@ -93,8 +89,7 @@ export function selectService(service: string, sceneRef: SceneObject) {
 
 export class SelectServiceButton extends SceneObjectBase<SelectServiceButtonState> {
   public onClick = () => {
-    const variable = getLabelsVariable(this);
-    if (!variable || !this.state.service) {
+    if (!this.state.service) {
       return;
     }
     selectService(this.state.service, this);

--- a/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
+++ b/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
@@ -14,7 +14,7 @@ import {
 import { Button } from '@grafana/ui';
 import { VariableHide } from '@grafana/schema';
 import { addToFavoriteServicesInStorage } from 'services/store';
-import { VAR_DATASOURCE, VAR_LABELS } from 'services/variables';
+import { getDataSourceVariable, getLabelsVariable } from 'services/variables';
 import { SERVICE_NAME, ServiceSelectionScene } from './ServiceSelectionScene';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { FilterOp } from 'services/filters';
@@ -56,7 +56,7 @@ function setParserIfFrameExistsForService(service: string, sceneRef: SceneObject
 }
 
 export function selectService(service: string, sceneRef: SceneObject) {
-  const variable = sceneGraph.lookupVariable(VAR_LABELS, sceneRef);
+  const variable = getLabelsVariable(sceneRef);
   if (!(variable instanceof AdHocFiltersVariable)) {
     return;
   }
@@ -84,7 +84,7 @@ export function selectService(service: string, sceneRef: SceneObject) {
     ],
     hide: VariableHide.hideLabel,
   });
-  const ds = sceneGraph.lookupVariable(VAR_DATASOURCE, sceneRef)?.getValue();
+  const ds = getDataSourceVariable(sceneRef)?.getValue();
   addToFavoriteServicesInStorage(ds, service);
 
   // In this case, we don't have a ServiceScene created yet, so we call a special function to navigate there for the first time
@@ -93,12 +93,8 @@ export function selectService(service: string, sceneRef: SceneObject) {
 
 export class SelectServiceButton extends SceneObjectBase<SelectServiceButtonState> {
   public onClick = () => {
-    const variable = sceneGraph.lookupVariable(VAR_LABELS, this);
-    if (!(variable instanceof AdHocFiltersVariable)) {
-      return;
-    }
-
-    if (!this.state.service) {
+    const variable = getLabelsVariable(this);
+    if (!variable || !this.state.service) {
       return;
     }
     selectService(this.state.service, this);

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -3,7 +3,6 @@ import { debounce, escapeRegExp } from 'lodash';
 import React, { useState } from 'react';
 import { DashboardCursorSync, GrafanaTheme2, TimeRange } from '@grafana/data';
 import {
-  AdHocFiltersVariable,
   behaviors,
   PanelBuilders,
   SceneComponentProps,
@@ -28,7 +27,7 @@ import {
 } from '@grafana/ui';
 import { getLokiDatasource } from 'services/scenes';
 import { getFavoriteServicesFromStorage } from 'services/store';
-import { LEVEL_VARIABLE_VALUE, VAR_DATASOURCE, VAR_LABELS } from 'services/variables';
+import { getDataSourceVariable, getLabelsVariable, LEVEL_VARIABLE_VALUE, VAR_DATASOURCE } from 'services/variables';
 import { selectService, SelectServiceButton } from './SelectServiceButton';
 import { PLUGIN_ID } from 'services/routing';
 import { buildLokiQuery } from 'services/query';
@@ -96,8 +95,8 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
 
   private onActivate() {
     // Clear all adhoc filters when the scene is activated, if there are any
-    const variable = sceneGraph.lookupVariable(VAR_LABELS, this);
-    if (variable instanceof AdHocFiltersVariable && variable.state.filters.length > 0) {
+    const variable = getLabelsVariable(this);
+    if (variable && variable.state.filters.length > 0) {
       variable.setState({
         filters: [],
       });
@@ -115,7 +114,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       this.subscribeToState((newState, oldState) => {
         // Updates servicesToQuery when servicesByVolume is changed
         if (newState.servicesByVolume !== oldState.servicesByVolume) {
-          const ds = sceneGraph.lookupVariable(VAR_DATASOURCE, this)?.getValue()?.toString();
+          const ds = getDataSourceVariable(this)?.getValue()?.toString();
           let servicesToQuery: string[] = [];
           if (ds && newState.servicesByVolume) {
             servicesToQuery = createListOfServicesToQuery(
@@ -131,7 +130,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
 
         // Updates servicesToQuery when searchServicesString is changed
         if (newState.searchServicesString !== oldState.searchServicesString) {
-          const ds = sceneGraph.lookupVariable(VAR_DATASOURCE, this)?.getValue()?.toString();
+          const ds = getDataSourceVariable(this)?.getValue()?.toString();
           let servicesToQuery: string[] = [];
           if (ds && this.state.servicesByVolume) {
             servicesToQuery = createListOfServicesToQuery(

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -96,7 +96,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
   private onActivate() {
     // Clear all adhoc filters when the scene is activated, if there are any
     const variable = getLabelsVariable(this);
-    if (variable && variable.state.filters.length > 0) {
+    if (variable.state.filters.length > 0) {
       variable.setState({
         filters: [],
       });
@@ -114,7 +114,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       this.subscribeToState((newState, oldState) => {
         // Updates servicesToQuery when servicesByVolume is changed
         if (newState.servicesByVolume !== oldState.servicesByVolume) {
-          const ds = getDataSourceVariable(this)?.getValue()?.toString();
+          const ds = getDataSourceVariable(this).getValue()?.toString();
           let servicesToQuery: string[] = [];
           if (ds && newState.servicesByVolume) {
             servicesToQuery = createListOfServicesToQuery(
@@ -130,7 +130,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
 
         // Updates servicesToQuery when searchServicesString is changed
         if (newState.searchServicesString !== oldState.searchServicesString) {
-          const ds = getDataSourceVariable(this)?.getValue()?.toString();
+          const ds = getDataSourceVariable(this).getValue()?.toString();
           let servicesToQuery: string[] = [];
           if (ds && this.state.servicesByVolume) {
             servicesToQuery = createListOfServicesToQuery(

--- a/src/services/scenes.ts
+++ b/src/services/scenes.ts
@@ -1,12 +1,6 @@
 import { urlUtil } from '@grafana/data';
 import { DataSourceWithBackend, config, getDataSourceSrv } from '@grafana/runtime';
-import {
-  AdHocFiltersVariable,
-  getUrlSyncManager,
-  sceneGraph,
-  SceneObject,
-  SceneObjectUrlValues,
-} from '@grafana/scenes';
+import { getUrlSyncManager, sceneGraph, SceneObject, SceneObjectUrlValues } from '@grafana/scenes';
 import { VAR_DATASOURCE_EXPR, LOG_STREAM_SELECTOR_EXPR } from './variables';
 import { EXPLORATIONS_ROUTE } from './routing';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
@@ -41,22 +35,6 @@ export async function getLokiDatasource(sceneObject: SceneObject) {
     | DataSourceWithBackend
     | undefined;
   return ds;
-}
-
-export function getAdHocFiltersVariable(variableName: string, sceneObject: SceneObject) {
-  const variable = sceneGraph.lookupVariable(variableName, sceneObject);
-
-  if (!variable) {
-    console.warn(`Could not get AdHocFiltersVariable ${variableName}. Variable not found.`);
-    return null;
-  }
-  if (!(variable instanceof AdHocFiltersVariable)) {
-    console.warn(
-      `Could not get AdHocFiltersVariable ${variableName}. Variable is not an instance of AdHocFiltersVariable`
-    );
-    return null;
-  }
-  return variable;
 }
 
 export function isDefined<T>(value: T | null | undefined): value is T {

--- a/src/services/variables.ts
+++ b/src/services/variables.ts
@@ -1,3 +1,7 @@
+import { CustomVariable, DataSourceVariable, sceneGraph, SceneObject } from '@grafana/scenes';
+import { getAdHocFiltersVariable } from './scenes';
+import { CustomConstantVariable } from './CustomConstantVariable';
+
 export const VAR_LABELS = 'filters';
 export const VAR_LABELS_EXPR = '${filters}';
 export const VAR_FIELDS = 'fields';
@@ -17,3 +21,51 @@ export const EXPLORATION_DS = { uid: VAR_DATASOURCE_EXPR };
 export const ALL_VARIABLE_VALUE = '$__all';
 export const LEVEL_VARIABLE_VALUE = 'detected_level';
 export const PATTERNS_TEXT_FILTER = 'patternsFilter';
+
+export function getPatternsVariable(scene: SceneObject) {
+  const variable = sceneGraph.lookupVariable(VAR_PATTERNS, scene);
+  if (variable instanceof CustomVariable) {
+    return variable;
+  }
+  return null;
+}
+
+export function getLabelsVariable(scene: SceneObject) {
+  return getAdHocFiltersVariable(VAR_LABELS, scene);
+}
+
+export function getFieldsVariable(scene: SceneObject) {
+  return getAdHocFiltersVariable(VAR_FIELDS, scene);
+}
+
+export function getLineFilterVariable(scene: SceneObject) {
+  const variable = sceneGraph.lookupVariable(VAR_LINE_FILTER, scene);
+  if (variable instanceof CustomVariable) {
+    return variable;
+  }
+  return null;
+}
+
+export function getLabelGroupByVariable(scene: SceneObject) {
+  const variable = sceneGraph.lookupVariable(VAR_LABEL_GROUP_BY, scene);
+  if (variable instanceof CustomConstantVariable) {
+    return variable;
+  }
+  return null;
+}
+
+export function getFieldGroupByVariable(scene: SceneObject) {
+  const variable = sceneGraph.lookupVariable(VAR_FIELD_GROUP_BY, scene);
+  if (variable instanceof CustomConstantVariable) {
+    return variable;
+  }
+  return null;
+}
+
+export function getDataSourceVariable(scene: SceneObject) {
+  const variable = sceneGraph.lookupVariable(VAR_DATASOURCE, scene);
+  if (variable instanceof DataSourceVariable) {
+    return variable;
+  }
+  return null;
+}

--- a/src/services/variables.ts
+++ b/src/services/variables.ts
@@ -23,7 +23,7 @@ export const PATTERNS_TEXT_FILTER = 'patternsFilter';
 
 export function getPatternsVariable(scene: SceneObject) {
   const variable = sceneGraph.lookupVariable(VAR_PATTERNS, scene);
-  if (variable instanceof CustomVariable) {
+  if (!(variable instanceof CustomVariable)) {
     throw new Error('VAR_PATTERNS not found');
   }
   return variable;

--- a/src/services/variables.ts
+++ b/src/services/variables.ts
@@ -24,9 +24,9 @@ export const PATTERNS_TEXT_FILTER = 'patternsFilter';
 export function getPatternsVariable(scene: SceneObject) {
   const variable = sceneGraph.lookupVariable(VAR_PATTERNS, scene);
   if (variable instanceof CustomVariable) {
-    return variable;
+    throw new Error('VAR_PATTERNS not found');
   }
-  return null;
+  return variable;
 }
 
 export function getLabelsVariable(scene: SceneObject) {
@@ -39,48 +39,41 @@ export function getFieldsVariable(scene: SceneObject) {
 
 export function getLineFilterVariable(scene: SceneObject) {
   const variable = sceneGraph.lookupVariable(VAR_LINE_FILTER, scene);
-  if (variable instanceof CustomVariable) {
-    return variable;
+  if (!(variable instanceof CustomVariable)) {
+    throw new Error('VAR_LINE_FILTER not found');
   }
-  return null;
+  return variable;
 }
 
 export function getLabelGroupByVariable(scene: SceneObject) {
   const variable = sceneGraph.lookupVariable(VAR_LABEL_GROUP_BY, scene);
-  if (variable instanceof CustomConstantVariable) {
-    return variable;
+  if (!(variable instanceof CustomConstantVariable)) {
+    throw new Error('VAR_LABEL_GROUP_BY not found');
   }
-  return null;
+  return variable;
 }
 
 export function getFieldGroupByVariable(scene: SceneObject) {
   const variable = sceneGraph.lookupVariable(VAR_FIELD_GROUP_BY, scene);
-  if (variable instanceof CustomConstantVariable) {
-    return variable;
+  if (!(variable instanceof CustomConstantVariable)) {
+    throw new Error('VAR_FIELD_GROUP_BY not found');
   }
-  return null;
+  return variable;
 }
 
 export function getDataSourceVariable(scene: SceneObject) {
   const variable = sceneGraph.lookupVariable(VAR_DATASOURCE, scene);
-  if (variable instanceof DataSourceVariable) {
-    return variable;
+  if (!(variable instanceof DataSourceVariable)) {
+    throw new Error('VAR_DATASOURCE not found');
   }
-  return null;
+  return variable;
 }
 
-export function getAdHocFiltersVariable(variableName: string, sceneObject: SceneObject) {
-  const variable = sceneGraph.lookupVariable(variableName, sceneObject);
+export function getAdHocFiltersVariable(variableName: string, scene: SceneObject) {
+  const variable = sceneGraph.lookupVariable(variableName, scene);
 
-  if (!variable) {
-    console.warn(`Could not get AdHocFiltersVariable ${variableName}. Variable not found.`);
-    return null;
-  }
   if (!(variable instanceof AdHocFiltersVariable)) {
-    console.warn(
-      `Could not get AdHocFiltersVariable ${variableName}. Variable is not an instance of AdHocFiltersVariable`
-    );
-    return null;
+    throw new Error(`Could not get AdHocFiltersVariable ${variableName}. Variable not found.`);
   }
   return variable;
 }

--- a/src/services/variables.ts
+++ b/src/services/variables.ts
@@ -1,5 +1,4 @@
-import { CustomVariable, DataSourceVariable, sceneGraph, SceneObject } from '@grafana/scenes';
-import { getAdHocFiltersVariable } from './scenes';
+import { AdHocFiltersVariable, CustomVariable, DataSourceVariable, sceneGraph, SceneObject } from '@grafana/scenes';
 import { CustomConstantVariable } from './CustomConstantVariable';
 
 export const VAR_LABELS = 'filters';
@@ -68,4 +67,20 @@ export function getDataSourceVariable(scene: SceneObject) {
     return variable;
   }
   return null;
+}
+
+export function getAdHocFiltersVariable(variableName: string, sceneObject: SceneObject) {
+  const variable = sceneGraph.lookupVariable(variableName, sceneObject);
+
+  if (!variable) {
+    console.warn(`Could not get AdHocFiltersVariable ${variableName}. Variable not found.`);
+    return null;
+  }
+  if (!(variable instanceof AdHocFiltersVariable)) {
+    console.warn(
+      `Could not get AdHocFiltersVariable ${variableName}. Variable is not an instance of AdHocFiltersVariable`
+    );
+    return null;
+  }
+  return variable;
 }

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -1,7 +1,6 @@
 import {expect, test} from '@grafana/plugin-e2e';
 import {ExplorePage} from './fixtures/explore';
 import {testIds} from '../src/services/testIds';
-import {FilterOp} from '../src/services/filters';
 
 test.describe('explore services breakdown page', () => {
   let explorePage: ExplorePage;
@@ -93,7 +92,7 @@ test.describe('explore services breakdown page', () => {
     await expect(page.getByTestId(testIds.exploreServiceDetails.searchLogs)).toBeVisible();
     // Adhoc err filter should be added
     await expect(page.getByTestId('data-testid Dashboard template variables submenu Label err')).toBeVisible();
-    await expect(page.getByText(FilterOp.NotEqual)).toBeVisible();
+    await expect(page.getByText('!=')).toBeVisible();
   });
 
 


### PR DESCRIPTION
A significant portion of the codebase reads or writes to variables. Being a common task, we're now moving that code to specific functions.

This aims to decrease unnecessary duplication and leakage of implementation details between scenes (e.g. having to know the exact class when you're only interested in the value).