### PR TITLE
Logs volume: Fix active state of series based on the filter's state

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
@@ -74,9 +74,6 @@ export function replaceFilter(
     validateVariableNameForField(key, resolveVariableNameForField(key, scene)),
     scene
   );
-  if (!variable) {
-    return;
-  }
 
   variable.setState({
     filters: [

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -24,7 +24,7 @@ import {
 import { Alert, Button, DrawStyle, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafana/ui';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { getFilterBreakdownValueScene } from 'services/fields';
-import { getQueryRunner, setLeverColorOverrides } from 'services/panel';
+import { getQueryRunner, setLevelColorOverrides } from 'services/panel';
 import { buildDataQuery } from 'services/query';
 import {
   ALL_VARIABLE_VALUE,
@@ -298,7 +298,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
           .setCustomFieldConfig('lineWidth', 0)
           .setCustomFieldConfig('pointSize', 0)
           .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
-          .setOverrides(setLeverColorOverrides);
+          .setOverrides(setLevelColorOverrides);
       }
       const gridItem = new SceneCSSGridItem({
         body: body.build(),

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -21,7 +21,7 @@ import {
 import { Alert, Button, DrawStyle, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafana/ui';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { DetectedLabel, getFilterBreakdownValueScene } from 'services/fields';
-import { getQueryRunner, setLeverColorOverrides } from 'services/panel';
+import { getQueryRunner, setLevelColorOverrides } from 'services/panel';
 import { buildDataQuery } from 'services/query';
 import { ValueSlugs } from 'services/routing';
 import { getLokiDatasource } from 'services/scenes';
@@ -228,7 +228,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
             .setCustomFieldConfig('lineWidth', 0)
             .setCustomFieldConfig('pointSize', 0)
             .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
-            .setOverrides(setLeverColorOverrides)
+            .setOverrides(setLevelColorOverrides)
             .build(),
         })
       );
@@ -268,7 +268,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
       .setCustomFieldConfig('lineWidth', 0)
       .setCustomFieldConfig('pointSize', 0)
       .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
-      .setOverrides(setLeverColorOverrides)
+      .setOverrides(setLevelColorOverrides)
       .setTitle(tagKey);
 
     const body = bodyOpts.build();

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -83,6 +83,11 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
         levelFilter?.subscribeToState((newState, prevState) => {
           const oldLevel = prevState.filters.find((filter) => filter.operator === FilterOp.Equal);
           const newLevel = newState.filters.find((filter) => filter.operator === FilterOp.Equal);
+
+          if (oldLevel === newLevel) {
+            return;
+          }
+
           if (newLevel) {
             originalOnToggleSeriesVisibility?.(newLevel.value, SeriesVisibilityChangeMode.ToggleSelection);
           } else if (oldLevel) {

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -82,15 +82,24 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     if (levelFilter) {
       this._subs.add(
         levelFilter?.subscribeToState((newState, prevState) => {
-          const hadLevel = prevState.filters.find((filter) => filter.key === LEVEL_VARIABLE_VALUE);
-          const removedLevel = newState.filters.findIndex((filter) => filter.key === LEVEL_VARIABLE_VALUE) < 0;
-          if (hadLevel && removedLevel) {
-            originalOnToggleSeriesVisibility?.(hadLevel.value, SeriesVisibilityChangeMode.ToggleSelection);
-          }
-          const addedLevel = newState.filters.find((filter) => filter.key === LEVEL_VARIABLE_VALUE);
-          if (addedLevel) {
-            originalOnToggleSeriesVisibility?.(addedLevel.value, SeriesVisibilityChangeMode.ToggleSelection);
-          }
+          const prevLevels = prevState.filters
+            .filter((filter) => filter.operator === FilterOp.Equal)
+            .map((filter) => filter.value);
+          const newLevels = newState.filters
+            .filter((filter) => filter.operator === FilterOp.Equal)
+            .map((filter) => filter.value);
+          prevLevels.forEach((prevLevel) => {
+            if (!newLevels.includes(prevLevel)) {
+              // prevLevel was removed, toggle
+              originalOnToggleSeriesVisibility?.(prevLevel, SeriesVisibilityChangeMode.ToggleSelection);
+            }
+          });
+          newLevels.forEach((newLevel) => {
+            if (!prevLevels.includes(newLevel)) {
+              // newLevel is new, toggle
+              originalOnToggleSeriesVisibility?.(newLevel, SeriesVisibilityChangeMode.ToggleSelection);
+            }
+          });
         })
       );
     }

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -8,7 +8,7 @@ import { getLabelsVariable, getLevelsVariable, LEVEL_VARIABLE_VALUE } from 'serv
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { getTimeSeriesExpr } from '../../services/expressions';
 import { SERVICE_NAME } from '../ServiceSelectionScene/ServiceSelectionScene';
-import { getVisibleLevels, toggleLevelFromLogsVolume } from 'services/levels';
+import { getVisibleLevels, toggleLevelFromFilter } from 'services/levels';
 import { FilterOp } from 'services/filters';
 
 export interface LogsVolumePanelState extends SceneObjectState {
@@ -98,7 +98,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
         return;
       }
 
-      const action = toggleLevelFromLogsVolume(level, this);
+      const action = toggleLevelFromFilter(level, this);
 
       reportAppInteraction(
         USER_EVENTS_PAGES.service_details,

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -4,7 +4,7 @@ import { PanelBuilders, SceneComponentProps, SceneObjectBase, SceneObjectState, 
 import { DrawStyle, LegendDisplayMode, PanelContext, SeriesVisibilityChangeMode, StackingMode } from '@grafana/ui';
 import { getQueryRunner, setLevelSeriesOverrides, setLeverColorOverrides } from 'services/panel';
 import { buildDataQuery } from 'services/query';
-import { getAdHocFiltersVariable, getLabelsVariable, LEVEL_VARIABLE_VALUE, VAR_LEVELS } from 'services/variables';
+import { getLabelsVariable, getLevelsVariable, LEVEL_VARIABLE_VALUE } from 'services/variables';
 import { addToFilters, replaceFilter } from './Breakdowns/AddToFiltersButton';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { getTimeSeriesExpr } from '../../services/expressions';
@@ -78,7 +78,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   private extendTimeSeriesLegendBus = (context: PanelContext) => {
     const originalOnToggleSeriesVisibility = context.onToggleSeriesVisibility;
 
-    const levelFilter = getAdHocFiltersVariable(VAR_LEVELS, this);
+    const levelFilter = getLevelsVariable(this);
     if (levelFilter) {
       this._subs.add(
         levelFilter?.subscribeToState((newState, prevState) => {
@@ -110,7 +110,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
         return;
       }
 
-      const levelFilter = getAdHocFiltersVariable(VAR_LEVELS, this);
+      const levelFilter = getLevelsVariable(this);
       const empty = levelFilter.state.filters.length === 0;
       const filterExists = levelFilter.state.filters.find(
         (filter) => filter.value === level && filter.operator === FilterOp.Equal

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -82,24 +82,13 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     if (levelFilter) {
       this._subs.add(
         levelFilter?.subscribeToState((newState, prevState) => {
-          const prevLevels = prevState.filters
-            .filter((filter) => filter.operator === FilterOp.Equal)
-            .map((filter) => filter.value);
-          const newLevels = newState.filters
-            .filter((filter) => filter.operator === FilterOp.Equal)
-            .map((filter) => filter.value);
-          prevLevels.forEach((prevLevel) => {
-            if (!newLevels.includes(prevLevel)) {
-              // prevLevel was removed, toggle
-              originalOnToggleSeriesVisibility?.(prevLevel, SeriesVisibilityChangeMode.ToggleSelection);
-            }
-          });
-          newLevels.forEach((newLevel) => {
-            if (!prevLevels.includes(newLevel)) {
-              // newLevel is new, toggle
-              originalOnToggleSeriesVisibility?.(newLevel, SeriesVisibilityChangeMode.ToggleSelection);
-            }
-          });
+          const oldLevel = prevState.filters.find((filter) => filter.operator === FilterOp.Equal);
+          const newLevel = newState.filters.find((filter) => filter.operator === FilterOp.Equal);
+          if (newLevel) {
+            originalOnToggleSeriesVisibility?.(newLevel.value, SeriesVisibilityChangeMode.ToggleSelection);
+          } else if (oldLevel) {
+            originalOnToggleSeriesVisibility?.(oldLevel.value, SeriesVisibilityChangeMode.ToggleSelection);
+          }
         })
       );
     }

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -9,6 +9,7 @@ import { addToFilters, replaceFilter } from './Breakdowns/AddToFiltersButton';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { getTimeSeriesExpr } from '../../services/expressions';
 import { SERVICE_NAME } from '../ServiceSelectionScene/ServiceSelectionScene';
+import { getVisibleLevels } from 'services/levels';
 
 export interface LogsVolumePanelState extends SceneObjectState {
   panel?: VizPanel;
@@ -60,10 +61,9 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
       .setOverrides(setLeverColorOverrides);
 
-    const fieldFilters = getAdHocFiltersVariable(VAR_LEVELS, this);
-    const filteredLevels = fieldFilters?.state.filters.map((filter) => filter.value);
-    if (filteredLevels?.length) {
-      viz.setOverrides(setLevelSeriesOverrides.bind(null, filteredLevels));
+    const focusedLevels = getVisibleLevels(this);
+    if (focusedLevels?.length) {
+      viz.setOverrides(setLevelSeriesOverrides.bind(null, focusedLevels));
     }
 
     const panel = viz.build();
@@ -101,9 +101,6 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       }
 
       const levelFilter = getAdHocFiltersVariable(VAR_LEVELS, this);
-      if (!levelFilter) {
-        return;
-      }
       const hadLevel = levelFilter.state.filters.find(
         (filter) => filter.key === LEVEL_VARIABLE_VALUE && filter.value !== level
       );

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -10,6 +10,7 @@ import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'se
 import { getTimeSeriesExpr } from '../../services/expressions';
 import { SERVICE_NAME } from '../ServiceSelectionScene/ServiceSelectionScene';
 import { getVisibleLevels } from 'services/levels';
+import { FilterOp } from 'services/filters';
 
 export interface LogsVolumePanelState extends SceneObjectState {
   panel?: VizPanel;
@@ -101,16 +102,17 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       }
 
       const levelFilter = getAdHocFiltersVariable(VAR_LEVELS, this);
-      const hadLevel = levelFilter.state.filters.find(
-        (filter) => filter.key === LEVEL_VARIABLE_VALUE && filter.value !== level
+      const empty = levelFilter.state.filters.length === 0;
+      const filterExists = levelFilter.state.filters.find(
+        (filter) => filter.value === level && filter.operator === FilterOp.Equal
       );
       let action;
-      if (hadLevel) {
+      if (empty || !filterExists) {
         replaceFilter(LEVEL_VARIABLE_VALUE, level, 'include', this);
-        action = 'remove';
+        action = 'add';
       } else {
         addToFilters(LEVEL_VARIABLE_VALUE, level, 'toggle', this);
-        action = 'add';
+        action = 'remove';
       }
 
       reportAppInteraction(

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -5,11 +5,10 @@ import { DrawStyle, LegendDisplayMode, PanelContext, SeriesVisibilityChangeMode,
 import { getQueryRunner, setLevelSeriesOverrides, setLeverColorOverrides } from 'services/panel';
 import { buildDataQuery } from 'services/query';
 import { getLabelsVariable, getLevelsVariable, LEVEL_VARIABLE_VALUE } from 'services/variables';
-import { addToFilters, replaceFilter } from './Breakdowns/AddToFiltersButton';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { getTimeSeriesExpr } from '../../services/expressions';
 import { SERVICE_NAME } from '../ServiceSelectionScene/ServiceSelectionScene';
-import { getVisibleLevels } from 'services/levels';
+import { getVisibleLevels, toggleLevelFromLogsVolume } from 'services/levels';
 import { FilterOp } from 'services/filters';
 
 export interface LogsVolumePanelState extends SceneObjectState {
@@ -99,19 +98,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
         return;
       }
 
-      const levelFilter = getLevelsVariable(this);
-      const empty = levelFilter.state.filters.length === 0;
-      const filterExists = levelFilter.state.filters.find(
-        (filter) => filter.value === level && filter.operator === FilterOp.Equal
-      );
-      let action;
-      if (empty || !filterExists) {
-        replaceFilter(LEVEL_VARIABLE_VALUE, level, 'include', this);
-        action = 'add';
-      } else {
-        addToFilters(LEVEL_VARIABLE_VALUE, level, 'toggle', this);
-        action = 'remove';
-      }
+      const action = toggleLevelFromLogsVolume(level, this);
 
       reportAppInteraction(
         USER_EVENTS_PAGES.service_details,

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -37,7 +37,7 @@ import {
 import { selectService, SelectServiceButton } from './SelectServiceButton';
 import { buildDataQuery, buildResourceQuery } from 'services/query';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
-import { getQueryRunner, setLeverColorOverrides } from 'services/panel';
+import { getQueryRunner, setLevelColorOverrides } from 'services/panel';
 import { ConfigureVolumeError } from './ConfigureVolumeError';
 import { NoVolumeError } from './NoVolumeError';
 import { getLabelsFromSeries, toggleLevelVisibility } from 'services/levels';
@@ -211,7 +211,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       .setCustomFieldConfig('pointSize', 0)
       .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
       .setUnit('short')
-      .setOverrides(setLeverColorOverrides)
+      .setOverrides(setLevelColorOverrides)
       .setOption('legend', {
         showLegend: true,
         calcs: ['sum'],

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -40,7 +40,7 @@ import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'se
 import { getQueryRunner, setLeverColorOverrides } from 'services/panel';
 import { ConfigureVolumeError } from './ConfigureVolumeError';
 import { NoVolumeError } from './NoVolumeError';
-import { getLabelsFromSeries, toggleLevelFromFilter } from 'services/levels';
+import { getLabelsFromSeries, toggleLevelVisibility } from 'services/levels';
 import { ServiceFieldSelector } from '../ServiceScene/Breakdowns/FieldSelector';
 import { CustomConstantVariable } from '../../services/CustomConstantVariable';
 import { areArraysEqual } from '../../services/comparison';
@@ -180,7 +180,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       originalOnToggleSeriesVisibility?.(level, mode);
 
       const allLevels = getLabelsFromSeries(panel.state.$data?.state.data?.series ?? []);
-      const levels = toggleLevelFromFilter(level, this.state.serviceLevel.get(service), mode, allLevels);
+      const levels = toggleLevelVisibility(level, this.state.serviceLevel.get(service), mode, allLevels);
       this.state.serviceLevel.set(service, levels);
 
       this.updateServiceLogs(service);

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -4,7 +4,7 @@ import { PanelBuilders, SceneCSSGridItem, SceneDataNode, SceneObject } from '@gr
 import { getColorByIndex } from './scenes';
 import { AddToFiltersButton } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
 import { getLogsFormatVariable, VAR_FIELDS, VAR_LABELS } from './variables';
-import { setLeverColorOverrides } from './panel';
+import { setLevelColorOverrides } from './panel';
 
 export type DetectedLabel = {
   label: string;
@@ -61,7 +61,7 @@ export function getFilterBreakdownValueScene(
       .setTitle(getTitle(frame))
       .setData(new SceneDataNode({ data: { ...data, series: [frame] } }))
       .setColor({ mode: 'fixed', fixedColor: getColorByIndex(frameIndex) })
-      .setOverrides(setLeverColorOverrides)
+      .setOverrides(setLevelColorOverrides)
       .setHeaderActions(new AddToFiltersButton({ frame, variableName }));
 
     if (style === DrawStyle.Bars) {
@@ -70,7 +70,7 @@ export function getFilterBreakdownValueScene(
         .setCustomFieldConfig('fillOpacity', 100)
         .setCustomFieldConfig('lineWidth', 0)
         .setCustomFieldConfig('pointSize', 0)
-        .setOverrides(setLeverColorOverrides)
+        .setOverrides(setLevelColorOverrides)
         .setCustomFieldConfig('drawStyle', DrawStyle.Bars);
     }
     return new SceneCSSGridItem({

--- a/src/services/levels.test.ts
+++ b/src/services/levels.test.ts
@@ -110,12 +110,17 @@ describe('getVisibleLevels', () => {
     jest.mocked(getLevelsVariable).mockReturnValue(levelsVariable);
   }
 
-  it('Returns an empty array when the filter is empty', () => {
+  it('Returns an empty array when everything is empty', () => {
     setup([]);
-    expect(getVisibleLevels(scene)).toEqual([]);
+    expect(getVisibleLevels([], scene)).toEqual([]);
   });
 
-  it('Returns an empty array when the filters are negative', () => {
+  it('Returns all levels when there are no filters', () => {
+    setup([]);
+    expect(getVisibleLevels(['error', 'info'], scene)).toEqual(['error', 'info']);
+  });
+
+  it('Removes negatively filtered levels', () => {
     setup([
       {
         key: 'detected_level',
@@ -123,7 +128,7 @@ describe('getVisibleLevels', () => {
         value: 'error',
       },
     ]);
-    expect(getVisibleLevels(scene)).toEqual([]);
+    expect(getVisibleLevels(['error', 'info'], scene)).toEqual(['info']);
   });
 
   it('Returns the positive levels from the filters', () => {
@@ -144,7 +149,28 @@ describe('getVisibleLevels', () => {
         value: 'info',
       },
     ]);
-    expect(getVisibleLevels(scene)).toEqual(['info']);
+    expect(getVisibleLevels(['info'], scene)).toEqual(['info']);
+  });
+
+  it('Filters the levels by the current filters', () => {
+    setup([
+      {
+        key: 'detected_level',
+        operator: FilterOp.NotEqual,
+        value: 'error',
+      },
+      {
+        key: 'detected_level',
+        operator: FilterOp.NotEqual,
+        value: 'warn',
+      },
+      {
+        key: 'detected_level',
+        operator: FilterOp.Equal,
+        value: 'info',
+      },
+    ]);
+    expect(getVisibleLevels(['error', 'warn', 'info', 'debug'], scene)).toEqual(['info']);
   });
 });
 

--- a/src/services/levels.test.ts
+++ b/src/services/levels.test.ts
@@ -1,26 +1,26 @@
 import { SeriesVisibilityChangeMode } from '@grafana/ui';
-import { getLabelsFromSeries, toggleLevelFromFilter } from './levels';
+import { getLabelsFromSeries, toggleLevelVisibility } from './levels';
 import { FieldType, toDataFrame } from '@grafana/data';
 
 const ALL_LEVELS = ['logs', 'debug', 'info', 'warn', 'error', 'crit'];
 
-describe('toggleLevelFromFilter', () => {
+describe('toggleLevelVisibility', () => {
   describe('Visibility mode toggle selection', () => {
     it('adds the level', () => {
-      expect(toggleLevelFromFilter('error', [], SeriesVisibilityChangeMode.ToggleSelection, ALL_LEVELS)).toEqual([
+      expect(toggleLevelVisibility('error', [], SeriesVisibilityChangeMode.ToggleSelection, ALL_LEVELS)).toEqual([
         'error',
       ]);
-      expect(toggleLevelFromFilter('error', undefined, SeriesVisibilityChangeMode.ToggleSelection, ALL_LEVELS)).toEqual(
+      expect(toggleLevelVisibility('error', undefined, SeriesVisibilityChangeMode.ToggleSelection, ALL_LEVELS)).toEqual(
         ['error']
       );
     });
     it('adds the level if the filter was not empty', () => {
       expect(
-        toggleLevelFromFilter('error', ['info', 'debug'], SeriesVisibilityChangeMode.ToggleSelection, ALL_LEVELS)
+        toggleLevelVisibility('error', ['info', 'debug'], SeriesVisibilityChangeMode.ToggleSelection, ALL_LEVELS)
       ).toEqual(['error']);
     });
     it('removes the level if the filter contained only the same level', () => {
-      expect(toggleLevelFromFilter('error', ['error'], SeriesVisibilityChangeMode.ToggleSelection, ALL_LEVELS)).toEqual(
+      expect(toggleLevelVisibility('error', ['error'], SeriesVisibilityChangeMode.ToggleSelection, ALL_LEVELS)).toEqual(
         []
       );
     });
@@ -28,21 +28,21 @@ describe('toggleLevelFromFilter', () => {
   describe('Visibility mode append to selection', () => {
     it('appends the label to other levels', () => {
       expect(
-        toggleLevelFromFilter('error', ['info'], SeriesVisibilityChangeMode.AppendToSelection, ALL_LEVELS)
+        toggleLevelVisibility('error', ['info'], SeriesVisibilityChangeMode.AppendToSelection, ALL_LEVELS)
       ).toEqual(['info', 'error']);
     });
     it('removes the label if already present', () => {
       expect(
-        toggleLevelFromFilter('error', ['info', 'error'], SeriesVisibilityChangeMode.AppendToSelection, ALL_LEVELS)
+        toggleLevelVisibility('error', ['info', 'error'], SeriesVisibilityChangeMode.AppendToSelection, ALL_LEVELS)
       ).toEqual(['info']);
     });
     it('appends all levels except the provided level if the filter was previously empty', () => {
       const allButError = ALL_LEVELS.filter((level) => level !== 'error');
-      expect(toggleLevelFromFilter('error', [], SeriesVisibilityChangeMode.AppendToSelection, ALL_LEVELS)).toEqual(
+      expect(toggleLevelVisibility('error', [], SeriesVisibilityChangeMode.AppendToSelection, ALL_LEVELS)).toEqual(
         allButError
       );
       expect(
-        toggleLevelFromFilter('error', undefined, SeriesVisibilityChangeMode.AppendToSelection, ALL_LEVELS)
+        toggleLevelVisibility('error', undefined, SeriesVisibilityChangeMode.AppendToSelection, ALL_LEVELS)
       ).toEqual(allButError);
     });
   });

--- a/src/services/levels.ts
+++ b/src/services/levels.ts
@@ -1,5 +1,7 @@
 import { DataFrame } from '@grafana/data';
 import { SeriesVisibilityChangeMode } from '@grafana/ui';
+import { getAdHocFiltersVariable, VAR_LEVELS } from './variables';
+import { SceneObject } from '@grafana/scenes';
 
 export function toggleLevelFromFilter(
   level: string,
@@ -43,4 +45,13 @@ export function getLabelValueFromDataFrame(frame: DataFrame) {
   }
 
   return labels[keys[0]];
+}
+
+export function getVisibleLevels(sceneRef: SceneObject) {
+  const fieldFilters = getAdHocFiltersVariable(VAR_LEVELS, sceneRef);
+  const levels = fieldFilters.state.filters.map((filter) => filter.value);
+  const excludedLevels = fieldFilters.state.filters
+    .filter((filter) => filter.operator === '!=')
+    .map((filter) => filter.value);
+  return levels.filter((level) => !excludedLevels.includes(level));
 }

--- a/src/services/levels.ts
+++ b/src/services/levels.ts
@@ -58,7 +58,7 @@ export function getVisibleLevels(sceneRef: SceneObject) {
   return levels.filter((level) => !excludedLevels.includes(level));
 }
 
-export function toggleLevelFromLogsVolume(level: string, sceneRef: SceneObject) {
+export function toggleLevelFromFilter(level: string, sceneRef: SceneObject) {
   const levelFilter = getLevelsVariable(sceneRef);
   const empty = levelFilter.state.filters.length === 0;
   const filterExists = levelFilter.state.filters.find(

--- a/src/services/levels.ts
+++ b/src/services/levels.ts
@@ -5,7 +5,7 @@ import { SceneObject } from '@grafana/scenes';
 import { FilterOp } from './filters';
 import { addToFilters, replaceFilter } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
 
-export function toggleLevelFromFilter(
+export function toggleLevelVisibility(
   level: string,
   serviceLevels: string[] | undefined,
   mode: SeriesVisibilityChangeMode,

--- a/src/services/levels.ts
+++ b/src/services/levels.ts
@@ -5,14 +5,18 @@ import { SceneObject } from '@grafana/scenes';
 import { FilterOp } from './filters';
 import { addToFilters, replaceFilter } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
 
+/**
+ * Given a set of `visibleLevels` in a panel, it returns a list of the new visible levels
+ * after applying the visibility change in `mode`.
+ */
 export function toggleLevelVisibility(
   level: string,
-  serviceLevels: string[] | undefined,
+  visibleLevels: string[] | undefined,
   mode: SeriesVisibilityChangeMode,
   allLevels: string[]
 ) {
   if (mode === SeriesVisibilityChangeMode.ToggleSelection) {
-    const levels = serviceLevels ?? [];
+    const levels = visibleLevels ?? [];
     if (levels.length === 1 && levels.includes(level)) {
       return levels.filter((existingLevel) => existingLevel !== level);
     }
@@ -22,7 +26,7 @@ export function toggleLevelVisibility(
    * When the behavior is `AppendToSelection` and the filter is empty, we initialize it
    * with all levels because the user is excluding this level in their action.
    */
-  let levels = !serviceLevels?.length ? allLevels : serviceLevels;
+  let levels = !visibleLevels?.length ? allLevels : visibleLevels;
   if (levels.includes(level)) {
     return levels.filter((existingLevel) => existingLevel !== level);
   }
@@ -49,6 +53,10 @@ export function getLabelValueFromDataFrame(frame: DataFrame) {
   return labels[keys[0]];
 }
 
+/*
+ * From the current state of the levels filter, return the level names that
+ * the user wants to see.
+ */
 export function getVisibleLevels(sceneRef: SceneObject) {
   const fieldFilters = getAdHocFiltersVariable(VAR_LEVELS, sceneRef);
   const levels = fieldFilters.state.filters.map((filter) => filter.value);
@@ -58,6 +66,12 @@ export function getVisibleLevels(sceneRef: SceneObject) {
   return levels.filter((level) => !excludedLevels.includes(level));
 }
 
+/**
+ * Toggle a level from the filter state.
+ * If the filter is empty, it's added.
+ * If the filter exists but it's different, it's replaced.
+ * If the filter exists, it's removed.
+ */
 export function toggleLevelFromFilter(level: string, sceneRef: SceneObject) {
   const levelFilter = getLevelsVariable(sceneRef);
   const empty = levelFilter.state.filters.length === 0;

--- a/src/services/levels.ts
+++ b/src/services/levels.ts
@@ -1,6 +1,6 @@
 import { DataFrame } from '@grafana/data';
 import { SeriesVisibilityChangeMode } from '@grafana/ui';
-import { getAdHocFiltersVariable, getLevelsVariable, LEVEL_VARIABLE_VALUE, VAR_LEVELS } from './variables';
+import { getLevelsVariable, LEVEL_VARIABLE_VALUE } from './variables';
 import { SceneObject } from '@grafana/scenes';
 import { FilterOp } from './filters';
 import { addToFilters, replaceFilter } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
@@ -58,12 +58,10 @@ export function getLabelValueFromDataFrame(frame: DataFrame) {
  * the user wants to see.
  */
 export function getVisibleLevels(sceneRef: SceneObject) {
-  const fieldFilters = getAdHocFiltersVariable(VAR_LEVELS, sceneRef);
-  const levels = fieldFilters.state.filters.map((filter) => filter.value);
-  const excludedLevels = fieldFilters.state.filters
-    .filter((filter) => filter.operator === '!=')
+  const levelsFilter = getLevelsVariable(sceneRef);
+  return levelsFilter.state.filters
+    .filter((filter) => filter.operator === FilterOp.Equal)
     .map((filter) => filter.value);
-  return levels.filter((level) => !excludedLevels.includes(level));
 }
 
 /**

--- a/src/services/levels.ts
+++ b/src/services/levels.ts
@@ -18,7 +18,7 @@ export function toggleLevelVisibility(
   if (mode === SeriesVisibilityChangeMode.ToggleSelection) {
     const levels = visibleLevels ?? [];
     if (levels.length === 1 && levels.includes(level)) {
-      return levels.filter((existingLevel) => existingLevel !== level);
+      return [];
     }
     return [level];
   }
@@ -57,11 +57,20 @@ export function getLabelValueFromDataFrame(frame: DataFrame) {
  * From the current state of the levels filter, return the level names that
  * the user wants to see.
  */
-export function getVisibleLevels(sceneRef: SceneObject) {
+export function getVisibleLevels(allLevels: string[], sceneRef: SceneObject) {
   const levelsFilter = getLevelsVariable(sceneRef);
-  return levelsFilter.state.filters
+  const wantedLevels = levelsFilter.state.filters
     .filter((filter) => filter.operator === FilterOp.Equal)
     .map((filter) => filter.value);
+  const unwantedLevels = levelsFilter.state.filters
+    .filter((filter) => filter.operator === FilterOp.NotEqual)
+    .map((filter) => filter.value);
+  return allLevels.filter((level) => {
+    if (unwantedLevels.includes(level)) {
+      return false;
+    }
+    return wantedLevels.length === 0 || wantedLevels.includes(level);
+  });
 }
 
 /**

--- a/src/services/levels.ts
+++ b/src/services/levels.ts
@@ -1,7 +1,9 @@
 import { DataFrame } from '@grafana/data';
 import { SeriesVisibilityChangeMode } from '@grafana/ui';
-import { getAdHocFiltersVariable, VAR_LEVELS } from './variables';
+import { getAdHocFiltersVariable, getLevelsVariable, LEVEL_VARIABLE_VALUE, VAR_LEVELS } from './variables';
 import { SceneObject } from '@grafana/scenes';
+import { FilterOp } from './filters';
+import { addToFilters, replaceFilter } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
 
 export function toggleLevelFromFilter(
   level: string,
@@ -54,4 +56,22 @@ export function getVisibleLevels(sceneRef: SceneObject) {
     .filter((filter) => filter.operator === '!=')
     .map((filter) => filter.value);
   return levels.filter((level) => !excludedLevels.includes(level));
+}
+
+export function toggleLevelFromLogsVolume(level: string, sceneRef: SceneObject) {
+  const levelFilter = getLevelsVariable(sceneRef);
+  const empty = levelFilter.state.filters.length === 0;
+  const filterExists = levelFilter.state.filters.find(
+    (filter) => filter.value === level && filter.operator === FilterOp.Equal
+  );
+  let action;
+  if (empty || !filterExists) {
+    replaceFilter(LEVEL_VARIABLE_VALUE, level, 'include', sceneRef);
+    action = 'add';
+  } else {
+    addToFilters(LEVEL_VARIABLE_VALUE, level, 'toggle', sceneRef);
+    action = 'remove';
+  }
+
+  return action;
 }

--- a/src/services/panel.test.ts
+++ b/src/services/panel.test.ts
@@ -1,8 +1,8 @@
 import { FieldType, createDataFrame } from '@grafana/data';
-import { setLeverColorOverrides, sortLevelTransformation } from './panel';
+import { setLevelColorOverrides, sortLevelTransformation } from './panel';
 import { lastValueFrom, of } from 'rxjs';
 
-describe('setLeverColorOverrides', () => {
+describe('setLevelColorOverrides', () => {
   test('Sets the color overrides for log levels', () => {
     const overrideColorMock = jest.fn();
     const matchFieldsWithNameMock = jest.fn().mockImplementation(() => ({ overrideColor: overrideColorMock }));
@@ -11,7 +11,7 @@ describe('setLeverColorOverrides', () => {
       matchFieldsWithName: matchFieldsWithNameMock,
     };
     // @ts-expect-error
-    setLeverColorOverrides(overrides);
+    setLevelColorOverrides(overrides);
 
     expect(matchFieldsWithNameMock).toHaveBeenCalledTimes(5);
     expect(overrideColorMock).toHaveBeenCalledTimes(5);

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -14,7 +14,7 @@ import { LogsSceneQueryRunner } from './LogsSceneQueryRunner';
 import { DrawStyle, StackingMode } from '@grafana/ui';
 
 const UNKNOWN_LEVEL_LOGS = 'logs';
-export function setLeverColorOverrides(overrides: FieldConfigOverridesBuilder<FieldConfig>) {
+export function setLevelColorOverrides(overrides: FieldConfigOverridesBuilder<FieldConfig>) {
   overrides.matchFieldsWithName('info').overrideColor({
     mode: 'fixed',
     fixedColor: 'semi-dark-green',
@@ -46,7 +46,7 @@ export function setLogsVolumeFieldConfigs(
     .setCustomFieldConfig('lineWidth', 0)
     .setCustomFieldConfig('pointSize', 0)
     .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
-    .setOverrides(setLeverColorOverrides);
+    .setOverrides(setLevelColorOverrides);
 }
 
 interface TimeSeriesFieldConfig extends FieldConfig {

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -38,9 +38,9 @@ export function setLevelColorOverrides(overrides: FieldConfigOverridesBuilder<Fi
 }
 
 export function setLogsVolumeFieldConfigs(
-  viz: ReturnType<typeof PanelBuilders.timeseries> | ReturnType<typeof FieldConfigBuilders.timeseries>
+  builder: ReturnType<typeof PanelBuilders.timeseries> | ReturnType<typeof FieldConfigBuilders.timeseries>
 ) {
-  return viz
+  return builder
     .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
     .setCustomFieldConfig('fillOpacity', 100)
     .setCustomFieldConfig('lineWidth', 0)

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -1,10 +1,17 @@
 import { DataFrame, FieldConfig, FieldMatcherID } from '@grafana/data';
-import { FieldConfigOverridesBuilder, SceneDataTransformer, SceneQueryRunner } from '@grafana/scenes';
+import {
+  FieldConfigBuilders,
+  FieldConfigOverridesBuilder,
+  PanelBuilders,
+  SceneDataTransformer,
+  SceneQueryRunner,
+} from '@grafana/scenes';
 import { map, Observable } from 'rxjs';
 import { LokiQuery } from './query';
 import { HideSeriesConfig } from '@grafana/schema';
 import { WRAPPED_LOKI_DS_UID } from './datasource';
 import { LogsSceneQueryRunner } from './LogsSceneQueryRunner';
+import { DrawStyle, StackingMode } from '@grafana/ui';
 
 const UNKNOWN_LEVEL_LOGS = 'logs';
 export function setLeverColorOverrides(overrides: FieldConfigOverridesBuilder<FieldConfig>) {
@@ -30,9 +37,22 @@ export function setLeverColorOverrides(overrides: FieldConfigOverridesBuilder<Fi
   });
 }
 
+export function setLogsVolumeFieldConfigs(
+  viz: ReturnType<typeof PanelBuilders.timeseries> | ReturnType<typeof FieldConfigBuilders.timeseries>
+) {
+  return viz
+    .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
+    .setCustomFieldConfig('fillOpacity', 100)
+    .setCustomFieldConfig('lineWidth', 0)
+    .setCustomFieldConfig('pointSize', 0)
+    .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
+    .setOverrides(setLeverColorOverrides);
+}
+
 interface TimeSeriesFieldConfig extends FieldConfig {
   hideFrom: HideSeriesConfig;
 }
+
 export function setLevelSeriesOverrides(levels: string[], overrideConfig: FieldConfigOverridesBuilder<FieldConfig>) {
   overrideConfig
     .match({


### PR DESCRIPTION
Series visibility + filters state:

https://github.com/user-attachments/assets/e7f0bc6b-07c4-421e-9e0f-e90b3a9d0a01

Fixes https://github.com/grafana/explore-logs/issues/686

Extra/minor changes:
- Renamed functions for consistency with their purpose.
- Renamed variables for readability and consistency with their purpose.
- Fixed typo in function name.
- Used variable getters from variables.ts.
- Added comments to levels functions.