### PR TITLE
fix: grafana image tag

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.0'
 
 services:
   grafana:
-    image: grafana/grafana:11.2
+    image: grafana/grafana:11.2.0
     environment:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_ANONYMOUS_ENABLED=true


### PR DESCRIPTION
Fix the Grafana image tag as the `11.2` tag is not existing:

> Error response from daemon: manifest for grafana/grafana:11.2 not found: manifest unknown: manifest unknown