### PR TITLE
Service selection scene: get service volume by partial or exact match

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -12,7 +12,7 @@ services:
         grafana_image: ${GRAFANA_IMAGE:-grafana}
         grafana_version: ${GRAFANA_VERSION:-latest}
     ports:
-      - 3000:3000/tcp
+      - 3001:3000/tcp
     volumes:
       - ./dist:/var/lib/grafana/plugins/grafana-logsapp
       - ./provisioning:/etc/grafana/provisioning

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig<PluginOptions>({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL: 'http://localhost:3001',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -88,7 +88,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
           }),
         ],
       }),
-      $data: getQueryRunner(buildResourceQuery(`{${SERVICE_NAME}=~\`${VAR_SERVICE_EXPR}.+\`}`, 'volume')),
+      $data: getQueryRunner(buildResourceQuery(`{${SERVICE_NAME}=~\`.*${VAR_SERVICE_EXPR}.*\`}`, 'volume')),
       serviceLevel: new Map<string, string[]>(),
       ...state,
     });

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -89,11 +89,12 @@ class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
     }
 
     const targetsInterpolated = ds.interpolateVariablesInQueries(request.targets, request.scopedVars);
+    const expression = targetsInterpolated[0].expr.replace('.*.*', '.+');
 
     const dsResponse = ds.getResource(
       'index/volume',
       {
-        query: targetsInterpolated[0].expr,
+        query: expression,
         from: request.range.from.utc().toISOString(),
         to: request.range.to.utc().toISOString(),
         limit: 1000,

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -28,6 +28,41 @@ test.describe('explore services page', () => {
     await expect(page.getByText('Showing 4 services')).toBeVisible();
   });
 
+  test('should filter service labels on exact search', async ({ page }) => {
+    await explorePage.servicesSearch.click();
+    await explorePage.servicesSearch.pressSequentially('mimir-ingester');
+    // service name should be in time series panel
+    await expect(page.getByTestId('data-testid Panel header mimir-ingester').nth(0)).toBeVisible();
+    // service name should also be in logs panel, just not visible to the user
+    await expect(page.getByTestId('data-testid Panel header mimir-ingester').nth(1)).toBeVisible();
+
+    // Exit out of the dropdown
+    await page.keyboard.press('Escape');
+    // The matched string should exist in the search dropdown
+    await expect(page.getByText('mimir-ingester').nth(0)).toBeVisible()
+    // And the panel title
+    await expect(page.getByText('mimir-ingester').nth(1)).toBeVisible()
+    // And the logs panel title should be hidden
+    await expect(page.getByText('mimir-ingester').nth(2)).not.toBeVisible()
+    await expect(page.getByText('Showing 1 service')).toBeVisible();
+  });
+
+  test('should filter service labels on partial string', async ({ page }) => {
+    await explorePage.servicesSearch.click();
+    await explorePage.servicesSearch.pressSequentially('imi');
+    // service name should be in time series panel
+    await expect(page.getByTestId('data-testid Panel header mimir-ingester').nth(0)).toBeVisible();
+    // service name should also be in logs panel, just not visible to the user
+    await expect(page.getByTestId('data-testid Panel header mimir-ingester').nth(1)).toBeVisible();
+
+    // Exit out of the dropdown
+    await page.keyboard.press('Escape');
+    // Only the first title is visible
+    await expect(page.getByText('mimir-ingester').nth(0)).toBeVisible()
+    await expect(page.getByText('mimir-ingester').nth(1)).not.toBeVisible()
+    await expect(page.getByText('Showing 4 services')).toBeVisible();
+  });
+
   test('should select a service label value and navigate to log view', async ({ page }) => {
     await explorePage.addServiceName();
     await expect(explorePage.logVolumeGraph).toBeVisible();


### PR DESCRIPTION
Fixes: https://github.com/grafana/explore-logs/issues/663


Note for reviewers: Needed to use `.*` instead of `.+`. `.+` requires additional chars of context to match. To get around the empty query being `.*.*` I added a replace in the runtime datasource after interpolation to replace `.*.*` with `.+`.

Also added some more e2e test coverage for these cases. 

Also updated the port of the grafana e2e instance because recently I started seeing my local grafana instance instead of the one in the docker container.