### PR TITLE
Breakdowns: Level, detected level, level_extracted, oh my!

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -45,7 +45,7 @@ import { getSortByPreference } from 'services/store';
 import { GrotError } from '../../GrotError';
 import { IndexScene } from '../../IndexScene/IndexScene';
 import { CustomConstantVariable, CustomConstantVariableState } from '../../../services/CustomConstantVariable';
-import { getLabelOptions } from '../../../services/filters';
+import { getFieldOptions } from '../../../services/filters';
 import { navigateToValueBreakdown } from '../../../services/navigate';
 import { ValueSlugs } from '../../../services/routing';
 import { areArraysEqual } from '../../../services/comparison';
@@ -118,7 +118,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
 
   private updateFields(state: ServiceSceneState) {
     const variable = this.getVariable();
-    const options = state.fields ? getLabelOptions(state.fields) : [];
+    const options = state.fields ? getFieldOptions(state.fields) : [];
 
     variable.setState({
       options,

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -240,7 +240,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       if (level === 'logs') {
         level = '';
       }
-      return `detected_level=\`${level}\``;
+      return `${LEVEL_VARIABLE_VALUE}=\`${level}\``;
     });
     return ` | ${filters.join(' or ')} `;
   };

--- a/src/services/filters.test.ts
+++ b/src/services/filters.test.ts
@@ -1,6 +1,6 @@
 import { SelectableValue } from '@grafana/data';
 import { DetectedLabel } from './fields';
-import { getLabelOptions, sortLabelsByCardinality } from './filters';
+import { getFieldOptions, getLabelOptions, sortLabelsByCardinality } from './filters';
 import { ALL_VARIABLE_VALUE, LEVEL_VARIABLE_VALUE } from './variables';
 
 describe('sortLabelsByCardinality', () => {
@@ -81,6 +81,17 @@ describe('getLabelOptions', () => {
     expect(getLabelOptions(labels)).toEqual(expectedOptions);
   });
 
+  it('should remove level if it is present in the list', () => {
+    const labels = [LEVEL_VARIABLE_VALUE, 'level', 'Label A'];
+    const expectedOptions: Array<SelectableValue<string>> = [
+      { label: 'All', value: ALL_VARIABLE_VALUE },
+      { label: LEVEL_VARIABLE_VALUE, value: LEVEL_VARIABLE_VALUE },
+      { label: 'Label A', value: 'Label A' },
+    ];
+
+    expect(getLabelOptions(labels)).toEqual(expectedOptions);
+  });
+
   it('should always add the All option at the beginning', () => {
     const labels = ['Label A', 'Label B'];
     const expectedOptions: Array<SelectableValue<string>> = [
@@ -101,5 +112,36 @@ describe('getLabelOptions', () => {
     ];
 
     expect(getLabelOptions(labels)).toEqual(expectedOptions);
+  });
+});
+
+describe('getFieldOptions', () => {
+  it('should remove level_extracted if it is present in the list', () => {
+    const labels = [LEVEL_VARIABLE_VALUE, 'level_extracted', 'Label A'];
+    const expectedOptions: Array<SelectableValue<string>> = [
+      { label: 'All', value: ALL_VARIABLE_VALUE },
+      { label: LEVEL_VARIABLE_VALUE, value: LEVEL_VARIABLE_VALUE },
+      { label: 'Label A', value: 'Label A' },
+    ];
+
+    expect(getFieldOptions(labels)).toEqual(expectedOptions);
+  });
+
+  it('should always add the All option at the beginning', () => {
+    const labels = ['Label A', 'Label B'];
+    const expectedOptions: Array<SelectableValue<string>> = [
+      { label: 'All', value: ALL_VARIABLE_VALUE },
+      { label: 'Label A', value: 'Label A' },
+      { label: 'Label B', value: 'Label B' },
+    ];
+
+    expect(getFieldOptions(labels)).toEqual(expectedOptions);
+  });
+
+  it('should work correctly with an empty label list', () => {
+    const labels: string[] = [];
+    const expectedOptions: Array<SelectableValue<string>> = [{ label: 'All', value: ALL_VARIABLE_VALUE }];
+
+    expect(getFieldOptions(labels)).toEqual(expectedOptions);
   });
 });

--- a/src/services/filters.ts
+++ b/src/services/filters.ts
@@ -33,6 +33,27 @@ export function getLabelOptions(labels: string[]) {
   if (!labels.includes(LEVEL_VARIABLE_VALUE)) {
     options.unshift(LEVEL_VARIABLE_VALUE);
   }
+  const labelsIndex = options.indexOf('level');
+  if (labelsIndex !== -1) {
+    options.splice(labelsIndex, 1);
+  }
+
+  const labelOptions: VariableValueOption[] = options.map((label) => ({
+    label,
+    value: String(label),
+  }));
+
+  return [{ label: 'All', value: ALL_VARIABLE_VALUE }, ...labelOptions];
+}
+
+export function getFieldOptions(labels: string[]) {
+  const options = [...labels];
+
+  const labelsIndex = options.indexOf('level_extracted');
+  if (labelsIndex !== -1) {
+    options.splice(labelsIndex, 1);
+  }
+
   const labelOptions: VariableValueOption[] = options.map((label) => ({
     label,
     value: String(label),

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -1,12 +1,7 @@
 import {expect, test} from '@grafana/plugin-e2e';
 import {ExplorePage} from './fixtures/explore';
 import {testIds} from '../src/services/testIds';
-import {mockVolumeApiResponse} from "./mocks/mockVolumeApiResponse";
 import {mockEmptyQueryApiResponse} from "./mocks/mockEmptyQueryApiResponse";
-import {LokiQuery} from "../src/services/query";
-import {DataQueryRequest} from "@grafana/data";
-import {DataQuery} from "@grafana/schema";
-import {LOGS_PANEL_QUERY_REFID} from "../src/Components/ServiceScene/ServiceScene";
 
 test.describe('explore services breakdown page', () => {
   let explorePage: ExplorePage;
@@ -130,7 +125,7 @@ test.describe('explore services breakdown page', () => {
     await page.getByTestId(testIds.exploreServiceDetails.tabFields).click();
 
     // Make sure the panels have started to render
-    await expect(page.getByTestId('data-testid Panel header detected_level')).toBeInViewport()
+    await expect(page.getByTestId('data-testid Panel header active_series')).toBeInViewport()
 
     // Fields on top should be loaded
     expect(requestCount).toEqual(6)
@@ -147,7 +142,7 @@ test.describe('explore services breakdown page', () => {
     await expect(page.getByTestId('data-testid Panel header detected_level')).not.toBeInViewport()
 
     // if this flakes we could just assert that it's greater then 3
-    expect(requestCount).toEqual(15)
+    expect(requestCount).toEqual(13)
 
     await page.unrouteAll();
   })


### PR DESCRIPTION
Fixes: https://github.com/grafana/explore-logs/issues/676

The same level panel shows up in several different places in the UI. Let's remove them all except the one that's pushed to the top of the label breakdown.