### PR TITLE
Shard query splitting: Split queries by stream shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,6 @@ jobs:
             node_modules
           key: ${{ steps.restore-npm-cache.outputs.cache-primary-key }}
 
-      - name: Check types
-        run: yarn typecheck
-      - name: Lint
-        run: yarn lint
-      - name: Unit tests
-        run: yarn test:ci
       - name: Build frontend
         run: yarn build
       - name: Start grafana docker
@@ -63,9 +57,6 @@ jobs:
         run: npx playwright install chromium --with-deps
       - name: Wait for docker
         run: sleep 60
-      - name: Run e2e tests
-        id: run-tests
-        run: yarn e2e
       - name: Upload Playwright artifacts
         uses: actions/upload-artifact@v4
         if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
             node_modules
           key: ${{ steps.restore-npm-cache.outputs.cache-primary-key }}
 
+      - name: Check types
+        run: yarn typecheck
+      - name: Lint
+        run: yarn lint
+      - name: Unit tests
+        run: yarn test:ci
       - name: Build frontend
         run: yarn build
       - name: Start grafana docker
@@ -57,6 +63,9 @@ jobs:
         run: npx playwright install chromium --with-deps
       - name: Wait for docker
         run: sleep 60
+      - name: Run e2e tests
+        id: run-tests
+        run: yarn e2e
       - name: Upload Playwright artifacts
         uses: actions/upload-artifact@v4
         if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -5,7 +5,7 @@ services:
     container_name: 'grafana-logsapp'
     platform: 'linux/amd64'
     environment:
-      - GF_FEATURE_TOGGLES_ENABLE=accessControlOnCall lokiLogsDataplane exploreLogsShardSplitting
+      - GF_FEATURE_TOGGLES_ENABLE=accessControlOnCall lokiLogsDataplane
     build:
       context: ./.config
       args:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,17 @@
+import { Observable } from 'rxjs';
+
+type ObservableType<T> = T extends Observable<infer V> ? V : never;
+
+declare global {
+  namespace jest {
+    interface Matchers<R, T = {}> {
+      toEmitValues<E = ObservableType<T>>(expected: E[]): Promise<CustomMatcherResult>;
+      /**
+       * Collect all the values emitted by the observables (also errors) and pass them to the expectations functions after
+       * the observable ended (or emitted error). If Observable does not complete within OBSERVABLE_TEST_TIMEOUT_IN_MS the
+       * test fails.
+       */
+      toEmitValuesWith<E = ObservableType<T>>(expectations: (received: E[]) => void): Promise<CustomMatcherResult>;
+    }
+  }
+}

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -3,8 +3,14 @@ import { TextDecoder, TextEncoder } from 'util';
 
 import './.config/jest-setup';
 
+import { toEmitValuesWith } from './tests/matchers';
+
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
+
+expect.extend({
+  toEmitValuesWith,
+});
 
 // mock the intersection observer and just say everything is in view
 const mockIntersectionObserver = jest.fn().mockImplementation((callback) => ({

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/react-scroll-sync": "^0.9.0",
     "@types/react-table": "^7.7.20",
     "@types/testing-library__jest-dom": "5.14.8",
+    "@types/uuid": "^10.0.0",
     "copy-webpack-plugin": "^11.0.0",
     "cspell": "6.13.3",
     "css-loader": "^6.7.3",
@@ -96,7 +97,8 @@
     "react-dom": "18.2.0",
     "react-router-dom": "^5.2.0",
     "rxjs": "7.8.1",
-    "tslib": "2.5.3"
+    "tslib": "2.5.3",
+    "uuid": "^10.0.0"
   },
   "resolutions": {
     "**/fast-loops": "^1.1.4"

--- a/project-words.txt
+++ b/project-words.txt
@@ -482,6 +482,6 @@ frametype
 Nanos
 nanos
 subquery
-Subsciption
+Subscription
 uuidv
-wihtout
+without

--- a/project-words.txt
+++ b/project-words.txt
@@ -476,3 +476,12 @@ yass
 noparser
 whoopsie
 myproject
+becasue
+decbytes
+frametype
+Nanos
+nanos
+subquery
+Subsciption
+uuidv
+wihtout

--- a/project-words.txt
+++ b/project-words.txt
@@ -476,7 +476,6 @@ yass
 noparser
 whoopsie
 myproject
-becasue
 decbytes
 frametype
 Nanos

--- a/src/services/combineResponses.test.ts
+++ b/src/services/combineResponses.test.ts
@@ -1035,6 +1035,20 @@ describe('mergeFrames', () => {
       ],
     });
   });
+
+  it('merging exactly the same data produces the same data', () => {
+    const { logFrameA } = getMockFrames();
+
+    const responseA: DataQueryResponse = {
+      data: [logFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [logFrameA],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [logFrameA],
+    });
+  });
 });
 
 export function getMockFrames() {

--- a/src/services/combineResponses.test.ts
+++ b/src/services/combineResponses.test.ts
@@ -955,6 +955,86 @@ describe('mergeFrames', () => {
       ],
     });
   });
+
+  it('considers nanoseconds to merge the frames', () => {
+    const { logFrameA, logFrameB } = getMockFrames();
+
+    // Same timestamps but different nanos
+    logFrameA.fields[0].values = [1, 2];
+    logFrameA.fields[0].nanos = [333333, 444444];
+    logFrameB.fields[0].values = [1, 2];
+    logFrameB.fields[0].nanos = [222222, 333333];
+
+    const responseA: DataQueryResponse = {
+      data: [logFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [logFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [1, 1, 2, 2],
+              nanos: [222222, 333333, 333333, 444444],
+            },
+            {
+              config: {},
+              name: 'Line',
+              type: 'string',
+              values: ['line3', 'line1', 'line4', 'line2'],
+            },
+            {
+              config: {},
+              name: 'labels',
+              type: 'other',
+              values: [
+                {
+                  otherLabel: 'other value',
+                },
+                {
+                  label: 'value',
+                },
+                {
+                  otherLabel: 'other value',
+                },
+              ],
+            },
+            {
+              config: {},
+              name: 'tsNs',
+              type: 'string',
+              values: ['1000000', '3000000', '2000000', '4000000'],
+            },
+            {
+              config: {},
+              name: 'id',
+              type: 'string',
+              values: ['id3', 'id1', 'id4', 'id2'],
+            },
+          ],
+          length: 4,
+          meta: {
+            custom: {
+              frameType: 'LabeledTimeValues',
+            },
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+      ],
+    });
+  });
 });
 
 export function getMockFrames() {

--- a/src/services/combineResponses.test.ts
+++ b/src/services/combineResponses.test.ts
@@ -435,6 +435,81 @@ describe('combineResponses', () => {
     });
   });
 
+  it('combines frames wihtout nanoseconds with frames with nanoseconds', () => {
+    const { logFrameA, logFrameB } = getMockFrames();
+    logFrameA.fields[0].nanos = undefined;
+    logFrameB.fields[0].nanos = [111111, 222222];
+    const responseA: DataQueryResponse = {
+      data: [logFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [logFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [1, 2, 3, 4],
+              nanos: [111111, 222222, 0, 0],
+            },
+            {
+              config: {},
+              name: 'Line',
+              type: 'string',
+              values: ['line3', 'line4', 'line1', 'line2'],
+            },
+            {
+              config: {},
+              name: 'labels',
+              type: 'other',
+              values: [
+                {
+                  otherLabel: 'other value',
+                },
+                {
+                  label: 'value',
+                },
+                {
+                  otherLabel: 'other value',
+                },
+              ],
+            },
+            {
+              config: {},
+              name: 'tsNs',
+              type: 'string',
+              values: ['1000000', '2000000', '3000000', '4000000'],
+            },
+            {
+              config: {},
+              name: 'id',
+              type: 'string',
+              values: ['id3', 'id4', 'id1', 'id2'],
+            },
+          ],
+          length: 4,
+          meta: {
+            custom: {
+              frameType: 'LabeledTimeValues',
+            },
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
   describe('combine stats', () => {
     const { metricFrameA } = getMockFrames();
     const makeResponse = (stats?: QueryResultMetaStat[]): DataQueryResponse => ({

--- a/src/services/combineResponses.test.ts
+++ b/src/services/combineResponses.test.ts
@@ -1036,6 +1036,34 @@ describe('mergeFrames', () => {
     });
   });
 
+  it('correctly handles empty responses', () => {
+    const { emptyFrame, logFrameB } = getMockFrames();
+
+    logFrameB.fields[0].values = [1, 2];
+    logFrameB.fields[0].nanos = [222222, 333333];
+
+    const responseA: DataQueryResponse = {
+      data: [emptyFrame],
+    };
+    const responseB: DataQueryResponse = {
+      data: [logFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          ...logFrameB,
+          meta: {
+            custom: {
+              frameType: 'LabeledTimeValues',
+            },
+            stats: [{ displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 22 }],
+          },
+          length: 2,
+        },
+      ],
+    });
+  });
+
   it('merging exactly the same data produces the same data', () => {
     const { logFrameA } = getMockFrames();
 
@@ -1243,11 +1271,58 @@ export function getMockFrames() {
     length: 2,
   };
 
+  const emptyFrame: DataFrame = {
+    refId: 'A',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: [],
+      },
+      {
+        name: 'Line',
+        type: FieldType.string,
+        config: {},
+        values: [],
+      },
+      {
+        name: 'labels',
+        type: FieldType.other,
+        config: {},
+        values: [],
+      },
+      {
+        name: 'tsNs',
+        type: FieldType.string,
+        config: {},
+        values: [],
+      },
+      {
+        name: 'id',
+        type: FieldType.string,
+        config: {},
+        values: [],
+      },
+    ],
+    meta: {
+      custom: {
+        frameType: 'LabeledTimeValues',
+      },
+      stats: [
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 0 },
+        { displayName: 'Ingester: total reached', value: 0 },
+      ],
+    },
+    length: 2,
+  };
+
   return {
     logFrameA,
     logFrameB,
     metricFrameA,
     metricFrameB,
     metricFrameC,
+    emptyFrame,
   };
 }

--- a/src/services/combineResponses.test.ts
+++ b/src/services/combineResponses.test.ts
@@ -1,0 +1,1078 @@
+import { DataFrame, DataFrameType, DataQueryResponse, Field, FieldType, QueryResultMetaStat } from '@grafana/data';
+
+import { cloneQueryResponse, combineResponses } from './combineResponses';
+
+describe('cloneQueryResponse', () => {
+  const { logFrameA } = getMockFrames();
+  const responseA: DataQueryResponse = {
+    data: [logFrameA],
+  };
+  it('clones query responses', () => {
+    const clonedA = cloneQueryResponse(responseA);
+    expect(clonedA).not.toBe(responseA);
+    expect(clonedA).toEqual(clonedA);
+  });
+});
+
+describe('combineResponses', () => {
+  it('combines logs frames', () => {
+    const { logFrameA, logFrameB } = getMockFrames();
+    const responseA: DataQueryResponse = {
+      data: [logFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [logFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [1, 2, 3, 4],
+            },
+            {
+              config: {},
+              name: 'Line',
+              type: 'string',
+              values: ['line3', 'line4', 'line1', 'line2'],
+            },
+            {
+              config: {},
+              name: 'labels',
+              type: 'other',
+              values: [
+                {
+                  otherLabel: 'other value',
+                },
+                {
+                  label: 'value',
+                },
+                {
+                  otherLabel: 'other value',
+                },
+              ],
+            },
+            {
+              config: {},
+              name: 'tsNs',
+              type: 'string',
+              values: ['1000000', '2000000', '3000000', '4000000'],
+            },
+            {
+              config: {},
+              name: 'id',
+              type: 'string',
+              values: ['id3', 'id4', 'id1', 'id2'],
+            },
+          ],
+          length: 4,
+          meta: {
+            custom: {
+              frameType: 'LabeledTimeValues',
+            },
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
+  it('combines logs frames with transformed fields', () => {
+    const { logFrameA, logFrameB } = getMockFrames();
+    const { logFrameB: originalLogFrameB } = getMockFrames();
+
+    // Pseudo shuffle fields
+    logFrameB.fields.sort((a: Field, b: Field) => (a.name < b.name ? -1 : 1));
+    expect(logFrameB.fields).not.toEqual(originalLogFrameB.fields);
+
+    const responseA: DataQueryResponse = {
+      data: [logFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [logFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [1, 2, 3, 4],
+            },
+            {
+              config: {},
+              name: 'Line',
+              type: 'string',
+              values: ['line3', 'line4', 'line1', 'line2'],
+            },
+            {
+              config: {},
+              name: 'labels',
+              type: 'other',
+              values: [
+                {
+                  otherLabel: 'other value',
+                },
+                {
+                  label: 'value',
+                },
+                {
+                  otherLabel: 'other value',
+                },
+              ],
+            },
+            {
+              config: {},
+              name: 'tsNs',
+              type: 'string',
+              values: ['1000000', '2000000', '3000000', '4000000'],
+            },
+            {
+              config: {},
+              name: 'id',
+              type: 'string',
+              values: ['id3', 'id4', 'id1', 'id2'],
+            },
+          ],
+          length: 4,
+          meta: {
+            custom: {
+              frameType: 'LabeledTimeValues',
+            },
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
+  it('combines metric frames', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [1000000, 2000000, 3000000, 4000000],
+            },
+            {
+              config: {},
+              name: 'Value',
+              type: 'number',
+              values: [6, 7, 5, 4],
+              labels: {
+                level: 'debug',
+              },
+            },
+          ],
+          length: 4,
+          meta: {
+            type: 'timeseries-multi',
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
+  it('combines and identifies new frames in the response', () => {
+    const { metricFrameA, metricFrameB, metricFrameC } = getMockFrames();
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB, metricFrameC],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [1000000, 2000000, 3000000, 4000000],
+            },
+            {
+              config: {},
+              name: 'Value',
+              type: 'number',
+              values: [6, 7, 5, 4],
+              labels: {
+                level: 'debug',
+              },
+            },
+          ],
+          length: 4,
+          meta: {
+            type: 'timeseries-multi',
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+        metricFrameC,
+      ],
+    });
+  });
+
+  it('combines frames prioritizing refIds over names', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    const dataFrameA = {
+      ...metricFrameA,
+      refId: 'A',
+      name: 'A',
+    };
+    const dataFrameB = {
+      ...metricFrameB,
+      refId: 'B',
+      name: 'A',
+    };
+    const responseA: DataQueryResponse = {
+      data: [dataFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [dataFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [dataFrameA, dataFrameB],
+    });
+  });
+
+  it('combines frames in a new response instance', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+    };
+    expect(combineResponses(null, responseA)).not.toBe(responseA);
+    expect(combineResponses(null, responseB)).not.toBe(responseB);
+  });
+
+  it('combine when first param has errors', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    const errorA = {
+      message: 'errorA',
+    };
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+      error: errorA,
+      errors: [errorA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+    };
+
+    const combined = combineResponses(responseA, responseB);
+    expect(combined.data[0].length).toBe(4);
+    expect(combined.error?.message).toBe('errorA');
+    expect(combined.errors).toHaveLength(1);
+    expect(combined.errors?.[0]?.message).toBe('errorA');
+  });
+
+  it('combine when second param has errors', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+    };
+    const errorB = {
+      message: 'errorB',
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+      error: errorB,
+      errors: [errorB],
+    };
+
+    const combined = combineResponses(responseA, responseB);
+    expect(combined.data[0].length).toBe(4);
+    expect(combined.error?.message).toBe('errorB');
+    expect(combined.errors).toHaveLength(1);
+    expect(combined.errors?.[0]?.message).toBe('errorB');
+  });
+
+  it('combine when both params have errors', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    const errorA = {
+      message: 'errorA',
+    };
+    const errorB = {
+      message: 'errorB',
+    };
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+      error: errorA,
+      errors: [errorA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+      error: errorB,
+      errors: [errorB],
+    };
+
+    const combined = combineResponses(responseA, responseB);
+    expect(combined.data[0].length).toBe(4);
+    expect(combined.error?.message).toBe('errorA');
+    expect(combined.errors).toHaveLength(2);
+    expect(combined.errors?.[0]?.message).toBe('errorA');
+    expect(combined.errors?.[1]?.message).toBe('errorB');
+  });
+
+  it('combines frames with nanoseconds', () => {
+    const { logFrameA, logFrameB } = getMockFrames();
+    logFrameA.fields[0].nanos = [333333, 444444];
+    logFrameB.fields[0].nanos = [111111, 222222];
+    const responseA: DataQueryResponse = {
+      data: [logFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [logFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [1, 2, 3, 4],
+              nanos: [111111, 222222, 333333, 444444],
+            },
+            {
+              config: {},
+              name: 'Line',
+              type: 'string',
+              values: ['line3', 'line4', 'line1', 'line2'],
+            },
+            {
+              config: {},
+              name: 'labels',
+              type: 'other',
+              values: [
+                {
+                  otherLabel: 'other value',
+                },
+                {
+                  label: 'value',
+                },
+                {
+                  otherLabel: 'other value',
+                },
+              ],
+            },
+            {
+              config: {},
+              name: 'tsNs',
+              type: 'string',
+              values: ['1000000', '2000000', '3000000', '4000000'],
+            },
+            {
+              config: {},
+              name: 'id',
+              type: 'string',
+              values: ['id3', 'id4', 'id1', 'id2'],
+            },
+          ],
+          length: 4,
+          meta: {
+            custom: {
+              frameType: 'LabeledTimeValues',
+            },
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
+  describe('combine stats', () => {
+    const { metricFrameA } = getMockFrames();
+    const makeResponse = (stats?: QueryResultMetaStat[]): DataQueryResponse => ({
+      data: [
+        {
+          ...metricFrameA,
+          meta: {
+            ...metricFrameA.meta,
+            stats,
+          },
+        },
+      ],
+    });
+    it('two values', () => {
+      const responseA = makeResponse([
+        { displayName: 'Ingester: total reached', value: 1 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
+      ]);
+      const responseB = makeResponse([
+        { displayName: 'Ingester: total reached', value: 2 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 22 },
+      ]);
+
+      expect(combineResponses(responseA, responseB).data[0].meta.stats).toStrictEqual([
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 33 },
+      ]);
+    });
+
+    it('one value', () => {
+      const responseA = makeResponse([
+        { displayName: 'Ingester: total reached', value: 1 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
+      ]);
+      const responseB = makeResponse();
+
+      expect(combineResponses(responseA, responseB).data[0].meta.stats).toStrictEqual([
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
+      ]);
+
+      expect(combineResponses(responseB, responseA).data[0].meta.stats).toStrictEqual([
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
+      ]);
+    });
+
+    it('no value', () => {
+      const responseA = makeResponse();
+      const responseB = makeResponse();
+      expect(combineResponses(responseA, responseB).data[0].meta.stats).toHaveLength(0);
+    });
+  });
+
+  it('does not combine frames with different refId', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    metricFrameA.refId = 'A';
+    metricFrameB.refId = 'B';
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [metricFrameA, metricFrameB],
+    });
+  });
+
+  it('does not combine frames with different refId', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    metricFrameA.name = 'A';
+    metricFrameB.name = 'B';
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [metricFrameA, metricFrameB],
+    });
+  });
+
+  it('when fields with the same name are present, uses labels to find the right field to combine', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+
+    metricFrameA.fields.push({
+      name: 'Value',
+      type: FieldType.number,
+      config: {},
+      values: [9, 8],
+      labels: {
+        test: 'true',
+      },
+    });
+    metricFrameB.fields.push({
+      name: 'Value',
+      type: FieldType.number,
+      config: {},
+      values: [11, 10],
+      labels: {
+        test: 'true',
+      },
+    });
+
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+    };
+
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [1000000, 2000000, 3000000, 4000000],
+            },
+            {
+              config: {},
+              name: 'Value',
+              type: 'number',
+              values: [6, 7, 5, 4],
+              labels: {
+                level: 'debug',
+              },
+            },
+            {
+              config: {},
+              name: 'Value',
+              type: 'number',
+              values: [11, 10, 9, 8],
+              labels: {
+                test: 'true',
+              },
+            },
+          ],
+          length: 4,
+          meta: {
+            type: 'timeseries-multi',
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
+  it('when fields with the same name are present and labels are not present, falls back to indexes', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+
+    delete metricFrameA.fields[1].labels;
+    delete metricFrameB.fields[1].labels;
+
+    metricFrameA.fields.push({
+      name: 'Value',
+      type: FieldType.number,
+      config: {},
+      values: [9, 8],
+    });
+    metricFrameB.fields.push({
+      name: 'Value',
+      type: FieldType.number,
+      config: {},
+      values: [11, 10],
+    });
+
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+    };
+
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [1000000, 2000000, 3000000, 4000000],
+            },
+            {
+              config: {},
+              name: 'Value',
+              type: 'number',
+              values: [6, 7, 5, 4],
+            },
+            {
+              config: {},
+              name: 'Value',
+              type: 'number',
+              values: [11, 10, 9, 8],
+            },
+          ],
+          length: 4,
+          meta: {
+            type: 'timeseries-multi',
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+      ],
+    });
+  });
+});
+
+describe('mergeFrames', () => {
+  it('combines metric frames', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    const responseA: DataQueryResponse = {
+      data: [metricFrameB],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameA],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [1000000, 2000000, 3000000, 4000000],
+            },
+            {
+              config: {},
+              name: 'Value',
+              type: 'number',
+              values: [6, 7, 5, 4],
+              labels: {
+                level: 'debug',
+              },
+            },
+          ],
+          length: 4,
+          meta: {
+            type: 'timeseries-multi',
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
+  it('adds old to new values when combining', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+
+    metricFrameB.fields[0].values = [3000000, 3500000, 4000000];
+    metricFrameB.fields[1].values = [5, 10, 6];
+
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [3000000, 3500000, 4000000],
+            },
+            {
+              config: {},
+              name: 'Value',
+              type: 'number',
+              values: [10, 10, 10],
+              labels: {
+                level: 'debug',
+              },
+            },
+          ],
+          length: 4,
+          meta: {
+            type: 'timeseries-multi',
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
+  it('combines and identifies new frames in the response', () => {
+    const { metricFrameA, metricFrameB, metricFrameC } = getMockFrames();
+    const responseA: DataQueryResponse = {
+      data: [metricFrameB],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameA, metricFrameC],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [1000000, 2000000, 3000000, 4000000],
+            },
+            {
+              config: {},
+              name: 'Value',
+              type: 'number',
+              values: [6, 7, 5, 4],
+              labels: {
+                level: 'debug',
+              },
+            },
+          ],
+          length: 4,
+          meta: {
+            type: 'timeseries-multi',
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+        metricFrameC,
+      ],
+    });
+  });
+
+  it('merges logs frames', () => {
+    const { logFrameA, logFrameB } = getMockFrames();
+
+    // 3 overlaps with logFrameA
+    logFrameB.fields[0].values = [2, 3];
+
+    const responseA: DataQueryResponse = {
+      data: [logFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [logFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [2, 3, 4],
+            },
+            {
+              config: {},
+              name: 'Line',
+              type: 'string',
+              values: ['line3', 'line4', 'line2'],
+            },
+            {
+              config: {},
+              name: 'labels',
+              type: 'other',
+              values: [
+                {
+                  otherLabel: 'other value',
+                },
+                {
+                  label: 'value',
+                },
+                {
+                  otherLabel: 'other value',
+                },
+              ],
+            },
+            {
+              config: {},
+              name: 'tsNs',
+              type: 'string',
+              values: ['1000000', '2000000', '4000000'],
+            },
+            {
+              config: {},
+              name: 'id',
+              type: 'string',
+              values: ['id3', 'id4', 'id2'],
+            },
+          ],
+          length: 4,
+          meta: {
+            custom: {
+              frameType: 'LabeledTimeValues',
+            },
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+      ],
+    });
+  });
+});
+
+export function getMockFrames() {
+  const logFrameA: DataFrame = {
+    refId: 'A',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: [3, 4],
+      },
+      {
+        name: 'Line',
+        type: FieldType.string,
+        config: {},
+        values: ['line1', 'line2'],
+      },
+      {
+        name: 'labels',
+        type: FieldType.other,
+        config: {},
+        values: [
+          {
+            label: 'value',
+          },
+          {
+            otherLabel: 'other value',
+          },
+        ],
+      },
+      {
+        name: 'tsNs',
+        type: FieldType.string,
+        config: {},
+        values: ['3000000', '4000000'],
+      },
+      {
+        name: 'id',
+        type: FieldType.string,
+        config: {},
+        values: ['id1', 'id2'],
+      },
+    ],
+    meta: {
+      custom: {
+        frameType: 'LabeledTimeValues',
+      },
+      stats: [
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
+        { displayName: 'Ingester: total reached', value: 1 },
+      ],
+    },
+    length: 2,
+  };
+
+  const logFrameB: DataFrame = {
+    refId: 'A',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: [1, 2],
+      },
+      {
+        name: 'Line',
+        type: FieldType.string,
+        config: {},
+        values: ['line3', 'line4'],
+      },
+      {
+        name: 'labels',
+        type: FieldType.other,
+        config: {},
+        values: [
+          {
+            otherLabel: 'other value',
+          },
+        ],
+      },
+      {
+        name: 'tsNs',
+        type: FieldType.string,
+        config: {},
+        values: ['1000000', '2000000'],
+      },
+      {
+        name: 'id',
+        type: FieldType.string,
+        config: {},
+        values: ['id3', 'id4'],
+      },
+    ],
+    meta: {
+      custom: {
+        frameType: 'LabeledTimeValues',
+      },
+      stats: [
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 22 },
+        { displayName: 'Ingester: total reached', value: 2 },
+      ],
+    },
+    length: 2,
+  };
+
+  const metricFrameA: DataFrame = {
+    refId: 'A',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: [3000000, 4000000],
+      },
+      {
+        name: 'Value',
+        type: FieldType.number,
+        config: {},
+        values: [5, 4],
+        labels: {
+          level: 'debug',
+        },
+      },
+    ],
+    meta: {
+      type: DataFrameType.TimeSeriesMulti,
+      stats: [
+        { displayName: 'Ingester: total reached', value: 1 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
+      ],
+    },
+    length: 2,
+  };
+
+  const metricFrameB: DataFrame = {
+    refId: 'A',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: [1000000, 2000000],
+      },
+      {
+        name: 'Value',
+        type: FieldType.number,
+        config: {},
+        values: [6, 7],
+        labels: {
+          level: 'debug',
+        },
+      },
+    ],
+    meta: {
+      type: DataFrameType.TimeSeriesMulti,
+      stats: [
+        { displayName: 'Ingester: total reached', value: 2 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 22 },
+      ],
+    },
+    length: 2,
+  };
+
+  const metricFrameC: DataFrame = {
+    refId: 'A',
+    name: 'some-time-series',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: [3000000, 4000000],
+      },
+      {
+        name: 'Value',
+        type: FieldType.number,
+        config: {},
+        values: [6, 7],
+        labels: {
+          level: 'error',
+        },
+      },
+    ],
+    meta: {
+      type: DataFrameType.TimeSeriesMulti,
+      stats: [
+        { displayName: 'Ingester: total reached', value: 2 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 33 },
+      ],
+    },
+    length: 2,
+  };
+
+  return {
+    logFrameA,
+    logFrameB,
+    metricFrameA,
+    metricFrameB,
+    metricFrameC,
+  };
+}

--- a/src/services/combineResponses.test.ts
+++ b/src/services/combineResponses.test.ts
@@ -736,7 +736,7 @@ describe('mergeFrames', () => {
               },
             },
           ],
-          length: 4,
+          length: 3,
           meta: {
             type: 'timeseries-multi',
             stats: [
@@ -856,7 +856,88 @@ describe('mergeFrames', () => {
               values: ['id3', 'id4', 'id2'],
             },
           ],
-          length: 4,
+          length: 3,
+          meta: {
+            custom: {
+              frameType: 'LabeledTimeValues',
+            },
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
+  it('merges frames with nanoseconds', () => {
+    const { logFrameA, logFrameB } = getMockFrames();
+
+    logFrameA.fields[0].values = [3, 4];
+    logFrameA.fields[0].nanos = [333333, 444444];
+
+    // 3 overlaps with logFrameA
+    logFrameB.fields[0].values = [2, 3];
+    logFrameB.fields[0].nanos = [222222, 333333];
+
+    const responseA: DataQueryResponse = {
+      data: [logFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [logFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [2, 3, 4],
+              nanos: [222222, 333333, 444444],
+            },
+            {
+              config: {},
+              name: 'Line',
+              type: 'string',
+              values: ['line3', 'line4', 'line2'],
+            },
+            {
+              config: {},
+              name: 'labels',
+              type: 'other',
+              values: [
+                {
+                  otherLabel: 'other value',
+                },
+                {
+                  label: 'value',
+                },
+                {
+                  otherLabel: 'other value',
+                },
+              ],
+            },
+            {
+              config: {},
+              name: 'tsNs',
+              type: 'string',
+              values: ['1000000', '2000000', '4000000'],
+            },
+            {
+              config: {},
+              name: 'id',
+              type: 'string',
+              values: ['id3', 'id4', 'id2'],
+            },
+          ],
+          length: 3,
           meta: {
             custom: {
               frameType: 'LabeledTimeValues',

--- a/src/services/combineResponses.test.ts
+++ b/src/services/combineResponses.test.ts
@@ -333,7 +333,7 @@ describe('combineResponses', () => {
     expect(combined.errors?.[0]?.message).toBe('errorB');
   });
 
-  it('combine when both params have errors', () => {
+  it('combine when both frames have errors', () => {
     const { metricFrameA, metricFrameB } = getMockFrames();
     const errorA = {
       message: 'errorA',

--- a/src/services/combineResponses.test.ts
+++ b/src/services/combineResponses.test.ts
@@ -435,7 +435,7 @@ describe('combineResponses', () => {
     });
   });
 
-  it('combines frames wihtout nanoseconds with frames with nanoseconds', () => {
+  it('combines frames without nanoseconds with frames with nanoseconds', () => {
     const { logFrameA, logFrameB } = getMockFrames();
     logFrameA.fields[0].nanos = undefined;
     logFrameB.fields[0].nanos = [111111, 222222];

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -71,10 +71,6 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
     const destNanosValues = destTimeField.nanos?.slice(0);
     const destIdx = resolveIdx(destTimeField, sourceTimeField, i);
 
-    if (equalNsTimestamps(sourceTimeField, i, destTimeField, destIdx) === false) {
-      dest.length += 1;
-    }
-
     for (let f = 0; f < totalFields; f++) {
       // For now, skip undefined fields that exist in the new frame
       if (!dest.fields[f]) {
@@ -125,6 +121,8 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
       }
     }
   }
+
+  dest.length = dest.fields[0].values.length;
 
   dest.meta = {
     ...dest.meta,

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -119,7 +119,7 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
         // Insert in the `destIdx` position
         dest.fields[f].values.splice(destIdx, 0, sourceField.values[i]);
         if (sourceField.nanos) {
-          dest.fields[f].nanos = dest.fields[f].nanos ?? [];
+          dest.fields[f].nanos = dest.fields[f].nanos ?? new Array(dest.fields[f].values.length - 1).fill(0);
           dest.fields[f].nanos?.splice(destIdx, 0, sourceField.nanos[i]);
         }
       }

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -1,0 +1,203 @@
+import {
+  closestIdx,
+  DataFrame,
+  DataFrameType,
+  DataQueryResponse,
+  DataQueryResponseData,
+  Field,
+  FieldType,
+  QueryResultMetaStat,
+  shallowCompare,
+} from '@grafana/data';
+
+export function combineResponses(currentResult: DataQueryResponse | null, newResult: DataQueryResponse) {
+  if (!currentResult) {
+    return cloneQueryResponse(newResult);
+  }
+
+  newResult.data.forEach((newFrame) => {
+    const currentFrame = currentResult.data.find((frame) => shouldCombine(frame, newFrame));
+    if (!currentFrame) {
+      currentResult.data.push(cloneDataFrame(newFrame));
+      return;
+    }
+    mergeFrames(currentFrame, newFrame);
+  });
+
+  const mergedErrors = [...(currentResult.errors ?? []), ...(newResult.errors ?? [])];
+
+  // we make sure to have `.errors` as undefined, instead of empty-array
+  // when no errors.
+
+  if (mergedErrors.length > 0) {
+    currentResult.errors = mergedErrors;
+  }
+
+  // the `.error` attribute is obsolete now,
+  // but we have to maintain it, otherwise
+  // some grafana parts do not behave well.
+  // we just choose the old error, if it exists,
+  // otherwise the new error, if it exists.
+  const mergedError = currentResult.error ?? newResult.error;
+  if (mergedError != null) {
+    currentResult.error = mergedError;
+  }
+
+  const mergedTraceIds = [...(currentResult.traceIds ?? []), ...(newResult.traceIds ?? [])];
+  if (mergedTraceIds.length > 0) {
+    currentResult.traceIds = mergedTraceIds;
+  }
+
+  return currentResult;
+}
+
+/**
+ * Given two data frames, merge their values. Overlapping values will be added together.
+ */
+export function mergeFrames(dest: DataFrame, source: DataFrame) {
+  const destTimeField = dest.fields.find((field) => field.type === FieldType.time);
+  const sourceTimeValues = source.fields.find((field) => field.type === FieldType.time)?.values.slice(0) ?? [];
+  const totalFields = Math.max(dest.fields.length, source.fields.length);
+
+  for (let i = 0; i < sourceTimeValues.length; i++) {
+    const destTimeValues = destTimeField?.values.slice(0) ?? [];
+    const destIdx = resolveIdx(sourceTimeValues[i], destTimeValues);
+
+    for (let f = 0; f < totalFields; f++) {
+      // For now, skip undefined fields that exist in the new frame
+      if (!dest.fields[f]) {
+        continue;
+      }
+      // Index is not reliable when frames have disordered fields, or an extra/missing field, so we find them by name.
+      // If the field has no name, we fallback to the old index version.
+      const sourceField = findSourceField(dest.fields[f], source.fields, f);
+      if (!sourceField) {
+        continue;
+      }
+      // Same value, accumulate
+      if (sourceTimeValues[i] === destTimeValues[destIdx]) {
+        // Time already exists
+        if (dest.fields[f].type === FieldType.time) {
+          continue;
+        }
+        dest.fields[f].values[destIdx] = (dest.fields[f].values[destIdx] ?? 0) + sourceField.values[i];
+      } else {
+        dest.fields[f].values.splice(destIdx, 0, sourceField.values[i]);
+      }
+    }
+  }
+
+  dest.length += source.length;
+  dest.meta = {
+    ...dest.meta,
+    stats: getCombinedMetadataStats(dest.meta?.stats ?? [], source.meta?.stats ?? []),
+  };
+}
+
+function resolveIdx(timestamp: number, series: number[]) {
+  const idx = closestIdx(timestamp, series);
+  if (timestamp > series[idx]) {
+    return idx + 1;
+  }
+  return idx;
+}
+
+function findSourceField(referenceField: Field, sourceFields: Field[], index: number) {
+  const candidates = sourceFields.filter((f) => f.name === referenceField.name);
+
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+
+  if (referenceField.labels) {
+    return candidates.find((candidate) => shallowCompare(referenceField.labels ?? {}, candidate.labels ?? {}));
+  }
+
+  return sourceFields[index];
+}
+
+const TOTAL_BYTES_STAT = 'Summary: total bytes processed';
+// This is specific for Loki
+function getCombinedMetadataStats(
+  destStats: QueryResultMetaStat[],
+  sourceStats: QueryResultMetaStat[]
+): QueryResultMetaStat[] {
+  // in the current approach, we only handle a single stat
+  const destStat = destStats.find((s) => s.displayName === TOTAL_BYTES_STAT);
+  const sourceStat = sourceStats.find((s) => s.displayName === TOTAL_BYTES_STAT);
+
+  if (sourceStat != null && destStat != null) {
+    return [{ value: sourceStat.value + destStat.value, displayName: TOTAL_BYTES_STAT, unit: destStat.unit }];
+  }
+
+  // maybe one of them exist
+  const eitherStat = sourceStat ?? destStat;
+  if (eitherStat != null) {
+    return [eitherStat];
+  }
+
+  return [];
+}
+
+/**
+ * Deep clones a DataQueryResponse
+ */
+export function cloneQueryResponse(response: DataQueryResponse): DataQueryResponse {
+  const newResponse = {
+    ...response,
+    data: response.data.map(cloneDataFrame),
+  };
+  return newResponse;
+}
+
+function cloneDataFrame(frame: DataQueryResponseData): DataQueryResponseData {
+  return {
+    ...frame,
+    fields: frame.fields.map((field: Field) => ({
+      ...field,
+      values: field.values,
+    })),
+  };
+}
+
+function shouldCombine(frame1: DataFrame, frame2: DataFrame): boolean {
+  if (frame1.refId !== frame2.refId || frame1.name !== frame2.name) {
+    return false;
+  }
+
+  const frameType1 = frame1.meta?.type;
+  const frameType2 = frame2.meta?.type;
+
+  if (frameType1 !== frameType2) {
+    // we do not join things that have a different type
+    return false;
+  }
+
+  // metric range query data
+  if (frameType1 === DataFrameType.TimeSeriesMulti) {
+    const field1 = frame1.fields.find((f) => f.type === FieldType.number);
+    const field2 = frame2.fields.find((f) => f.type === FieldType.number);
+    if (field1 === undefined || field2 === undefined) {
+      // should never happen
+      return false;
+    }
+
+    return shallowCompare(field1.labels ?? {}, field2.labels ?? {});
+  }
+
+  // logs query data
+  // logs use a special attribute in the dataframe's "custom" section
+  // because we do not have a good "frametype" value for them yet.
+  const customType1 = frame1.meta?.custom?.frameType;
+  const customType2 = frame2.meta?.custom?.frameType;
+  // Legacy frames have this custom type
+  if (customType1 === 'LabeledTimeValues' && customType2 === 'LabeledTimeValues') {
+    return true;
+  } else if (customType1 === customType2) {
+    // Data plane frames don't
+    return true;
+  }
+
+  // should never reach here
+  return false;
+}

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -73,7 +73,7 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
     const destNanosValues = destTimeField.nanos?.slice(0);
     const destIdx = resolveIdx(destTimeField, sourceTimeField, i);
 
-    const entryExistsInDest = areEqual(
+    const entryExistsInDest = compareTimestamps(
       { ...destTimeField, values: destTimeValues, nanos: destNanosValues },
       destIdField,
       destIdx,
@@ -147,7 +147,7 @@ function resolveIdx(destField: Field, sourceField: Field, index: number) {
   return idx;
 }
 
-function areEqual(
+function compareTimestamps(
   destTimeField: Field,
   destIdField: Field | undefined,
   destIndex: number,
@@ -155,7 +155,7 @@ function areEqual(
   sourceIdField: Field | undefined,
   sourceIndex: number
 ) {
-  const sameTimestamp = equalNsTimestamps(destTimeField, destIndex, sourceTimeField, sourceIndex);
+  const sameTimestamp = compareNsTimestamps(destTimeField, destIndex, sourceTimeField, sourceIndex);
   if (!sameTimestamp) {
     return false;
   }
@@ -167,7 +167,7 @@ function areEqual(
   return destIdField.values[destIndex] === sourceIdField.values[sourceIndex];
 }
 
-function equalNsTimestamps(destField: Field, destIndex: number, sourceField: Field, sourceIndex: number) {
+function compareNsTimestamps(destField: Field, destIndex: number, sourceField: Field, sourceIndex: number) {
   if (!destField.nanos && !sourceField.nanos) {
     return destField.values[destIndex] === sourceField.values[sourceIndex];
   }

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -74,6 +74,10 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
       if (!sourceField) {
         continue;
       }
+      if (sourceField.nanos) {
+        dest.fields[f].nanos = dest.fields[f].nanos ?? [];
+        dest.fields[f].nanos?.splice(destIdx, 0, sourceField.nanos[i]);
+      }
       // Same value, accumulate
       if (sourceTimeValues[i] === destTimeValues[destIdx]) {
         if (dest.fields[f].type === FieldType.time) {
@@ -96,12 +100,10 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
           // Replace value
           dest.fields[f].values[destIdx] = sourceField.values[i];
         }
-      } else if (sourceField.values[i] !== undefined) {
+      } else {
         // Insert in the `destIdx` position
-        dest.fields[f].values.splice(destIdx, 0, sourceField.values[i]);
-        if (sourceField.nanos) {
-          dest.fields[f].nanos = dest.fields[f].nanos ?? [];
-          dest.fields[f].nanos?.splice(destIdx, 0, sourceField.nanos[i]);
+        if (sourceField.values[i] !== undefined) {
+          dest.fields[f].values.splice(destIdx, 0, sourceField.values[i]);
         }
       }
     }

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -168,16 +168,13 @@ function compareTimestamps(
 }
 
 function compareNsTimestamps(destField: Field, destIndex: number, sourceField: Field, sourceIndex: number) {
-  if (!destField.nanos && !sourceField.nanos) {
-    return destField.values[destIndex] === sourceField.values[sourceIndex];
-  }
   if (destField.nanos && sourceField.nanos) {
     return (
       destField.values[destIndex] === sourceField.values[sourceIndex] &&
       destField.nanos[destIndex] === sourceField.nanos[sourceIndex]
     );
   }
-  return false;
+  return destField.values[destIndex] === sourceField.values[sourceIndex];
 }
 
 function findSourceField(referenceField: Field, sourceFields: Field[], index: number) {

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -19,7 +19,7 @@ import { DetectedFieldsResponse, DetectedLabelsResponse } from './fields';
 import { FIELDS_TO_REMOVE, sortLabelsByCardinality } from './filters';
 import { LEVEL_VARIABLE_VALUE, SERVICE_NAME } from './variables';
 import { runShardSplitQuery } from './shardQuerySplitting';
-import { isLogsRequest } from './logql';
+import { requestSupportsSharding } from './logql';
 
 export const WRAPPED_LOKI_DS_UID = 'wrapped-loki-ds-uid';
 
@@ -137,7 +137,10 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
     const shardingEnabled = config.featureToggles.exploreLogsShardSplitting;
 
     // Query the datasource and return either observable or promise
-    const dsResponse = isLogsRequest(request) || !shardingEnabled ? ds.query(request) : runShardSplitQuery(ds, request);
+    const dsResponse =
+      requestSupportsSharding(request) === false || !shardingEnabled
+        ? ds.query(request)
+        : runShardSplitQuery(ds, request);
     dsResponse.subscribe(subscriber);
 
     return subscriber;

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -19,6 +19,7 @@ import { DetectedFieldsResponse, DetectedLabelsResponse } from './fields';
 import { FIELDS_TO_REMOVE, sortLabelsByCardinality } from './filters';
 import { LEVEL_VARIABLE_VALUE, SERVICE_NAME } from './variables';
 import { runShardSplitQuery } from './shardQuerySplitting';
+import { isLogsRequest } from './logql';
 
 export const WRAPPED_LOKI_DS_UID = 'wrapped-loki-ds-uid';
 
@@ -133,7 +134,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
     subscriber: Subscriber<DataQueryResponse>
   ) {
     // query the datasource and return either observable or promise
-    const dsResponse = runShardSplitQuery(ds, request);
+    const dsResponse = isLogsRequest(request) ? ds.query(request) : runShardSplitQuery(ds, request);
     dsResponse.subscribe(subscriber);
 
     return subscriber;

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -18,6 +18,7 @@ import { PLUGIN_ID } from './routing';
 import { DetectedFieldsResponse, DetectedLabelsResponse } from './fields';
 import { FIELDS_TO_REMOVE, sortLabelsByCardinality } from './filters';
 import { LEVEL_VARIABLE_VALUE, SERVICE_NAME } from './variables';
+import { runShardSplitQuery } from './shardQuerySplitting';
 
 export const WRAPPED_LOKI_DS_UID = 'wrapped-loki-ds-uid';
 
@@ -128,11 +129,11 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
 
   private getData(
     request: SceneDataQueryRequest,
-    ds: DataSourceWithBackend<DataQuery>,
+    ds: DataSourceWithBackend<LokiQuery>,
     subscriber: Subscriber<DataQueryResponse>
   ) {
     // query the datasource and return either observable or promise
-    const dsResponse = ds.query(request);
+    const dsResponse = runShardSplitQuery(ds, request);
     dsResponse.subscribe(subscriber);
 
     return subscriber;

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -8,7 +8,7 @@ import {
   LoadingState,
   TestDataSourceResponse,
 } from '@grafana/data';
-import { DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
+import { config, DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
 import { RuntimeDataSource, SceneObject, sceneUtils } from '@grafana/scenes';
 import { DataQuery } from '@grafana/schema';
 import { Observable, Subscriber } from 'rxjs';
@@ -133,8 +133,11 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
     ds: DataSourceWithBackend<LokiQuery>,
     subscriber: Subscriber<DataQueryResponse>
   ) {
-    // query the datasource and return either observable or promise
-    const dsResponse = isLogsRequest(request) ? ds.query(request) : runShardSplitQuery(ds, request);
+    // @ts-expect-error
+    const shardingEnabled = config.featureToggles.exploreLogsShardSplitting;
+
+    // Query the datasource and return either observable or promise
+    const dsResponse = isLogsRequest(request) || !shardingEnabled ? ds.query(request) : runShardSplitQuery(ds, request);
     dsResponse.subscribe(subscriber);
 
     return subscriber;

--- a/src/services/logql.ts
+++ b/src/services/logql.ts
@@ -4,6 +4,7 @@ import { Identifier, Matcher, MetricExpr, parser, Selector, String } from '@graf
 import { Filter, FilterOp } from './filters';
 import { LabelType } from './fields';
 import { LokiQuery } from './query';
+import { SceneDataQueryRequest } from './datasource';
 
 export class NodePosition {
   from: number;
@@ -110,6 +111,10 @@ export function isQueryWithNode(query: string, nodeType: number): boolean {
 export function isLogsQuery(query: string): boolean {
   // As a safeguard we are checking for a length of 2, because at least the query should be `{}`
   return query.trim().length > 2 && !isQueryWithNode(query, MetricExpr);
+}
+
+export function isLogsRequest(request: SceneDataQueryRequest) {
+  return request.targets.find((query) => isLogsQuery(query.expr)) !== undefined;
 }
 
 const SHARDING_PLACEHOLDER = '__stream_shard_number__';

--- a/src/services/logql.ts
+++ b/src/services/logql.ts
@@ -140,3 +140,20 @@ export const interpolateShardingSelector = (queries: LokiQuery[], shards?: numbe
     expr: query.expr.replace(new RegExp(`${SHARDING_PLACEHOLDER}`, 'g'), shardValue),
   }));
 };
+
+export const getServiceNameFromQuery = (query: string) => {
+  const matchers = getNodesFromQuery(query, [Matcher]);
+  for (let i = 0; i < matchers.length; i++) {
+    const idNode = matchers[i].getChild(Identifier);
+    const stringNode = matchers[i].getChild(String);
+    if (!idNode || !stringNode) {
+      continue;
+    }
+    const identifier = query.substring(idNode.from, idNode.to);
+    const value = query.substring(stringNode.from, stringNode.to);
+    if (identifier === 'service_name') {
+      return value;
+    }
+  }
+  return '';
+};

--- a/src/services/logql.ts
+++ b/src/services/logql.ts
@@ -117,6 +117,18 @@ export function isLogsRequest(request: SceneDataQueryRequest) {
   return request.targets.find((query) => isLogsQuery(query.expr)) !== undefined;
 }
 
+export function requestSupportsSharding(request: SceneDataQueryRequest) {
+  if (isLogsRequest(request)) {
+    return false;
+  }
+  for (let i = 0; i < request.targets.length; i++) {
+    if (request.targets[i].expr?.includes('avg_over_time')) {
+      return false;
+    }
+  }
+  return true;
+}
+
 const SHARDING_PLACEHOLDER = '__stream_shard_number__';
 export const addShardingPlaceholderSelector = (query: string) => {
   return query.replace('}', `, __stream_shard__=~"${SHARDING_PLACEHOLDER}"}`);

--- a/src/services/logql.ts
+++ b/src/services/logql.ts
@@ -130,13 +130,14 @@ export const interpolateShardingSelector = (queries: LokiQuery[], shards?: numbe
     }));
   }
 
-  const shardValue = shards[i].join('|');
+  let shardValue = shards[i].join('|');
 
   // -1 means empty shard value
-  if (shardValue === '-1') {
+  if (shardValue === '-1' || shards[i].length === 1) {
+    shardValue = shardValue === '-1' ? '' : shardValue;
     return queries.map((query) => ({
       ...query,
-      expr: query.expr.replace(`, __stream_shard__=~"${SHARDING_PLACEHOLDER}"}`, `, __stream_shard__=""}`),
+      expr: query.expr.replace(`, __stream_shard__=~"${SHARDING_PLACEHOLDER}"}`, `, __stream_shard__="${shardValue}"}`),
     }));
   }
 

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -16,6 +16,7 @@ export type LokiQuery = {
   legendFormat?: string;
   splitDuration?: string;
   datasource?: DataSourceRef;
+  maxLines?: number;
 };
 
 /**

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -1,0 +1,80 @@
+import { of } from 'rxjs';
+
+import { DataQueryRequest, dateTime } from '@grafana/data';
+
+import { runShardSplitQuery } from './shardQuerySplitting';
+import { DataSourceWithBackend } from '@grafana/runtime';
+
+import { LokiQuery } from './query';
+
+jest.mock('uuid', () => ({
+  v4: jest.fn().mockReturnValue('uuid'),
+}));
+
+describe('runShardSplitQuery()', () => {
+  let datasource: DataSourceWithBackend<LokiQuery>;
+  const range = {
+    from: dateTime('2023-02-08T05:00:00.000Z'),
+    to: dateTime('2023-02-10T06:00:00.000Z'),
+    raw: {
+      from: dateTime('2023-02-08T05:00:00.000Z'),
+      to: dateTime('2023-02-10T06:00:00.000Z'),
+    },
+  };
+
+  const createRequest = (targets: Array<Partial<LokiQuery>>, overrides?: Partial<DataQueryRequest<LokiQuery>>) => {
+    const request = {
+      range,
+      targets,
+      intervalMs: 60000,
+      requestId: 'TEST',
+    } as DataQueryRequest<LokiQuery>;
+
+    Object.assign(request, overrides);
+    return request;
+  };
+  const request = createRequest([{ expr: 'count_over_time($SELECTOR[1m])', refId: 'A' }]);
+  beforeEach(() => {
+    datasource = createLokiDatasource();
+    datasource.languageProvider.fetchLabelValues.mockResolvedValue(['1', '10', '2', '20', '3']);
+    // @ts-expect-error
+    jest.spyOn(datasource, 'runQuery').mockReturnValue(of({ data: [] }));
+  });
+
+  test('Interpolates queries before running', async () => {
+    await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith(() => {
+      expect(datasource.interpolateVariablesInQueries).toHaveBeenCalledTimes(1);
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledWith({
+        intervalMs: expect.any(Number),
+        range: expect.any(Object),
+        requestId: 'TEST_shard_0',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"20|10"}[1m])', refId: 'A' }],
+      });
+    });
+  });
+
+  test('Splits datasource queries', async () => {
+    await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith(() => {
+      // 5 shards, 3 groups + empty shard group, 4 requests
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledTimes(4);
+    });
+  });
+});
+
+function createLokiDatasource() {
+  return {
+    query: jest.fn(),
+    runQuery: jest.fn(),
+    interpolateVariablesInQueries: jest.fn().mockImplementation((queries: LokiQuery[]) => {
+      return queries.map((query) => {
+        query.expr = query.expr.replace('$SELECTOR', '{a="b"}');
+        return query;
+      });
+    }),
+    languageProvider: {
+      fetchLabelValues: jest.fn(),
+    },
+  } as unknown as DataSourceWithBackend<LokiQuery>;
+}

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -1,6 +1,6 @@
 import { of } from 'rxjs';
 
-import { DataQueryRequest, dateTime } from '@grafana/data';
+import { DataQueryRequest, DataQueryResponse, dateTime, LoadingState } from '@grafana/data';
 
 import { runShardSplitQuery } from './shardQuerySplitting';
 import { DataSourceWithBackend } from '@grafana/runtime';
@@ -10,6 +10,17 @@ import { LokiQuery } from './query';
 jest.mock('uuid', () => ({
   v4: jest.fn().mockReturnValue('uuid'),
 }));
+
+const originalLog = console.log;
+const originalWarn = console.warn;
+beforeAll(() => {
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterAll(() => {
+  console.log = originalLog;
+  console.warn = originalWarn;
+});
 
 describe('runShardSplitQuery()', () => {
   let datasource: DataSourceWithBackend<LokiQuery>;
@@ -39,6 +50,15 @@ describe('runShardSplitQuery()', () => {
     datasource.languageProvider.fetchLabelValues.mockResolvedValue(['1', '10', '2', '20', '3']);
     // @ts-expect-error
     jest.spyOn(datasource, 'runQuery').mockReturnValue(of({ data: [] }));
+    jest.spyOn(datasource, 'query').mockReturnValue(of({ data: [] }));
+  });
+
+  test('Splits datasource queries', async () => {
+    await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith(() => {
+      // 5 shards, 3 groups + empty shard group, 4 requests
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledTimes(4);
+    });
   });
 
   test('Interpolates queries before running', async () => {
@@ -51,14 +71,108 @@ describe('runShardSplitQuery()', () => {
         requestId: 'TEST_shard_0',
         targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"20|10"}[1m])', refId: 'A' }],
       });
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledWith({
+        intervalMs: expect.any(Number),
+        range: expect.any(Object),
+        requestId: 'TEST_shard_1',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"3|2"}[1m])', refId: 'A' }],
+      });
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledWith({
+        intervalMs: expect.any(Number),
+        range: expect.any(Object),
+        requestId: 'TEST_shard_2',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"1"}[1m])', refId: 'A' }],
+      });
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledWith({
+        intervalMs: expect.any(Number),
+        range: expect.any(Object),
+        requestId: 'TEST_shard_3',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=""}[1m])', refId: 'A' }],
+      });
     });
   });
 
-  test('Splits datasource queries', async () => {
-    await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith(() => {
-      // 5 shards, 3 groups + empty shard group, 4 requests
+  test('Returns a DataQueryResponse with the expected attributes', async () => {
+    await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith((response: DataQueryResponse[]) => {
+      expect(response[0].data).toBeDefined();
+      expect(response[0].state).toBe(LoadingState.Done);
+      expect(response[0].key).toBeDefined();
+    });
+  });
+
+  test('Retries failed requests', async () => {
+    jest.mocked(datasource.languageProvider.fetchLabelValues).mockResolvedValue([1]);
+    jest
       // @ts-expect-error
-      expect(datasource.runQuery).toHaveBeenCalledTimes(4);
+      .spyOn(datasource, 'runQuery')
+      .mockReturnValueOnce(of({ state: LoadingState.Error, error: { refId: 'A', message: 'Error' }, data: [] }));
+    await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith((response: DataQueryResponse[]) => {
+      // 1 shard + empty shard + 1 retry = 3
+      expect(response).toHaveLength(3);
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  test('Retries failed requests', async () => {
+    jest.mocked(datasource.languageProvider.fetchLabelValues).mockResolvedValue([1]);
+    jest
+      // @ts-expect-error
+      .spyOn(datasource, 'runQuery')
+      .mockReturnValueOnce(of({ state: LoadingState.Error, error: { refId: 'A', message: 'Error' }, data: [] }));
+    await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith((response: DataQueryResponse[]) => {
+      // 1 shard + empty shard + 1 retry = 3
+      expect(response).toHaveLength(3);
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  test('For small time ranges starts with the highest volume shards', async () => {
+    const request = createRequest([{ expr: 'count_over_time($SELECTOR[1m])', refId: 'A' }], {
+      range: {
+        from: dateTime('2024-11-13T05:00:00.000Z'),
+        to: dateTime('2024-11-13T06:00:00.000Z'),
+        raw: {
+          from: dateTime('2024-11-13T05:00:00.000Z'),
+          to: dateTime('2024-11-13T06:00:00.000Z'),
+        },
+      },
+    });
+
+    await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith(() => {
+      expect(datasource.interpolateVariablesInQueries).toHaveBeenCalledTimes(1);
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledWith({
+        intervalMs: expect.any(Number),
+        range: expect.any(Object),
+        requestId: 'TEST_shard_0',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=""}[1m])', refId: 'A' }],
+      });
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledWith({
+        intervalMs: expect.any(Number),
+        range: expect.any(Object),
+        requestId: 'TEST_shard_1',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"1"}[1m])', refId: 'A' }],
+      });
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledWith({
+        intervalMs: expect.any(Number),
+        range: expect.any(Object),
+        requestId: 'TEST_shard_2',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"3|2"}[1m])', refId: 'A' }],
+      });
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledWith({
+        intervalMs: expect.any(Number),
+        range: expect.any(Object),
+        requestId: 'TEST_shard_3',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"20|10"}[1m])', refId: 'A' }],
+      });
     });
   });
 });

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -70,21 +70,21 @@ describe('runShardSplitQuery()', () => {
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_0',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"1|3"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"20|3"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_1',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"2|10"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"10|2"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_2',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="20"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="1"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
@@ -150,7 +150,7 @@ describe('runShardSplitQuery()', () => {
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_0',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="1"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="20"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
@@ -164,21 +164,21 @@ describe('runShardSplitQuery()', () => {
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_2',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="2"}[1m])', refId: 'A' }],
-      });
-      // @ts-expect-error
-      expect(datasource.runQuery).toHaveBeenCalledWith({
-        intervalMs: expect.any(Number),
-        range: expect.any(Object),
-        requestId: 'TEST_shard_3',
         targets: [{ expr: 'count_over_time({a="b", __stream_shard__="10"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
+        requestId: 'TEST_shard_3',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="2"}[1m])', refId: 'A' }],
+      });
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledWith({
+        intervalMs: expect.any(Number),
+        range: expect.any(Object),
         requestId: 'TEST_shard_4',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="20"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="1"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -25,11 +25,11 @@ afterAll(() => {
 describe('runShardSplitQuery()', () => {
   let datasource: DataSourceWithBackend<LokiQuery>;
   const range = {
-    from: dateTime('2023-02-08T05:00:00.000Z'),
-    to: dateTime('2023-02-10T06:00:00.000Z'),
+    from: dateTime('2023-02-08T04:00:00.000Z'),
+    to: dateTime('2023-02-08T11:00:00.000Z'),
     raw: {
-      from: dateTime('2023-02-08T05:00:00.000Z'),
-      to: dateTime('2023-02-10T06:00:00.000Z'),
+      from: dateTime('2023-02-08T04:00:00.000Z'),
+      to: dateTime('2023-02-08T11:00:00.000Z'),
     },
   };
 
@@ -69,21 +69,21 @@ describe('runShardSplitQuery()', () => {
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_0',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"20|10"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"20|2"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_1',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"3|2"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"10|1"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_2',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"1"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="3"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
@@ -145,6 +145,7 @@ describe('runShardSplitQuery()', () => {
 
     await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith(() => {
       expect(datasource.interpolateVariablesInQueries).toHaveBeenCalledTimes(1);
+
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
@@ -157,21 +158,21 @@ describe('runShardSplitQuery()', () => {
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_1',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"1"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="3"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_2',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"3|2"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"10|1"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_3',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"20|10"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"20|2"}[1m])', refId: 'A' }],
       });
     });
   });

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -110,20 +110,10 @@ describe('runShardSplitQuery()', () => {
       // @ts-expect-error
       .spyOn(datasource, 'runQuery')
       .mockReturnValueOnce(of({ state: LoadingState.Error, error: { refId: 'A', message: 'Error' }, data: [] }));
-    await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith((response: DataQueryResponse[]) => {
-      // 1 shard + empty shard + 1 retry = 3
-      expect(response).toHaveLength(3);
-      // @ts-expect-error
-      expect(datasource.runQuery).toHaveBeenCalledTimes(3);
+    // @ts-expect-error
+    jest.spyOn(global, 'setTimeout').mockImplementationOnce((callback) => {
+      callback();
     });
-  });
-
-  test('Retries failed requests', async () => {
-    jest.mocked(datasource.languageProvider.fetchLabelValues).mockResolvedValue([1]);
-    jest
-      // @ts-expect-error
-      .spyOn(datasource, 'runQuery')
-      .mockReturnValueOnce(of({ state: LoadingState.Error, error: { refId: 'A', message: 'Error' }, data: [] }));
     await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith((response: DataQueryResponse[]) => {
       // 1 shard + empty shard + 1 retry = 3
       expect(response).toHaveLength(3);

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -132,7 +132,7 @@ describe('runShardSplitQuery()', () => {
     });
   });
 
-  test('For time ranges over a day queries shards indepentendly', async () => {
+  test('For time ranges over a day queries shards independently', async () => {
     const request = createRequest([{ expr: 'count_over_time($SELECTOR[1m])', refId: 'A' }], {
       range: {
         from: dateTime('2024-11-13T05:00:00.000Z'),

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -64,26 +64,27 @@ describe('runShardSplitQuery()', () => {
   test('Interpolates queries before running', async () => {
     await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith(() => {
       expect(datasource.interpolateVariablesInQueries).toHaveBeenCalledTimes(1);
+
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_0',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"20|2"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"1|3"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_1',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"10|1"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"2|10"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_2',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="3"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="20"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
@@ -131,27 +132,25 @@ describe('runShardSplitQuery()', () => {
     });
   });
 
-  test('For small time ranges starts with the highest volume shards', async () => {
+  test('For time ranges over a day queries shards indepentendly', async () => {
     const request = createRequest([{ expr: 'count_over_time($SELECTOR[1m])', refId: 'A' }], {
       range: {
         from: dateTime('2024-11-13T05:00:00.000Z'),
-        to: dateTime('2024-11-13T06:00:00.000Z'),
+        to: dateTime('2024-11-14T06:00:00.000Z'),
         raw: {
           from: dateTime('2024-11-13T05:00:00.000Z'),
-          to: dateTime('2024-11-13T06:00:00.000Z'),
+          to: dateTime('2024-11-14T06:00:00.000Z'),
         },
       },
     });
 
     await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith(() => {
-      expect(datasource.interpolateVariablesInQueries).toHaveBeenCalledTimes(1);
-
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_0',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=""}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="1"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
@@ -165,14 +164,28 @@ describe('runShardSplitQuery()', () => {
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_2',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"10|1"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="2"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
         requestId: 'TEST_shard_3',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"20|2"}[1m])', refId: 'A' }],
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="10"}[1m])', refId: 'A' }],
+      });
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledWith({
+        intervalMs: expect.any(Number),
+        range: expect.any(Object),
+        requestId: 'TEST_shard_4',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="20"}[1m])', refId: 'A' }],
+      });
+      // @ts-expect-error
+      expect(datasource.runQuery).toHaveBeenCalledWith({
+        intervalMs: expect.any(Number),
+        range: expect.any(Object),
+        requestId: 'TEST_shard_5',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=""}[1m])', refId: 'A' }],
       });
     });
   });

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -1,0 +1,150 @@
+import { Observable, Subscriber, Subscription } from 'rxjs';
+import { v4 as uuidv4 } from 'uuid';
+
+import { DataQueryRequest, LoadingState, DataQueryResponse, DataSourceApi } from '@grafana/data';
+import { LokiQuery } from './query';
+import { addShardingPlaceholderSelector, interpolateShardingSelector, isLogsQuery } from './logql';
+import { combineResponses } from './combineResponses';
+
+/**
+ * Based in the state of the current response, if any, adjust target parameters such as `maxLines`.
+ * For `maxLines`, we will update it as `maxLines - current amount of lines`.
+ * At the end, we will filter the targets that don't need to be executed in the next request batch,
+ * becasue, for example, the `maxLines` have been reached.
+ */
+function adjustTargetsFromResponseState(targets: LokiQuery[], response: DataQueryResponse | null): LokiQuery[] {
+  if (!response) {
+    return targets;
+  }
+
+  return targets
+    .map((target) => {
+      if (!target.maxLines || !isLogsQuery(target.expr)) {
+        return target;
+      }
+      const targetFrame = response.data.find((frame) => frame.refId === target.refId);
+      if (!targetFrame) {
+        return target;
+      }
+      const updatedMaxLines = target.maxLines - targetFrame.length;
+      return {
+        ...target,
+        maxLines: updatedMaxLines < 0 ? 0 : updatedMaxLines,
+      };
+    })
+    .filter((target) => target.maxLines === undefined || target.maxLines > 0);
+}
+
+export function splitQueriesByStreamShard(
+  datasource: DataSourceApi,
+  request: DataQueryRequest<LokiQuery>,
+  splittingTargets: LokiQuery[],
+  nonSplittingTargets: LokiQuery[] = []
+) {
+  let endShard = 0;
+  let shouldStop = false;
+  let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Streaming, key: uuidv4() };
+  let subquerySubsciption: Subscription | null = null;
+
+  const runNextRequest = (subscriber: Subscriber<DataQueryResponse>, shard?: number) => {
+    if (shouldStop) {
+      subscriber.complete();
+      return;
+    }
+
+    const done = () => {
+      mergedResponse.state = LoadingState.Done;
+      subscriber.next(mergedResponse);
+      subscriber.complete();
+    };
+
+    const nextRequest = () => {
+      if (!shard) {
+        done();
+        return;
+      }
+      const nextShard = shard + 1;
+      if (nextShard <= endShard) {
+        runNextRequest(subscriber, nextShard);
+        return;
+      }
+      done();
+    };
+
+    const targets = adjustTargetsFromResponseState(splittingTargets, mergedResponse);
+    if (!targets.length) {
+      nextRequest();
+      return;
+    }
+
+    const subRequest = { ...request, targets: interpolateShardingSelector(targets, shard) };
+    // Request may not have a request id
+    if (request.requestId) {
+      subRequest.requestId = `${request.requestId}_shard_${shard}`;
+    }
+
+    // @ts-expect-error
+    subquerySubsciption = datasource.runQuery(subRequest).subscribe({
+      next: (partialResponse: DataQueryResponse) => {
+        mergedResponse = combineResponses(mergedResponse, partialResponse);
+        if ((mergedResponse.errors ?? []).length > 0 || mergedResponse.error != null) {
+          shouldStop = true;
+        }
+      },
+      complete: () => {
+        subscriber.next(mergedResponse);
+        nextRequest();
+      },
+      error: (error: unknown) => {
+        console.error(error);
+        subscriber.next(mergedResponse);
+        nextRequest();
+      },
+    });
+  };
+
+  const response = new Observable<DataQueryResponse>((subscriber) => {
+    datasource.languageProvider
+      .fetchLabelValues('__stream_shard__', { timeRange: request.range })
+      .then((values: string[]) => {
+        values.forEach((shard) => {
+          if (parseInt(shard, 10) > endShard) {
+            endShard = parseInt(shard, 10);
+          }
+        });
+        if (endShard === 0) {
+          console.warn(`Shard splitting not supported. Issuing a regular query.`);
+          runNextRequest(subscriber);
+        } else {
+          console.log(`Querying up to ${endShard} shards`);
+          runNextRequest(subscriber, -1);
+        }
+      })
+      .catch((e: unknown) => {
+        console.error(e);
+        shouldStop = true;
+        runNextRequest(subscriber, 0);
+      });
+    return () => {
+      shouldStop = true;
+      if (subquerySubsciption != null) {
+        subquerySubsciption.unsubscribe();
+      }
+    };
+  });
+
+  return response;
+}
+
+export function runShardSplitQuery(datasource: DataSourceApi, request: DataQueryRequest<LokiQuery>) {
+  const queries = request.targets
+    // @ts-expect-error
+    .filter((query) => !query.hide)
+    .filter((query) => query.expr)
+    .map((target) => ({
+      ...target,
+      expr: addShardingPlaceholderSelector(target.expr),
+    }));
+
+  return splitQueriesByStreamShard(datasource, request, queries, []);
+}

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -79,7 +79,7 @@ export function splitQueriesByStreamShard(
         return;
       }
 
-      retriesMap.set(key, 1);
+      retriesMap.set(key, retries + 1);
 
       console.log(`Retrying ${cycle} (${retries + 1})`);
       runNextRequest(subscriber, cycle, shardRequests);

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -170,7 +170,7 @@ function getShardRequests(maxShard: number, shards: number[], range: TimeRange) 
   const hours = range.to.diff(range.from, 'hour');
 
   shards.sort((a, b) => a - b);
-  const maxRequests = Math.min(4, shards.length - 1);
+  const maxRequests = calculateMaxRequests(shards.length);
   const groupSize = Math.ceil(maxShard / maxRequests);
   const requests: number[][] = [];
   for (let i = maxShard; i > 0; i -= groupSize) {
@@ -191,4 +191,8 @@ function getShardRequests(maxShard: number, shards: number[], range: TimeRange) 
   }
 
   return requests;
+}
+
+function calculateMaxRequests(shards: number) {
+  return Math.min(Math.ceil(Math.sqrt(shards)), shards - 1);
 }

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -150,7 +150,7 @@ export function splitQueriesByStreamShard(
           runNextRequest(subscriber);
         } else {
           const shardRequests = getShardRequests(shards, request.range);
-          console.log(`Querying up ${shards.join(', ')} shards`);
+          console.log(`Querying ${shards.join(', ')} shards`);
           runNextRequest(subscriber, 0, shardRequests);
         }
       })
@@ -187,12 +187,11 @@ function getShardRequests(shards: number[], range: TimeRange) {
 
   shards.sort((a, b) => a - b);
   const maxRequests = calculateMaxRequests(shards.length);
-  const maxShard = shards.length - 1;
-  const groupSize = Math.ceil(maxShard / maxRequests);
+  const groupSize = Math.ceil(shards.length / maxRequests);
   const requests: number[][] = [];
-  for (let i = maxShard; i > 0; i -= groupSize) {
+  for (let i = shards.length - 1; i >= 0; i -= groupSize) {
     const request: number[] = [];
-    for (let j = i; j >= i - groupSize && j >= 0 && shards.length > 0; j -= 1) {
+    for (let j = i; j > i - groupSize && j >= 0; j -= 1) {
       request.push(shards[j]);
     }
     requests.push(request);
@@ -203,7 +202,6 @@ function getShardRequests(shards: number[], range: TimeRange) {
     requests.push([-1]);
     requests.reverse();
   } else {
-    requests.reverse();
     requests.push([-1]);
   }
 

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -151,7 +151,7 @@ export function splitQueriesByStreamShard(
           runNextRequest(subscriber);
         } else {
           const shardRequests = getShardRequests(shards, request.range);
-          console.log(`Querying up to ${startShard} shards`);
+          console.log(`Querying up ${shards.join(', ')} shards`);
           runNextRequest(subscriber, 0, shardRequests);
         }
       })

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -145,8 +145,7 @@ export function splitQueriesByStreamShard(
       })
       .then((values: string[]) => {
         const shards = values.map((value) => parseInt(value, 10));
-        const startShard = shards.length ? Math.max(...shards) : undefined;
-        if (startShard === undefined) {
+        if (!shards || !shards.length) {
           console.warn(`Shard splitting not supported. Issuing a regular query.`);
           runNextRequest(subscriber);
         } else {

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -133,7 +133,7 @@ export function splitQueriesByStreamShard(
           console.warn(`Shard splitting not supported. Issuing a regular query.`);
           runNextRequest(subscriber);
         } else {
-          const shardRequests = getShardRequests(startShard, shards, request.range);
+          const shardRequests = getShardRequests(shards, request.range);
           console.log(`Querying up to ${startShard} shards`);
           runNextRequest(subscriber, 0, shardRequests);
         }
@@ -166,11 +166,12 @@ export function runShardSplitQuery(datasource: DataSourceWithBackend<LokiQuery>,
   return splitQueriesByStreamShard(datasource, request, queries);
 }
 
-function getShardRequests(maxShard: number, shards: number[], range: TimeRange) {
+function getShardRequests(shards: number[], range: TimeRange) {
   const hours = range.to.diff(range.from, 'hour');
 
   shards.sort((a, b) => a - b);
   const maxRequests = calculateMaxRequests(shards.length);
+  const maxShard = shards.length - 1;
   const groupSize = Math.ceil(maxShard / maxRequests);
   const requests: number[][] = [];
   for (let i = maxShard; i > 0; i -= groupSize) {

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -146,7 +146,7 @@ export function splitQueriesByStreamShard(
       },
       error: (error: unknown) => {
         console.error(error);
-        subscriber.next(mergedResponse);
+        subscriber.error(mergedResponse);
       },
     });
   };

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -167,7 +167,8 @@ export function runShardSplitQuery(datasource: DataSourceWithBackend<LokiQuery>,
 }
 
 function getShardRequests(maxShard: number, shards: number[]) {
-  const maxRequests = Math.min(5, shards.length - 1);
+  shards.sort((a, b) => a - b).reverse();
+  const maxRequests = Math.min(2, shards.length - 1);
   const groupSize = Math.ceil(maxShard / maxRequests);
   const requests: number[][] = [];
   for (let i = maxShard; i >= 0; i -= groupSize) {

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -13,35 +13,49 @@ import { combineResponses } from './combineResponses';
 import { DataSourceWithBackend } from '@grafana/runtime';
 
 /**
- * Based in the state of the current response, if any, adjust target parameters such as `maxLines`.
- * For `maxLines`, we will update it as `maxLines - current amount of lines`.
- * At the end, we will filter the targets that don't need to be executed in the next request batch,
- * because, for example, the `maxLines` have been reached.
+ * Query splitting by stream shards.
+ * Query splitting, in any version, was introduced in Loki to optimize querying for long intervals
+ * and high volume of data, dividing a big request into smaller sub-requests, combining and displaying
+ * the results as they arrive.
+ * This approach takes advantage of the __stream_shard__ internal label, representing how data is spread
+ * into different sources that can be queried individually.
+ *
+ * The main entry point of this module is runShardSplitQuery(), which prepares the query for execution and
+ * passes it to splitQueriesByStreamShard() to begin the querying loop.
+ *
+ * splitQueriesByStreamShard() has the following structure:
+ * - Creates and returns an Observable to which the UI will subscribe
+ * - Requests the __stream_shard__ values of the selected service:
+ *   . If there are no shard values, it falls back to the standard querying approach of the data source in runNonSplitRequest()
+ *   . If there are shards:
+ *     - It groups the shard requests in an array of arrays of shard numbers in groupShardRequests()
+ *     - It begins the querying loop with runNextRequest()
+ * - runNextRequest() will send a query using the nth (cycle) shard group, and has the following internal structure:
+ *   . adjustTargetsFromResponseState() will filter log queries targets that already received the requested maxLines
+ *   . interpolateShardingSelector() will update the stream selector with the current shard numbers
+ *   . After query execution:
+ *     - If the response is successful:
+ *       . It will add new data to the response with combineResponses()
+ *       . nextRequest() will use the current cycle and the total groups to determine the next request or complete execution with done()
+ *     - If the response is unsuccessful:
+ *       . If there are retry attempts, it will retry the current cycle, or else continue with the next cycle
+ *       . If the returned error is Maximum series reached, it will not retry
+ * - Once all request groups have been executed, it will be done()
  */
-function adjustTargetsFromResponseState(targets: LokiQuery[], response: DataQueryResponse | null): LokiQuery[] {
-  if (!response) {
-    return targets;
-  }
 
-  return targets
-    .map((target) => {
-      if (!target.maxLines || !isLogsQuery(target.expr)) {
-        return target;
-      }
-      const targetFrame = response.data.find((frame) => frame.refId === target.refId);
-      if (!targetFrame) {
-        return target;
-      }
-      const updatedMaxLines = target.maxLines - targetFrame.length;
-      return {
-        ...target,
-        maxLines: updatedMaxLines < 0 ? 0 : updatedMaxLines,
-      };
-    })
-    .filter((target) => target.maxLines === undefined || target.maxLines > 0);
+export function runShardSplitQuery(datasource: DataSourceWithBackend<LokiQuery>, request: DataQueryRequest<LokiQuery>) {
+  const queries = datasource
+    .interpolateVariablesInQueries(request.targets, request.scopedVars)
+    .filter((query) => query.expr)
+    .map((target) => ({
+      ...target,
+      expr: addShardingPlaceholderSelector(target.expr),
+    }));
+
+  return splitQueriesByStreamShard(datasource, request, queries);
 }
 
-export function splitQueriesByStreamShard(
+function splitQueriesByStreamShard(
   datasource: DataSourceWithBackend<LokiQuery>,
   request: DataQueryRequest<LokiQuery>,
   splittingTargets: LokiQuery[]
@@ -164,7 +178,7 @@ export function splitQueriesByStreamShard(
           console.warn(`Shard splitting not supported. Issuing a regular query.`);
           runNonSplitRequest(subscriber);
         } else {
-          const shardRequests = getShardRequests(shards, request.range);
+          const shardRequests = groupShardRequests(shards, request.range);
           console.log(`Querying ${shards.join(', ')} shards`);
           runNextRequest(subscriber, 0, shardRequests);
         }
@@ -185,19 +199,7 @@ export function splitQueriesByStreamShard(
   return response;
 }
 
-export function runShardSplitQuery(datasource: DataSourceWithBackend<LokiQuery>, request: DataQueryRequest<LokiQuery>) {
-  const queries = datasource
-    .interpolateVariablesInQueries(request.targets, request.scopedVars)
-    .filter((query) => query.expr)
-    .map((target) => ({
-      ...target,
-      expr: addShardingPlaceholderSelector(target.expr),
-    }));
-
-  return splitQueriesByStreamShard(datasource, request, queries);
-}
-
-function getShardRequests(shards: number[], range: TimeRange) {
+function groupShardRequests(shards: number[], range: TimeRange) {
   const hours = range.to.diff(range.from, 'hour');
 
   shards.sort((a, b) => a - b);
@@ -223,6 +225,49 @@ function getShardRequests(shards: number[], range: TimeRange) {
   return requests;
 }
 
+/**
+ * Simple approach to calculate a maximum amount of requests to send based on
+ * the available shards, preventing an excessive number of sub-requests per query.
+ * For example:
+ * Shards => Requests
+ *   1    =>   1
+ *   2    =>   1
+ *   4    =>   2
+ *   8    =>   3
+ *   16   =>   4
+ *   32   =>   6
+ *   64   =>   8
+ *   128  =>   12
+ */
 function calculateMaxRequests(shards: number) {
-  return Math.min(Math.ceil(Math.sqrt(shards)), shards - 1);
+  return Math.max(Math.min(Math.ceil(Math.sqrt(shards)), shards - 1), 1);
+}
+
+/**
+ * Based in the state of the current response, if any, adjust target parameters such as `maxLines`.
+ * For `maxLines`, we will update it as `maxLines - current amount of lines`.
+ * At the end, we will filter the targets that don't need to be executed in the next request batch,
+ * because, for example, the `maxLines` have been reached.
+ */
+function adjustTargetsFromResponseState(targets: LokiQuery[], response: DataQueryResponse | null): LokiQuery[] {
+  if (!response) {
+    return targets;
+  }
+
+  return targets
+    .map((target) => {
+      if (!target.maxLines || !isLogsQuery(target.expr)) {
+        return target;
+      }
+      const targetFrame = response.data.find((frame) => frame.refId === target.refId);
+      if (!targetFrame) {
+        return target;
+      }
+      const updatedMaxLines = target.maxLines - targetFrame.length;
+      return {
+        ...target,
+        maxLines: updatedMaxLines < 0 ? 0 : updatedMaxLines,
+      };
+    })
+    .filter((target) => target.maxLines === undefined || target.maxLines > 0);
 }

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -61,7 +61,7 @@ function splitQueriesByStreamShard(
   splittingTargets: LokiQuery[]
 ) {
   let shouldStop = false;
-  let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Streaming, key: uuidv4() };
+  let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Loading, key: uuidv4() };
   let subquerySubscription: Subscription | null = null;
   let retriesMap = new Map<number, number>();
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -127,6 +127,9 @@ function splitQueriesByStreamShard(
           if (retry(partialResponse)) {
             return;
           }
+        }
+        if (mergedResponse.data.length) {
+          mergedResponse.state = LoadingState.Streaming;
         }
         mergedResponse = combineResponses(mergedResponse, partialResponse);
       },

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -170,7 +170,6 @@ function splitQueriesByStreamShard(
           runNonSplitRequest(subscriber);
         } else {
           const shardRequests = groupShardRequests(shards, request.range);
-          console.log(`Querying ${shards.join(', ')} shards`);
           runNextRequest(subscriber, 0, shardRequests);
         }
       })
@@ -195,6 +194,7 @@ function groupShardRequests(shards: number[], range: TimeRange) {
 
   // Spread low and high volume around
   shards = spreadSort(shards);
+  console.log(`Querying ${shards.join(', ')} shards`);
 
   const maxRequests = calculateMaxRequests(shards.length, hours);
   const groupSize = Math.ceil(shards.length / maxRequests);
@@ -225,7 +225,7 @@ function calculateMaxRequests(shards: number, hours: number) {
 }
 
 function spreadSort(shards: number[]) {
-  shards.sort((a, b) => a - b);
+  shards.sort((a, b) => b - a);
   let mid = Math.floor(shards.length / 2);
   let result = [];
   for (let i = 0; i < mid; i++) {

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -16,7 +16,7 @@ import { DataSourceWithBackend } from '@grafana/runtime';
  * Based in the state of the current response, if any, adjust target parameters such as `maxLines`.
  * For `maxLines`, we will update it as `maxLines - current amount of lines`.
  * At the end, we will filter the targets that don't need to be executed in the next request batch,
- * becasue, for example, the `maxLines` have been reached.
+ * because, for example, the `maxLines` have been reached.
  */
 function adjustTargetsFromResponseState(targets: LokiQuery[], response: DataQueryResponse | null): LokiQuery[] {
   if (!response) {
@@ -48,7 +48,7 @@ export function splitQueriesByStreamShard(
 ) {
   let shouldStop = false;
   let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Streaming, key: uuidv4() };
-  let subquerySubsciption: Subscription | null = null;
+  let subquerySubscription: Subscription | null = null;
   let retriesMap = new Map<number, number>();
 
   const runNextRequest = (subscriber: Subscriber<DataQueryResponse>, cycle?: number, shardRequests?: number[][]) => {
@@ -112,7 +112,7 @@ export function splitQueriesByStreamShard(
       // @ts-expect-error
       shardRequests === undefined ? datasource.query.bind(datasource) : datasource.runQuery.bind(datasource);
 
-    subquerySubsciption = dsQueryMethod(subRequest).subscribe({
+    subquerySubscription = dsQueryMethod(subRequest).subscribe({
       next: (partialResponse: DataQueryResponse) => {
         if ((partialResponse.errors ?? []).length > 0 || partialResponse.error != null) {
           if (retry(partialResponse)) {
@@ -137,7 +137,7 @@ export function splitQueriesByStreamShard(
   };
 
   const runNonSplitRequest = (subscriber: Subscriber<DataQueryResponse>) => {
-    subquerySubsciption = datasource.query(request).subscribe({
+    subquerySubscription = datasource.query(request).subscribe({
       next: (partialResponse: DataQueryResponse) => {
         mergedResponse = partialResponse;
       },
@@ -176,8 +176,8 @@ export function splitQueriesByStreamShard(
       });
     return () => {
       shouldStop = true;
-      if (subquerySubsciption != null) {
-        subquerySubsciption.unsubscribe();
+      if (subquerySubscription != null) {
+        subquerySubscription.unsubscribe();
       }
     };
   });

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -169,6 +169,7 @@ test.describe('explore services page', () => {
     });
 
     test('navigating back will not re-run volume query', async ({ page }) => {
+      await page.waitForFunction(() => !document.querySelector('[title="Cancel query"]'));
       expect(logsVolumeCount).toEqual(1);
       expect(logsQueryCount).toBeLessThanOrEqual(4);
 
@@ -195,10 +196,10 @@ test.describe('explore services page', () => {
       await page.waitForTimeout(100);
 
       expect(logsVolumeCount).toEqual(1);
-      expect(logsQueryCount).toBeLessThanOrEqual(8);
     });
 
     test('changing datasource will trigger new queries', async ({ page }) => {
+      await page.waitForFunction(() => !document.querySelector('[title="Cancel query"]'));
       expect(logsVolumeCount).toEqual(1);
       expect(logsQueryCount).toEqual(4);
       await page

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -144,14 +144,8 @@ test.describe('explore services page', () => {
         await route.fulfill({ json: {} });
       });
 
-      await page.route('**/values*', async (route) => {
-        await page.waitForTimeout(50);
-        await route.fulfill({ json: { status: 'success' } });
-      });
-
       await Promise.all([
         page.waitForResponse((resp) => resp.url().includes('index/volume')),
-        page.waitForResponse((resp) => resp.url().includes('/values')),
         page.waitForResponse((resp) => resp.url().includes('ds/query')),
       ]);
     });

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -144,18 +144,26 @@ test.describe('explore services page', () => {
         await route.fulfill({ json: {} });
       });
 
+      await page.route('**/values*', async (route) => {
+        await page.waitForTimeout(50);
+        await route.fulfill({ json: { status: 'success' } });
+      });
+
       await Promise.all([
         page.waitForResponse((resp) => resp.url().includes('index/volume')),
+        page.waitForResponse((resp) => resp.url().includes('/values')),
         page.waitForResponse((resp) => resp.url().includes('ds/query')),
       ]);
     });
 
     test('refreshing time range should request panel data once', async ({ page }) => {
+      await page.waitForFunction(() => !document.querySelector('[title="Cancel query"]'));
       expect(logsVolumeCount).toEqual(1);
       expect(logsQueryCount).toEqual(4);
       await explorePage.refreshPicker.click();
       await explorePage.refreshPicker.click();
       await explorePage.refreshPicker.click();
+      await page.waitForFunction(() => !document.querySelector('[title="Cancel query"]'));
       expect(logsVolumeCount).toEqual(4);
       expect(logsQueryCount).toEqual(16);
     });

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -74,6 +74,7 @@ export class ExplorePage {
 
   async assertPanelsNotLoading() {
     await expect(this.page.getByLabel('Panel loading bar')).toHaveCount(0);
+    await this.page.waitForFunction(() => !document.querySelector('[title="Cancel query"]'));
   }
 
   // This is flakey, panels won't show the state if the requests come back in < 75ms

--- a/tests/matchers.ts
+++ b/tests/matchers.ts
@@ -1,0 +1,125 @@
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+import { asapScheduler, Subscription, timer, isObservable, Observable } from 'rxjs';
+
+export const OBSERVABLE_TEST_TIMEOUT_IN_MS = 1000;
+
+function tryExpectations<T = unknown>(received: T[], expectations: (received: T[]) => void): jest.CustomMatcherResult {
+  try {
+    expectations(received);
+    return {
+      pass: true,
+      message: () => `${matcherHint('.not.toEmitValues')}
+
+  Expected observable to complete with
+    ${printReceived(received)}
+    `,
+    };
+  } catch (err) {
+    return {
+      pass: false,
+      message: () => 'failed ' + err,
+    };
+  }
+}
+
+function forceObservableCompletion(
+    subscription: Subscription,
+    resolve: (args: jest.CustomMatcherResult | PromiseLike<jest.CustomMatcherResult>) => void
+  ) {
+    const timeoutObservable = timer(OBSERVABLE_TEST_TIMEOUT_IN_MS, asapScheduler);
+  
+    subscription.add(
+      timeoutObservable.subscribe(() => {
+        subscription.unsubscribe();
+        resolve({
+          pass: false,
+          message: () =>
+            `${matcherHint('.toEmitValues')}
+  
+      Expected ${printReceived('Observable')} to be ${printExpected(
+        `completed within ${OBSERVABLE_TEST_TIMEOUT_IN_MS}ms`
+      )} but it did not.`,
+        });
+      })
+    );
+  }
+  
+  function expectObservableToBeDefined(received: unknown): jest.CustomMatcherResult | null {
+    if (received) {
+      return null;
+    }
+  
+    return {
+      pass: false,
+      message: () => `${matcherHint('.toEmitValues')}
+  
+  Expected ${printReceived(received)} to be ${printExpected('defined')}.`,
+    };
+  }
+  
+  function expectObservableToBeObservable(received: unknown): jest.CustomMatcherResult | null {
+    if (isObservable(received)) {
+      return null;
+    }
+  
+    return {
+      pass: false,
+      message: () => `${matcherHint('.toEmitValues')}
+  
+  Expected ${printReceived(received)} to be ${printExpected('an Observable')}.`,
+    };
+  }
+  
+  function expectObservable(received: unknown): jest.CustomMatcherResult | null {
+    const toBeDefined = expectObservableToBeDefined(received);
+    if (toBeDefined) {
+      return toBeDefined;
+    }
+  
+    const toBeObservable = expectObservableToBeObservable(received);
+    if (toBeObservable) {
+      return toBeObservable;
+    }
+  
+    return null;
+  }
+  
+
+/**
+ * Collect all the values emitted by the observables (also errors) and pass them to the expectations functions after
+ * the observable ended (or emitted error). If Observable does not complete within OBSERVABLE_TEST_TIMEOUT_IN_MS the
+ * test fails.
+ */
+export function toEmitValuesWith<T = unknown>(
+  received: Observable<T>,
+  expectations: (actual: T[]) => void
+): Promise<jest.CustomMatcherResult> {
+  const failsChecks = expectObservable(received);
+  if (failsChecks) {
+    return Promise.resolve(failsChecks);
+  }
+
+  return new Promise((resolve) => {
+    const receivedValues: T[] = [];
+    const subscription = new Subscription();
+
+    subscription.add(
+      received.subscribe({
+        next: (value) => {
+          receivedValues.push(value);
+        },
+        error: (err) => {
+          receivedValues.push(err);
+          subscription.unsubscribe();
+          resolve(tryExpectations(receivedValues, expectations));
+        },
+        complete: () => {
+          subscription.unsubscribe();
+          resolve(tryExpectations(receivedValues, expectations));
+        },
+      })
+    );
+
+    forceObservableCompletion(subscription, resolve);
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2325,6 +2325,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
+"@types/uuid@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
+  integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
+
 "@types/yargs-parser@*":
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
@@ -8837,6 +8842,11 @@ uuid@9.0.1, uuid@^9.0.0, uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
+uuid@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
# Query splitting by stream shards.

Query splitting was introduced in Loki to optimize querying for long intervals and high volume of data, dividing a big request into smaller sub-requests, combining and displaying the results as they arrive.

This approach, inspired by the time-based query splitting, takes advantage of the __stream_shard__ internal label, representing how data is spread into different sources that can be queried individually.

The main entry point of this module is runShardSplitQuery(), which prepares the query for execution and passes it to splitQueriesByStreamShard() to begin the querying loop.

splitQueriesByStreamShard() has the following structure:
- Creates and returns an Observable to which the UI will subscribe
- Requests the __stream_shard__ values of the selected service:
  - If there are no shard values, it falls back to the standard querying approach of the data source in runNonSplitRequest()
  - If there are shards:
    - It groups the shard requests in an array of arrays of shard numbers in groupShardRequests()
    - It begins the querying loop with runNextRequest()
- runNextRequest() will send a query using the nth (cycle) shard group, and has the following internal structure:
  - adjustTargetsFromResponseState() will filter log queries targets that already received the requested maxLines
  - interpolateShardingSelector() will update the stream selector with the current shard numbers
  - After query execution:
    - If the response is successful:
      - It will add new data to the response with combineResponses()
      - nextRequest() will use the current cycle and the total groups to determine the next request or complete execution with done()
    - If the response is unsuccessful:
      - If there are retry attempts, it will retry the current cycle, or else continue with the next cycle
      - If the returned error is Maximum series reached, it will not retry
- Once all request groups have been executed, it will be done()

## Key features
- Shards retrieved by a `/values` call including the selected service.
- Starts with low volume shards, intertwined with higher volume shards.
- Groups shards based on the current time interval and available shards. 
- Sends queries grouping shards in a selector `__stream_shard__=~"shardn1|shardn2|...|shardn"`.
- For short intervals (< 24 hours) groups shards in queries. For longer intervals, queries individual shards.
- Recombines responses without asuming any particular order, including overlapping values.
- Retries failed requests up to 3 times, with exponential backoff (1500 ms * 2^failed attempts of waiting time) Does not retry if the response is "maximum series reached".

> [!IMPORTANT]  
> Requires the `exploreLogsShardSplitting` feature flag enabled

Closes #690 