### PR TITLE
Sorting: add outlier detection as a sorting option

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -466,3 +466,4 @@ inital
 lezer
 logql
 subqueries
+dbscan

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -31,7 +31,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
         {
           value: 'outliers',
           label: 'Detected outliers',
-          description: 'Order by detected outliers in the data',
+          description: 'Order by the amount of detected outliers in the data',
         },
         {
           value: ReducerID.stdDev,

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -29,6 +29,11 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
           description: 'Smart ordering of graphs based on the most significant spikes in the data',
         },
         {
+          value: 'outliers',
+          label: 'Detected outliers',
+          description: 'Order by detected outliers in the data',
+        },
+        {
           value: ReducerID.stdDev,
           label: 'Widest spread',
           description: 'Sort graphs by deviation from the average value',

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,9 +3,11 @@ import { App } from 'Components/App';
 import init from '@bsull/augurs';
 import { linkConfigs } from 'services/extensions/links';
 import { init as initRuntimeDs } from 'services/datasource';
+import { wasmSupported } from 'services/sorting';
 
-// eslint-disable-next-line no-console
-init().then(() => console.debug('Grafana ML initialized'));
+if (wasmSupported()) {
+  init();
+}
 
 export const plugin = new AppPlugin<{}>().setRootPage(App);
 

--- a/src/services/sorting.ts
+++ b/src/services/sorting.ts
@@ -1,5 +1,5 @@
-import { ChangepointDetector } from '@bsull/augurs';
-import { DataFrame, FieldType, ReducerID, doStandardCalcs, fieldReducers } from '@grafana/data';
+import { ChangepointDetector, OutlierDetector, OutlierOutput } from '@bsull/augurs';
+import { DataFrame, FieldType, ReducerID, doStandardCalcs, fieldReducers, outerJoinDataFrames } from '@grafana/data';
 import { getLabelValueFromDataFrame } from './levels';
 import { memoize } from 'lodash';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from './analytics';
@@ -8,19 +8,19 @@ export const sortSeries = memoize(
   (series: DataFrame[], sortBy: string, direction: string) => {
     if (sortBy === 'alphabetical') {
       return sortSeriesByName(series, direction);
-    } else if (sortBy === 'outlier') {
-      return sortSeriesByOutliers(series, direction);
+    }
+
+    if (sortBy === 'outliers') {
+      initOutlierDetector(series);
     }
 
     const reducer = (dataFrame: DataFrame) => {
       // ML & Wasm sorting options
       try {
         if (sortBy === 'changepoint') {
-          if (wasmSupported()) {
-            return calculateDataFrameChangepoints(dataFrame);
-          } else {
-            throw new Error('Changepoint not supported, using stdDev');
-          }
+          return calculateDataFrameChangepoints(dataFrame);
+        } else if (sortBy === 'outliers') {
+          return calculateOutlierValue(series, dataFrame);
         }
       } catch (e) {
         console.error(e);
@@ -66,6 +66,10 @@ export const sortSeries = memoize(
 );
 
 export const calculateDataFrameChangepoints = (data: DataFrame) => {
+  if (!wasmSupported()) {
+    throw new Error('WASM not supported, fall back to stdDev');
+  }
+
   const fields = data.fields.filter((f) => f.type === FieldType.number);
 
   const dataPoints = fields[0].values.length;
@@ -100,8 +104,46 @@ export const sortSeriesByName = (series: DataFrame[], direction: string) => {
   return sortedSeries;
 };
 
-export const sortSeriesByOutliers = (series: DataFrame[], direction: string) => {
-  return series;
+const initOutlierDetector = (series: DataFrame[]) => {
+  if (!wasmSupported()) {
+    return;
+  }
+
+  // Combine all frames into one by joining on time.
+  const joined = outerJoinDataFrames({ frames: series });
+  if (!joined) {
+    return;
+  }
+
+  // Get number fields: these are our series.
+  const joinedSeries = joined.fields.filter((f) => f.type === FieldType.number);
+  const nTimestamps = joinedSeries[0].values.length;
+  const points = new Float64Array(joinedSeries.flatMap((series) => series.values as number[]));
+
+  try {
+    const detector = OutlierDetector.dbscan({ sensitivity: 0.4 }).preprocess(points, nTimestamps);
+    outliers = detector.detect();
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+let outliers: OutlierOutput | undefined = undefined;
+
+export const calculateOutlierValue = (series: DataFrame[], data: DataFrame): number => {
+  if (!wasmSupported()) {
+    throw new Error('WASM not supported, fall back to stdDev');
+  }
+  if (!outliers) {
+    throw new Error('Initialize outlier detector first');
+  }
+
+  const index = series.indexOf(data);
+  if (outliers.seriesResults[index].isOutlier) {
+    return outliers.seriesResults[index].outlierIntervals.length;
+  }
+
+  return 0;
 };
 
 const wasmSupported = () => {

--- a/src/services/sorting.ts
+++ b/src/services/sorting.ts
@@ -25,7 +25,6 @@ export const sortSeries = memoize(
       } catch (e) {
         console.error(e);
         // ML sorting panicked, fallback to stdDev
-        reportAppInteraction(USER_EVENTS_PAGES.service_details, USER_EVENTS_ACTIONS.service_details.wasm_not_supported);
         sortBy = ReducerID.stdDev;
       }
       const fieldReducer = fieldReducers.get(sortBy);
@@ -147,5 +146,11 @@ export const calculateOutlierValue = (series: DataFrame[], data: DataFrame): num
 };
 
 const wasmSupported = () => {
-  return typeof WebAssembly === 'object';
+  const support = typeof WebAssembly === 'object';
+
+  if (!support) {
+    reportAppInteraction(USER_EVENTS_PAGES.service_details, USER_EVENTS_ACTIONS.service_details.wasm_not_supported);
+  }
+
+  return support;
 };

--- a/src/services/sorting.ts
+++ b/src/services/sorting.ts
@@ -145,7 +145,7 @@ export const calculateOutlierValue = (series: DataFrame[], data: DataFrame): num
   return 0;
 };
 
-const wasmSupported = () => {
+export const wasmSupported = () => {
   const support = typeof WebAssembly === 'object';
 
   if (!support) {


### PR DESCRIPTION
This PR adds outlier detection to sort value breakdowns. It works by using [DBSCAN](https://grafana.com/docs/grafana-cloud/alerting-and-irm/machine-learning/forecasts/outlier-detection/#select-the-detection-algorithm-and-sensitivity) to detect outlying intervals, and sorting by the detected quantity.

Addtionally, we're wrapping all the WASM invocations, logging the errors and falling back to StdDev when it happens.