### PR TITLE
ServiceScene: prevent services with a mix of json and logfmt from request looping

### DIFF
--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -33,7 +33,6 @@ export function updateParserFromDataFrame(frame: DataFrame, sceneRef: SceneObjec
     newType = ` | ${res.type}`;
   }
 
-  // const newType = res.type ? ` | ${res.type}` : '';
   if (variable.getValue() !== newType) {
     variable.changeValueTo(newType);
   }

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -23,7 +23,15 @@ interface ExtractedFields {
 export function updateParserFromDataFrame(frame: DataFrame, sceneRef: SceneObject): ExtractedFields {
   const variable = getLogsFormatVariable(sceneRef);
   const res = extractParserAndFieldsFromDataFrame(frame);
-  const newType = res.type ? ` | ${res.type}` : '';
+
+  // Nested ternary?
+  const newType = res.type
+    ? res.type === 'json'
+      ? `| json  | logfmt | drop __error__, __error_details__`
+      : ` | ${res.type}`
+    : '';
+
+  // const newType = res.type ? ` | ${res.type}` : '';
   if (variable.getValue() !== newType) {
     variable.changeValueTo(newType);
   }

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -24,12 +24,14 @@ export function updateParserFromDataFrame(frame: DataFrame, sceneRef: SceneObjec
   const variable = getLogsFormatVariable(sceneRef);
   const res = extractParserAndFieldsFromDataFrame(frame);
 
-  // Nested ternary?
-  const newType = res.type
-    ? res.type === 'json'
-      ? `| json  | logfmt | drop __error__, __error_details__`
-      : ` | ${res.type}`
-    : '';
+  let newType;
+  if (!res.type) {
+    newType = '';
+  } else if (res.type === 'json') {
+    newType = `| json  | logfmt | drop __error__, __error_details__`;
+  } else {
+    newType = ` | ${res.type}`;
+  }
 
   // const newType = res.type ? ` | ${res.type}` : '';
   if (variable.getValue() !== newType) {


### PR DESCRIPTION
Fixes: https://github.com/grafana/explore-logs/issues/704

Note, this is a shorter-term solution, the implementation of detected_fields returns a parser for each field which can be used to better identify which parser to use.