### PR TITLE
generator: add new service with mix of json and logfmt

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -92,7 +92,23 @@ var generators = map[model.LabelValue]map[model.LabelValue]LogGenerator{
 				}
 			}()
 		},
+		"nginx-json-mixed": func(ctx context.Context, logger *AppLogger) {
+			go func() {
+				for ctx.Err() == nil {
+					level := randLevel()
+					t := time.Now()
+					if rand.Intn(10)%2 == 0 && level == ERROR {
+						log := flog.NewCommonLogFormat(t, randURI(), statusFromLevel(level))
+						// Add a stacktrace to the logfmt log, and include a field that will conflict with stream selectors
+						logger.Log(level, t, fmt.Sprintf("%s %s", log, `namespace=whoopsie caller=flush.go:253 stacktrace="Exception in thread \"main\" java.lang.NullPointerException\n        at com.example.myproject.Book.getTitle(Book.java:16)\n        at com.example.myproject.Author.getBookTitles(Author.java:25)\n        at com.example.myproject.Bootstrap.main(Bootstrap.java:14)"`))
+					}
+					logger.Log(level, t, flog.NewJSONLogFormat(t, randURI(), statusFromLevel(level)))
+					time.Sleep(time.Duration(rand.Intn(5000)) * time.Millisecond)
+				}
+			}()
+		},
 	},
+
 	"mimir-dev": {
 		"mimir-ingester":    mimirPod,
 		"mimir-distributor": mimirPod,

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -100,7 +100,7 @@ var generators = map[model.LabelValue]map[model.LabelValue]LogGenerator{
 					if rand.Intn(10)%2 == 0 && level == ERROR {
 						log := flog.NewCommonLogFormat(t, randURI(), statusFromLevel(level))
 						// Add a stacktrace to the logfmt log, and include a field that will conflict with stream selectors
-						logger.Log(level, t, fmt.Sprintf("%s %s", log, `namespace=whoopsie caller=flush.go:253 stacktrace="Exception in thread \"main\" java.lang.NullPointerException\n        at com.example.myproject.Book.getTitle(Book.java:16)\n        at com.example.myproject.Author.getBookTitles(Author.java:25)\n        at com.example.myproject.Bootstrap.main(Bootstrap.java:14)"`))
+						logger.Log(level, t, fmt.Sprintf("%s %s", log, `method=GET namespace=whoopsie caller=flush.go:253 stacktrace="Exception in thread \"main\" java.lang.NullPointerException\n        at com.example.myproject.Book.getTitle(Book.java:16)\n        at com.example.myproject.Author.getBookTitles(Author.java:25)\n        at com.example.myproject.Bootstrap.main(Bootstrap.java:14)"`))
 					}
 					logger.Log(level, t, flog.NewJSONLogFormat(t, randURI(), statusFromLevel(level)))
 					time.Sleep(time.Duration(rand.Intn(5000)) * time.Millisecond)

--- a/project-words.txt
+++ b/project-words.txt
@@ -473,3 +473,5 @@ REFID
 unroute
 myown
 yass
+whoopsie
+myproject


### PR DESCRIPTION
Adding more test cases for e2e tests and local testing.
* New service (`nginx-json-mixed`) with mix of JSON and logfmt
* 50% of errors (2.5% of all log lines) will log an additional line containing:
* * Stacktrace with newlines
* * field that conflicts with stream selector
* * Common field in logfmt line and json lines