### PR TITLE
Logs Volume Panel: properly handle "logs" detected level

### DIFF
--- a/src/services/levels.test.ts
+++ b/src/services/levels.test.ts
@@ -5,6 +5,7 @@ import { getLevelsVariable, VAR_LEVELS } from './variables';
 import { AdHocFiltersVariable, SceneObject } from '@grafana/scenes';
 import { FilterOp } from './filters';
 import { addToFilters, replaceFilter } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
+import { LEVEL_NAME } from 'Components/Table/constants';
 
 jest.mock('./variables');
 jest.mock('Components/ServiceScene/Breakdowns/AddToFiltersButton');
@@ -172,6 +173,28 @@ describe('getVisibleLevels', () => {
     ]);
     expect(getVisibleLevels(['error', 'warn', 'info', 'debug'], scene)).toEqual(['info']);
   });
+
+  it('Handles empty positive log level filter', () => {
+    setup([
+      {
+        key: 'detected_level',
+        operator: FilterOp.Equal,
+        value: '""',
+      },
+    ]);
+    expect(getVisibleLevels(['error', 'logs'], scene)).toEqual(['logs']);
+  });
+
+  it('Handles negative positive log level filter', () => {
+    setup([
+      {
+        key: 'detected_level',
+        operator: FilterOp.NotEqual,
+        value: '""',
+      },
+    ]);
+    expect(getVisibleLevels(['error', 'logs'], scene)).toEqual(['error']);
+  });
 });
 
 describe('toggleLevelFromFilter', () => {
@@ -208,5 +231,12 @@ describe('toggleLevelFromFilter', () => {
 
     expect(toggleLevelFromFilter('info', scene)).toBe('remove');
     expect(addToFilters).toHaveBeenCalledTimes(1);
+  });
+
+  it('Handles empty log levels', () => {
+    setup([]);
+
+    expect(toggleLevelFromFilter('logs', scene)).toBe('add');
+    expect(replaceFilter).toHaveBeenCalledWith(LEVEL_NAME, '""', 'include', scene);
   });
 });

--- a/src/services/levels.ts
+++ b/src/services/levels.ts
@@ -61,16 +61,23 @@ export function getVisibleLevels(allLevels: string[], sceneRef: SceneObject) {
   const levelsFilter = getLevelsVariable(sceneRef);
   const wantedLevels = levelsFilter.state.filters
     .filter((filter) => filter.operator === FilterOp.Equal)
-    .map((filter) => filter.value);
+    .map((filter) => normalizeLevelName(filter.value));
   const unwantedLevels = levelsFilter.state.filters
     .filter((filter) => filter.operator === FilterOp.NotEqual)
-    .map((filter) => filter.value);
+    .map((filter) => normalizeLevelName(filter.value));
   return allLevels.filter((level) => {
     if (unwantedLevels.includes(level)) {
       return false;
     }
     return wantedLevels.length === 0 || wantedLevels.includes(level);
   });
+}
+
+function normalizeLevelName(level: string) {
+  if (level === '""') {
+    return 'logs';
+  }
+  return level;
 }
 
 /**
@@ -85,6 +92,11 @@ export function toggleLevelFromFilter(level: string, sceneRef: SceneObject) {
   const filterExists = levelFilter.state.filters.find(
     (filter) => filter.value === level && filter.operator === FilterOp.Equal
   );
+
+  if (level === 'logs') {
+    level = '""';
+  }
+
   let action;
   if (empty || !filterExists) {
     replaceFilter(LEVEL_VARIABLE_VALUE, level, 'include', sceneRef);


### PR DESCRIPTION
Before these changes, selecting "logs" in the Logs Volume panel would result in no data, applying an incorrect filter.

<img width="1509" alt="imagen" src="https://github.com/user-attachments/assets/a6befce8-609d-40bb-955f-f2a5cd42737e">

Fixes #746