### PR TITLE
Extract parser: update heuristic for mixed logs

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -471,3 +471,4 @@ svgs
 Dont
 REFID
 unroute
+myown

--- a/src/services/fields.test.ts
+++ b/src/services/fields.test.ts
@@ -57,7 +57,7 @@ describe('updateParserFromDataFrame', () => {
   });
   jest.mocked(getLogsFormatVariable).mockReturnValue(logsFmtVariable);
 
-  it('should exclude json errors', () => {
+  it('should exclude mixed parser errors', () => {
     const dataFrame = createDataFrame({
       refId: 'A',
       fields: [
@@ -65,7 +65,7 @@ describe('updateParserFromDataFrame', () => {
         {
           name: 'Line',
           type: FieldType.string,
-          values: ['{"jsonLabel": "jsonValue"}'],
+          values: ['{"jsonLabel": "jsonValue"}', 'level=error myown=summer'],
         },
         { name: 'labelTypes', type: FieldType.other, values: [{ field1: 'I', field2: 'P', field3: 'S' }] },
       ],
@@ -73,7 +73,7 @@ describe('updateParserFromDataFrame', () => {
     const scene = {} as SceneObject;
 
     expect(updateParserFromDataFrame(dataFrame, scene)).toEqual({
-      type: 'json',
+      type: 'mixed',
       fields: ['field2'],
     });
     expect(logsFmtVariable.state.value).toEqual('| json  | logfmt | drop __error__, __error_details__');

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -18,8 +18,10 @@ export type DetectedLabelsResponse = {
   detectedLabels: DetectedLabel[];
 };
 
+type ExtractedFieldsType = 'logfmt' | 'json' | 'mixed';
+
 interface ExtractedFields {
-  type: 'logfmt' | 'json';
+  type: ExtractedFieldsType;
   fields: string[];
 }
 
@@ -30,7 +32,7 @@ export function updateParserFromDataFrame(frame: DataFrame, sceneRef: SceneObjec
   let newType;
   if (!res.type) {
     newType = '';
-  } else if (res.type === 'json') {
+  } else if (res.type === 'mixed') {
     newType = `| json  | logfmt | drop __error__, __error_details__`;
   } else {
     newType = ` | ${res.type}`;
@@ -55,8 +57,23 @@ export function extractParserAndFieldsFromDataFrame(data: DataFrame) {
     }, {}) ?? {}
   );
 
+  const types: ExtractedFieldsType[] = [];
+
   const linesField = data.fields.find((f) => f.name === 'Line' || f.name === 'body');
-  result.type = linesField?.values[0]?.[0] === '{' ? 'json' : 'logfmt';
+  linesField?.values.forEach((value: string) => {
+    if (types.length === 2) {
+      return;
+    }
+    try {
+      if (JSON.parse(value) && !types.includes('json')) {
+        types.push('json');
+      }
+    } catch (e) {
+      types.push('logfmt');
+    }
+  });
+
+  result.type = types.length === 1 ? types[0] : 'mixed';
 
   return result;
 }

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -64,10 +64,7 @@ export function extractParserAndFieldsFromDataFrame(data: DataFrame) {
     return result;
   }
 
-  for (let i = 0; i < linesField.values.length; i++) {
-    if (types.length === 2) {
-      break;
-    }
+  for (let i = 0; i < linesField.values.length && types.length < 2; i++) {
     const line = linesField.values[i].trim();
     if (line.startsWith('{') && line.endsWith('}')) {
       if (!types.includes('json')) {
@@ -77,6 +74,8 @@ export function extractParserAndFieldsFromDataFrame(data: DataFrame) {
       types.push('logfmt');
     }
   }
+
+  console.log(types);
 
   result.type = types.length === 1 ? types[0] : 'mixed';
 

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -75,8 +75,6 @@ export function extractParserAndFieldsFromDataFrame(data: DataFrame) {
     }
   }
 
-  console.log(types);
-
   result.type = types.length === 1 ? types[0] : 'mixed';
 
   return result;

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -58,13 +58,17 @@ export function extractParserAndFieldsFromDataFrame(data: DataFrame) {
   );
 
   const types: ExtractedFieldsType[] = [];
-
   const linesField = data.fields.find((f) => f.name === 'Line' || f.name === 'body');
-  linesField?.values.forEach((value: string) => {
+
+  if (!linesField) {
+    return result;
+  }
+
+  for (let i = 0; i < linesField.values.length; i++) {
     if (types.length === 2) {
-      return;
+      break;
     }
-    const line = value.trim();
+    const line = linesField.values[i].trim();
     if (line.startsWith('{') && line.endsWith('}')) {
       if (!types.includes('json')) {
         types.push('json');
@@ -72,7 +76,7 @@ export function extractParserAndFieldsFromDataFrame(data: DataFrame) {
     } else if (!types.includes('logfmt')) {
       types.push('logfmt');
     }
-  });
+  }
 
   result.type = types.length === 1 ? types[0] : 'mixed';
 

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -64,11 +64,12 @@ export function extractParserAndFieldsFromDataFrame(data: DataFrame) {
     if (types.length === 2) {
       return;
     }
-    try {
-      if (JSON.parse(value) && !types.includes('json')) {
+    const line = value.trim();
+    if (line.startsWith('{') && line.endsWith('}')) {
+      if (!types.includes('json')) {
         types.push('json');
       }
-    } catch (e) {
+    } else if (!types.includes('logfmt')) {
       types.push('logfmt');
     }
   });


### PR DESCRIPTION
The first log of the sample can be anything, and the fact that we're only checking one felt awkward.

Updated the implementation to:
- Check all the lines
- Use JSON.parse() instead of checking the first character, like we do in [LogRowMessage](https://github.com/grafana/grafana/blob/main/public/app/features/logs/components/LogRowMessage.tsx#L72).
- Add both parsers when the type is mixed and not only json