### PR TITLE
Filters: add support for filters with multiple values

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -43,7 +43,7 @@ import { getDrilldownSlug, PageSlugs } from '../../services/routing';
 import { ServiceSelectionScene } from '../ServiceSelectionScene/ServiceSelectionScene';
 import { LoadingPlaceholder } from '@grafana/ui';
 import { locationService } from '@grafana/runtime';
-import { renderLogQLFieldFilters, joinFilters, renderPatternFilters } from 'services/query';
+import { renderLogQLFieldFilters, renderLogQLLabelFilters, renderPatternFilters } from 'services/query';
 
 export interface AppliedPattern {
   pattern: string;
@@ -182,7 +182,7 @@ function getVariableSet(initialDatasourceUid: string, initialFilters?: AdHocVari
     layout: 'vertical',
     label: 'Service',
     filters: initialFilters ?? [],
-    expressionBuilder: joinFilters,
+    expressionBuilder: renderLogQLLabelFilters,
     hide: VariableHide.hideLabel,
     key: 'adhoc_service_filter',
   });

--- a/src/services/expressions.ts
+++ b/src/services/expressions.ts
@@ -10,6 +10,7 @@ import {
 } from './variables';
 import { isDefined } from './scenes';
 import { SceneObject } from '@grafana/scenes';
+import { renderLogQLLabelFilters } from './query';
 
 /**
  * Crafts count over time query that excludes empty values for stream selector name
@@ -34,10 +35,8 @@ export function getTimeSeriesExpr(sceneRef: SceneObject, streamSelectorName: str
     }
   }
 
-  const streamSelectors = [...labelsVariable.state.filters, labelExpressionToAdd]
-    .filter(isDefined)
-    .map((f) => `${f.key}${f.operator}\`${f.value}\``)
-    .join(',');
+  const labelFilters = [...labelsVariable.state.filters, labelExpressionToAdd].filter(isDefined);
+  const streamSelectors = renderLogQLLabelFilters(labelFilters);
 
   const fields = fieldsVariable.state.filters;
   const levels = levelsVariables.state.filters;

--- a/src/services/query.test.ts
+++ b/src/services/query.test.ts
@@ -1,21 +1,112 @@
-import { buildDataQuery } from './query';
+import { AdHocVariableFilter } from '@grafana/data';
+import { buildDataQuery, renderLogQLFieldFilters } from './query';
+import { FilterOp } from './filters';
 
-test('Given an expression outputs a Loki query', () => {
-  expect(buildDataQuery('{place="luna"}')).toEqual({
-    editorMode: 'code',
-    expr: '{place="luna"}',
-    queryType: 'range',
-    refId: 'A',
-    supportingQueryType: 'grafana-lokiexplore-app',
+describe('buildDataQuery', () => {
+  test('Given an expression outputs a Loki query', () => {
+    expect(buildDataQuery('{place="luna"}')).toEqual({
+      editorMode: 'code',
+      expr: '{place="luna"}',
+      queryType: 'range',
+      refId: 'A',
+      supportingQueryType: 'grafana-lokiexplore-app',
+    });
+  });
+
+  test('Given an expression and overrides outputs a Loki query', () => {
+    expect(buildDataQuery('{place="luna"}', { editorMode: 'gpt', refId: 'C' })).toEqual({
+      editorMode: 'gpt',
+      expr: '{place="luna"}',
+      queryType: 'range',
+      refId: 'C',
+      supportingQueryType: 'grafana-lokiexplore-app',
+    });
   });
 });
 
-test('Given an expression and overrides outputs a Loki query', () => {
-  expect(buildDataQuery('{place="luna"}', { editorMode: 'gpt', refId: 'C' })).toEqual({
-    editorMode: 'gpt',
-    expr: '{place="luna"}',
-    queryType: 'range',
-    refId: 'C',
-    supportingQueryType: 'grafana-lokiexplore-app',
+describe('renderLogQLFieldFilters', () => {
+  test('Renders positive filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.Equal,
+        value: 'info',
+      },
+      {
+        key: 'cluster',
+        operator: FilterOp.Equal,
+        value: 'lil-cluster',
+      },
+    ];
+
+    expect(renderLogQLFieldFilters(filters)).toEqual('| level=`info` | cluster=`lil-cluster`');
+  });
+
+  test('Renders negative filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.NotEqual,
+        value: 'info',
+      },
+      {
+        key: 'cluster',
+        operator: FilterOp.NotEqual,
+        value: 'lil-cluster',
+      },
+    ];
+
+    expect(renderLogQLFieldFilters(filters)).toEqual('| level!=`info` | cluster!=`lil-cluster`');
+  });
+
+  test('Groups positive filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.Equal,
+        value: 'info',
+      },
+      {
+        key: 'level',
+        operator: FilterOp.Equal,
+        value: 'error',
+      },
+    ];
+
+    expect(renderLogQLFieldFilters(filters)).toEqual('| level=`info` or level=`error`');
+  });
+
+  test('Renders grouped and ungrouped positive and negative filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.Equal,
+        value: 'info',
+      },
+      {
+        key: 'component',
+        operator: FilterOp.NotEqual,
+        value: 'comp1',
+      },
+      {
+        key: 'level',
+        operator: FilterOp.Equal,
+        value: 'error',
+      },
+      {
+        key: 'cluster',
+        operator: FilterOp.Equal,
+        value: 'lil-cluster',
+      },
+      {
+        key: 'pod',
+        operator: FilterOp.NotEqual,
+        value: 'pod1',
+      },
+    ];
+
+    expect(renderLogQLFieldFilters(filters)).toEqual(
+      '| level=`info` or level=`error` | cluster=`lil-cluster` | component!=`comp1` | pod!=`pod1`'
+    );
   });
 });

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -75,8 +75,6 @@ export function renderLogQLLabelFilters(filters: AdHocVariableFilter[]) {
 
   const negativeFilters = negative.map((filter) => renderFilter(filter)).join(', ');
 
-  console.log(trim(`${positiveFilters.join(', ')}, ${negativeFilters}`, ' ,'));
-
   return trim(`${positiveFilters.join(', ')}, ${negativeFilters}`, ' ,');
 }
 


### PR DESCRIPTION
Aimed to fix https://github.com/grafana/explore-logs/issues/691 , this PR adds support for all fields and labels with multiple values.

Fields demo:

https://github.com/user-attachments/assets/984f4d25-aa11-409b-9e4e-19a708bdf9f1

Labels demo:

https://github.com/user-attachments/assets/cfd97a70-a94e-4901-ac1f-15269ec0fc86

