### PR TITLE
Fields breakdown: Executing aggregation query twice

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -101,12 +101,14 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
   }
 
   private variableChanged = (newState: CustomConstantVariableState, oldState: CustomConstantVariableState) => {
-    if (
-      !areArraysEqual(newState.options, oldState.options) ||
-      newState.value !== oldState.value ||
-      newState.loading !== oldState.loading
-    ) {
+    if (!areArraysEqual(newState.options, oldState.options) || newState.value !== oldState.value) {
       this.updateBody(newState);
+    }
+
+    if (newState.loading !== oldState.loading) {
+      this.setState({
+        loading: newState.loading,
+      });
     }
   };
 

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -113,13 +113,15 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
    * @param oldState
    */
   private onVariableStateChange = (newState: CustomConstantVariableState, oldState: CustomConstantVariableState) => {
-    if (
-      !areArraysEqual(newState.options, oldState.options) ||
-      newState.value !== oldState.value ||
-      newState.loading !== oldState.loading
-    ) {
+    if (!areArraysEqual(newState.options, oldState.options) || newState.value !== oldState.value) {
       const variable = this.getVariable();
       this.updateBody(variable, newState);
+    }
+
+    if (newState.loading !== oldState.loading) {
+      this.setState({
+        loading: newState.loading,
+      });
     }
   };
 


### PR DESCRIPTION
This is running an extra query we don't want to run, and it causes the whole page to flicker.

To reproduce: You must navigate to the field label view, and then select any field value for the first time (the second query is not run on subsequent navigations when the scene is already cached).

Sometimes the first duplicate query is cancelled, sometimes not, but we always fire the query twice with the exact same query args on the first view of any field value breakdown.

The fix:
Don't call updateBody when the variable loading state changes, just set the loading state of the scene (or do nothing TODO)