### PR TITLE
fix(service-selection-scrolling): remove forced overflow scroll

### DIFF
--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -400,7 +400,6 @@ function getStyles(theme: GrafanaTheme2) {
       flexDirection: 'column',
     }),
     body: css({
-      overflowY: 'scroll',
       flexGrow: 1,
       display: 'flex',
       flexDirection: 'column',


### PR DESCRIPTION
Currently I see two scrollbars. The inner scroll isn't needed anymore, thus we can remove the "forced" `overflow-y: scroll`.
<img width="64" alt="image" src="https://github.com/user-attachments/assets/0282c80c-dc88-483e-8b3f-3d0624355ffb">
