### PR TITLE
Value breakdowns: Add calculated sort

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldValuesBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldValuesBreakdownScene.tsx
@@ -11,38 +11,60 @@ import {
   SceneObjectState,
   SceneReactObject,
 } from '@grafana/scenes';
-import {buildDataQuery, LokiQuery} from '../../../services/query';
-import {getSortByPreference} from '../../../services/store';
-import {DataQueryError, LoadingState} from '@grafana/data';
-import {LayoutSwitcher} from './LayoutSwitcher';
-import {getQueryRunner} from '../../../services/panel';
-import {ByFrameRepeater} from './ByFrameRepeater';
-import {Alert, DrawStyle, LoadingPlaceholder} from '@grafana/ui';
-import {getFilterBreakdownValueScene} from '../../../services/fields';
-import {getLabelValue} from './SortByScene';
-import {getFieldGroupByVariable, VAR_FIELDS} from '../../../services/variables';
+import { buildDataQuery, LokiQuery } from '../../../services/query';
+import { getSortByPreference } from '../../../services/store';
+import { DataQueryError, LoadingState } from '@grafana/data';
+import { LayoutSwitcher } from './LayoutSwitcher';
+import { getQueryRunner } from '../../../services/panel';
+import { ByFrameRepeater } from './ByFrameRepeater';
+import { Alert, DrawStyle, LoadingPlaceholder } from '@grafana/ui';
+import { getFilterBreakdownValueScene } from '../../../services/fields';
+import { getLabelValue } from './SortByScene';
+import { getFieldGroupByVariable, VAR_FIELDS } from '../../../services/variables';
 import React from 'react';
 import {
   FIELDS_BREAKDOWN_GRID_TEMPLATE_COLUMNS,
   FieldsBreakdownScene,
   getFieldBreakdownExpr,
 } from './FieldsBreakdownScene';
-import {AddFilterEvent} from './AddToFiltersButton';
-import {navigateToDrilldownPage} from '../../../services/navigate';
-import {PageSlugs} from '../../../services/routing';
-import {ServiceScene} from '../ServiceScene';
-import {DEFAULT_SORT_BY} from '../../../services/sorting';
+import { AddFilterEvent } from './AddToFiltersButton';
+import { navigateToDrilldownPage } from '../../../services/navigate';
+import { PageSlugs } from '../../../services/routing';
+import { ServiceScene } from '../ServiceScene';
+import { DEFAULT_SORT_BY } from '../../../services/sorting';
 
 export interface FieldValuesBreakdownSceneState extends SceneObjectState {
   body?: LayoutSwitcher | SceneReactObject;
   $data?: SceneDataProvider;
   lastFilterEvent?: AddFilterEvent;
 }
+
 export class FieldValuesBreakdownScene extends SceneObjectBase<FieldValuesBreakdownSceneState> {
   constructor(state: Partial<FieldValuesBreakdownSceneState>) {
     super(state);
     this.addActivationHandler(this.onActivate.bind(this));
   }
+
+  public static Selector({ model }: SceneComponentProps<FieldValuesBreakdownScene>) {
+    const { body } = model.useState();
+    if (body instanceof LayoutSwitcher) {
+      return <>{body && <body.Selector model={body} />}</>;
+    }
+
+    return <></>;
+  }
+
+  public static Component = ({ model }: SceneComponentProps<FieldValuesBreakdownScene>) => {
+    const { body } = model.useState();
+    // @todo why are the types like this?
+    if (body instanceof LayoutSwitcher) {
+      return <>{body && <body.Component model={body} />}</>;
+    } else if (body instanceof SceneReactObject) {
+      return <>{body && <body.Component model={body} />}</>;
+    }
+
+    return <LoadingPlaceholder text={'Loading...'} />;
+  };
 
   onActivate() {
     const groupByVariable = getFieldGroupByVariable(this);
@@ -209,25 +231,4 @@ export class FieldValuesBreakdownScene extends SceneObjectBase<FieldValuesBreakd
       ],
     });
   }
-
-  public static Selector({ model }: SceneComponentProps<FieldValuesBreakdownScene>) {
-    const { body } = model.useState();
-    if (body instanceof LayoutSwitcher) {
-      return <>{body && <body.Selector model={body} />}</>;
-    }
-
-    return <></>;
-  }
-
-  public static Component = ({ model }: SceneComponentProps<FieldValuesBreakdownScene>) => {
-    const { body } = model.useState();
-    // @todo why are the types like this?
-    if (body instanceof LayoutSwitcher) {
-      return <>{body && <body.Component model={body} />}</>;
-    } else if (body instanceof SceneReactObject) {
-      return <>{body && <body.Component model={body} />}</>;
-    }
-
-    return <LoadingPlaceholder text={'Loading...'} />;
-  };
 }

--- a/src/Components/ServiceScene/Breakdowns/FieldValuesBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldValuesBreakdownScene.tsx
@@ -11,27 +11,27 @@ import {
   SceneObjectState,
   SceneReactObject,
 } from '@grafana/scenes';
-import { buildDataQuery, LokiQuery } from '../../../services/query';
-import { getSortByPreference } from '../../../services/store';
-import { DataQueryError, LoadingState } from '@grafana/data';
-import { LayoutSwitcher } from './LayoutSwitcher';
-import { getQueryRunner } from '../../../services/panel';
-import { ByFrameRepeater } from './ByFrameRepeater';
-import { Alert, DrawStyle, LoadingPlaceholder } from '@grafana/ui';
-import { getFilterBreakdownValueScene } from '../../../services/fields';
-import { getLabelValue } from './SortByScene';
-import { getFieldGroupByVariable, VAR_FIELDS } from '../../../services/variables';
+import {buildDataQuery, LokiQuery} from '../../../services/query';
+import {getSortByPreference} from '../../../services/store';
+import {DataQueryError, LoadingState} from '@grafana/data';
+import {LayoutSwitcher} from './LayoutSwitcher';
+import {getQueryRunner} from '../../../services/panel';
+import {ByFrameRepeater} from './ByFrameRepeater';
+import {Alert, DrawStyle, LoadingPlaceholder} from '@grafana/ui';
+import {getFilterBreakdownValueScene} from '../../../services/fields';
+import {getLabelValue} from './SortByScene';
+import {getFieldGroupByVariable, VAR_FIELDS} from '../../../services/variables';
 import React from 'react';
 import {
   FIELDS_BREAKDOWN_GRID_TEMPLATE_COLUMNS,
   FieldsBreakdownScene,
   getFieldBreakdownExpr,
 } from './FieldsBreakdownScene';
-import { AddFilterEvent } from './AddToFiltersButton';
-import { navigateToDrilldownPage } from '../../../services/navigate';
-import { PageSlugs } from '../../../services/routing';
-import { ServiceScene } from '../ServiceScene';
-import { DEFAULT_SORT_BY } from '../../../services/sorting';
+import {AddFilterEvent} from './AddToFiltersButton';
+import {navigateToDrilldownPage} from '../../../services/navigate';
+import {PageSlugs} from '../../../services/routing';
+import {ServiceScene} from '../ServiceScene';
+import {DEFAULT_SORT_BY} from '../../../services/sorting';
 
 export interface FieldValuesBreakdownSceneState extends SceneObjectState {
   body?: LayoutSwitcher | SceneReactObject;
@@ -176,7 +176,8 @@ export class FieldValuesBreakdownScene extends SceneObjectBase<FieldValuesBreakd
           getLayoutChild: getFilterBreakdownValueScene(
             getLabelValue,
             query?.expr.includes('count_over_time') ? DrawStyle.Bars : DrawStyle.Line,
-            VAR_FIELDS
+            VAR_FIELDS,
+            sceneGraph.getAncestor(this, FieldsBreakdownScene).state.sort
           ),
           sortBy,
           direction,
@@ -198,7 +199,8 @@ export class FieldValuesBreakdownScene extends SceneObjectBase<FieldValuesBreakd
           getLayoutChild: getFilterBreakdownValueScene(
             getLabelValue,
             query?.expr.includes('count_over_time') ? DrawStyle.Bars : DrawStyle.Line,
-            VAR_FIELDS
+            VAR_FIELDS,
+            sceneGraph.getAncestor(this, FieldsBreakdownScene).state.sort
           ),
           sortBy,
           direction,

--- a/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
@@ -11,14 +11,14 @@ import {
   SceneObjectState,
   SceneReactObject,
 } from '@grafana/scenes';
-import { LayoutSwitcher } from './LayoutSwitcher';
-import { getLabelValue } from './SortByScene';
-import { DrawStyle, LoadingPlaceholder, StackingMode } from '@grafana/ui';
-import { getQueryRunner, setLevelColorOverrides } from '../../../services/panel';
-import { getSortByPreference } from '../../../services/store';
-import { LoadingState } from '@grafana/data';
-import { ByFrameRepeater } from './ByFrameRepeater';
-import { getFilterBreakdownValueScene } from '../../../services/fields';
+import {LayoutSwitcher} from './LayoutSwitcher';
+import {getLabelValue} from './SortByScene';
+import {DrawStyle, LoadingPlaceholder, StackingMode} from '@grafana/ui';
+import {getQueryRunner, setLevelColorOverrides} from '../../../services/panel';
+import {getSortByPreference} from '../../../services/store';
+import {LoadingState} from '@grafana/data';
+import {ByFrameRepeater} from './ByFrameRepeater';
+import {getFilterBreakdownValueScene} from '../../../services/fields';
 import {
   ALL_VARIABLE_VALUE,
   getLabelGroupByVariable,
@@ -28,13 +28,13 @@ import {
   VAR_LABELS,
 } from '../../../services/variables';
 import React from 'react';
-import { LABEL_BREAKDOWN_GRID_TEMPLATE_COLUMNS, LabelBreakdownScene } from './LabelBreakdownScene';
-import { buildDataQuery } from '../../../services/query';
-import { navigateToDrilldownPage } from '../../../services/navigate';
-import { PageSlugs } from '../../../services/routing';
-import { ServiceScene } from '../ServiceScene';
-import { AddFilterEvent } from './AddToFiltersButton';
-import { DEFAULT_SORT_BY } from '../../../services/sorting';
+import {LABEL_BREAKDOWN_GRID_TEMPLATE_COLUMNS, LabelBreakdownScene} from './LabelBreakdownScene';
+import {buildDataQuery} from '../../../services/query';
+import {navigateToDrilldownPage} from '../../../services/navigate';
+import {PageSlugs} from '../../../services/routing';
+import {ServiceScene} from '../ServiceScene';
+import {AddFilterEvent} from './AddToFiltersButton';
+import {DEFAULT_SORT_BY} from '../../../services/sorting';
 
 export interface LabelValueBreakdownSceneState extends SceneObjectState {
   body?: LayoutSwitcher;
@@ -177,7 +177,7 @@ export class LabelValuesBreakdownScene extends SceneObjectBase<LabelValueBreakdo
               }),
             ],
           }),
-          getLayoutChild: getFilterBreakdownValueScene(getLabelValue, DrawStyle.Bars, VAR_LABELS),
+          getLayoutChild: getFilterBreakdownValueScene(getLabelValue, DrawStyle.Bars, VAR_LABELS, sceneGraph.getAncestor(this, LabelBreakdownScene).state.sort),
           sortBy,
           direction,
           getFilter,
@@ -194,7 +194,7 @@ export class LabelValuesBreakdownScene extends SceneObjectBase<LabelValueBreakdo
               }),
             ],
           }),
-          getLayoutChild: getFilterBreakdownValueScene(getLabelValue, DrawStyle.Bars, VAR_LABELS),
+          getLayoutChild: getFilterBreakdownValueScene(getLabelValue, DrawStyle.Bars, VAR_LABELS, sceneGraph.getAncestor(this, LabelBreakdownScene).state.sort),
           sortBy,
           direction,
           getFilter,

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -7,9 +7,8 @@ import { getSortByPreference, setSortByPreference } from 'services/store';
 import { testIds } from '../../../services/testIds';
 import { DEFAULT_SORT_BY } from '../../../services/sorting';
 
-
-export type SortBy = 'changepoint' | 'outliers' | ReducerID
-export type SortDirection = 'asc' | 'desc'
+export type SortBy = 'changepoint' | 'outliers' | ReducerID | '';
+export type SortDirection = 'asc' | 'desc';
 export interface SortBySceneState extends SceneObjectState {
   target: 'fields' | 'labels';
   sortBy: SortBy;
@@ -24,7 +23,7 @@ export class SortCriteriaChanged extends BusEventBase {
 }
 
 export class SortByScene extends SceneObjectBase<SortBySceneState> {
-  public sortingOptions: Array<{label: string, options: SelectableValue<SortBy>}> = [
+  public sortingOptions: Array<{ label: string; options: SelectableValue<SortBy> }> = [
     {
       label: '',
       options: [
@@ -100,8 +99,12 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
 
   public static Component = ({ model }: SceneComponentProps<SortByScene>) => {
     const { sortBy, direction } = model.useState();
-    const group = model.sortingOptions.find((group) => group.options.find((option: SelectableValue<SortBy>) => option.value === sortBy));
-    const sortByValue: SelectableValue<SortBy> | undefined = group?.options.find((option: SelectableValue<SortBy>) => option.value === sortBy);
+    const group = model.sortingOptions.find((group) =>
+      group.options.find((option: SelectableValue<SortBy>) => option.value === sortBy)
+    );
+    const sortByValue: SelectableValue<SortBy> | undefined = group?.options.find(
+      (option: SelectableValue<SortBy>) => option.value === sortBy
+    );
     return (
       <>
         <InlineField>

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -7,10 +7,13 @@ import { getSortByPreference, setSortByPreference } from 'services/store';
 import { testIds } from '../../../services/testIds';
 import { DEFAULT_SORT_BY } from '../../../services/sorting';
 
+
+export type SortBy = 'changepoint' | 'outliers' | ReducerID
+export type SortDirection = 'asc' | 'desc'
 export interface SortBySceneState extends SceneObjectState {
   target: 'fields' | 'labels';
-  sortBy: string;
-  direction: string;
+  sortBy: SortBy;
+  direction: SortDirection;
 }
 
 export class SortCriteriaChanged extends BusEventBase {
@@ -21,7 +24,7 @@ export class SortCriteriaChanged extends BusEventBase {
 }
 
 export class SortByScene extends SceneObjectBase<SortBySceneState> {
-  public sortingOptions = [
+  public sortingOptions: Array<{label: string, options: SelectableValue<SortBy>}> = [
     {
       label: '',
       options: [
@@ -72,7 +75,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
     });
   }
 
-  public onCriteriaChange = (criteria: SelectableValue<string>) => {
+  public onCriteriaChange = (criteria: SelectableValue<SortBy>) => {
     if (!criteria.value) {
       return;
     }
@@ -81,7 +84,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
     this.publishEvent(new SortCriteriaChanged(this.state.target, criteria.value, this.state.direction), true);
   };
 
-  public onDirectionChange = (direction: SelectableValue<string>) => {
+  public onDirectionChange = (direction: SelectableValue<SortDirection>) => {
     if (!direction.value) {
       return;
     }
@@ -92,8 +95,8 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
 
   public static Component = ({ model }: SceneComponentProps<SortByScene>) => {
     const { sortBy, direction } = model.useState();
-    const group = model.sortingOptions.find((group) => group.options.find((option) => option.value === sortBy));
-    const value = group?.options.find((option) => option.value === sortBy);
+    const group = model.sortingOptions.find((group) => group.options.find((option: SelectableValue<SortBy>) => option.value === sortBy));
+    const sortByValue: SelectableValue<SortBy> | undefined = group?.options.find((option: SelectableValue<SortBy>) => option.value === sortBy);
     return (
       <>
         <InlineField>
@@ -122,7 +125,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
         >
           <Select
             data-testid={testIds.breakdowns.common.sortByFunction}
-            value={value}
+            value={sortByValue}
             width={20}
             isSearchable={true}
             options={model.sortingOptions}

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -77,10 +77,10 @@ export function getFilterBreakdownValueScene(
   getTitle: (df: DataFrame) => string,
   style: DrawStyle,
   variableName: typeof VAR_FIELDS | typeof VAR_LABELS,
-  sort: SortByScene
+  sortByScene: SortByScene
 ) {
   return (frame: DataFrame, frameIndex: number) => {
-    const reducerID = getReducerId(sort.state.sortBy);
+    const reducerID = getReducerId(sortByScene.state.sortBy);
     const panel = PanelBuilders.timeseries() //
       .setOption('legend', { showLegend: false })
       .setCustomFieldConfig('fillOpacity', 9)

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -1,4 +1,5 @@
 import pluginJson from '../plugin.json';
+import {SortBy, SortDirection} from "../Components/ServiceScene/Breakdowns/SortByScene";
 
 const SERVICES_LOCALSTORAGE_KEY = `${pluginJson.id}.services.favorite`;
 const DS_LOCALSTORAGE_KEY = `${pluginJson.id}.datasource`;
@@ -59,13 +60,15 @@ export function addLastUsedDataSourceToStorage(dsKey: string) {
 }
 
 const SORT_BY_LOCALSTORAGE_KEY = `${pluginJson.id}.values.sort`;
-export function getSortByPreference(target: string, defaultSortBy: string, defaultDirection: 'desc' | 'asc') {
-  const preference = localStorage.getItem(`${SORT_BY_LOCALSTORAGE_KEY}.${target}.by`) ?? '';
+export function getSortByPreference(target: string, defaultSortBy: SortBy, defaultDirection: SortDirection): {sortBy: SortBy | '', direction: SortDirection} {
+  const preference  = (localStorage.getItem(`${SORT_BY_LOCALSTORAGE_KEY}.${target}.by`) ?? '');
   const parts = preference.split('.');
   if (!parts[0] || !parts[1]) {
     return { sortBy: defaultSortBy, direction: defaultDirection };
   }
-  return { sortBy: parts[0], direction: parts[1] };
+  const sortBy = parts[0] as SortBy
+  const direction = parts[1] as SortDirection
+  return { sortBy, direction };
 }
 
 export function setSortByPreference(target: string, sortBy: string, direction: string) {

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -1,5 +1,5 @@
 import pluginJson from '../plugin.json';
-import {SortBy, SortDirection} from "../Components/ServiceScene/Breakdowns/SortByScene";
+import { SortBy, SortDirection } from '../Components/ServiceScene/Breakdowns/SortByScene';
 
 const SERVICES_LOCALSTORAGE_KEY = `${pluginJson.id}.services.favorite`;
 const DS_LOCALSTORAGE_KEY = `${pluginJson.id}.datasource`;
@@ -60,14 +60,18 @@ export function addLastUsedDataSourceToStorage(dsKey: string) {
 }
 
 const SORT_BY_LOCALSTORAGE_KEY = `${pluginJson.id}.values.sort`;
-export function getSortByPreference(target: string, defaultSortBy: SortBy, defaultDirection: SortDirection): {sortBy: SortBy | '', direction: SortDirection} {
-  const preference  = (localStorage.getItem(`${SORT_BY_LOCALSTORAGE_KEY}.${target}.by`) ?? '');
+export function getSortByPreference(
+  target: string,
+  defaultSortBy: SortBy,
+  defaultDirection: SortDirection
+): { sortBy: SortBy | ''; direction: SortDirection } {
+  const preference = localStorage.getItem(`${SORT_BY_LOCALSTORAGE_KEY}.${target}.by`) ?? '';
   const parts = preference.split('.');
   if (!parts[0] || !parts[1]) {
     return { sortBy: defaultSortBy, direction: defaultDirection };
   }
-  const sortBy = parts[0] as SortBy
-  const direction = parts[1] as SortDirection
+  const sortBy = parts[0] as SortBy;
+  const direction = parts[1] as SortDirection;
   return { sortBy, direction };
 }
 


### PR DESCRIPTION
Fixes: https://github.com/grafana/explore-logs/issues/499

When sorting by a calc value, we add that to the legend:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/77b45ab0-33dc-4820-b75d-7dc7dccd735f">

If using a non-calc value, the panels show up as they currently do:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d0c58b98-272b-4135-8d34-79336b8e5c0b">

Note: this doesn't add the calcs to the single view, 
Also since we renamed the calc values, the names don't line up with what is presented in the legend.
