### PR TITLE
Logs Volume: track filtering interactions

### DIFF
--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -11,6 +11,7 @@ import {
   VAR_LEVELS,
 } from 'services/variables';
 import { addToFilters, replaceFilter } from './Breakdowns/AddToFiltersButton';
+import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 
 export interface LogsVolumePanelState extends SceneObjectState {
   panel?: VizPanel;
@@ -98,11 +99,23 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       const hadLevel = levelFilter.state.filters.find(
         (filter) => filter.key === LEVEL_VARIABLE_VALUE && filter.value !== level
       );
+      let action;
       if (hadLevel) {
         replaceFilter(LEVEL_VARIABLE_VALUE, level, 'include', this);
+        action = 'remove';
       } else {
         addToFilters(LEVEL_VARIABLE_VALUE, level, 'toggle', this);
+        action = 'add';
       }
+
+      reportAppInteraction(
+        USER_EVENTS_PAGES.service_details,
+        USER_EVENTS_ACTIONS.service_details.level_in_logs_volume_clicked,
+        {
+          level,
+          action,
+        }
+      );
     };
   };
 

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -40,6 +40,8 @@ export const USER_EVENTS_ACTIONS = {
     add_to_filters_in_breakdown_clicked: 'add_to_filters_in_breakdown_clicked',
     // Clicking on "Select" button button in time series panels. Used in multiple views.The view type is passed as a parameter. Props: field, previousField, view
     select_field_in_breakdown_clicked: 'select_field_in_breakdown_clicked',
+    // Clicking on one of the levels in the Logs Volume panel
+    level_in_logs_volume_clicked: 'level_in_logs_volume_clicked',
     // Changing layout type (e.g. single/grid/rows). Used in multiple views. The view type is passed as a parameter. Props: layout, view
     layout_type_changed: 'layout_type_changed',
     // Changing search string in logs. Props: searchQuery


### PR DESCRIPTION
Last week we added filtering support from Logs Volume, but we have no visibility on the usage of this feature.