### PR TITLE
Sync loki versions in docker-compose.dev.yaml

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -19,7 +19,7 @@ services:
     extra_hosts:
       - 'host.docker.internal:host-gateway'
   loki:
-    image: grafana/loki:main
+    image: grafana/loki:main-d43b2de
     environment:
       LOG_CLUSTER_DEPTH: '8'
       LOG_SIM_TH: '0.3'


### PR DESCRIPTION
Appears to be breaking e2e tests