### PR TITLE
fix(patterns-breakdown): fix expression to create pattern key breakdown

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.test.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.test.tsx
@@ -1,0 +1,113 @@
+import { LoadingState } from '@grafana/data';
+import { sceneGraph } from '@grafana/scenes';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { of } from 'rxjs';
+import { PatternNameLabel } from './PatternNameLabel';
+
+const mockResult = {
+  state: LoadingState.Done,
+  data: [
+    {
+      fields: [
+        {
+          values: {
+            toArray: () => [
+              { field_1: 'value1', field_2: 'value2' },
+              { field_1: 'value3', field_2: 'value4' },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+};
+
+jest.mock('@grafana/scenes', () => {
+  const actualScenes = jest.requireActual('@grafana/scenes'); // Require the actual module
+
+  return {
+    ...actualScenes,
+    sceneGraph: {
+      ...actualScenes.sceneGraph,
+      getTimeRange: jest.fn().mockReturnValue({
+        state: { value: { from: 'now-1h', to: 'now' } },
+      }),
+    },
+  };
+});
+
+jest.mock('services/analytics', () => ({
+  ...jest.requireActual('services/analytics'),
+  reportAppInteraction: jest.fn(),
+}));
+
+const mockQuery = jest.fn().mockReturnValue(of([mockResult]));
+const mockDatasource = { query: mockQuery };
+
+jest.mock('services/scenes', () => ({
+  ...jest.requireActual('services/scenes'),
+  getLokiDatasource: jest.fn().mockImplementation(() => mockDatasource),
+}));
+
+jest.mock('services/variables', () => ({
+  ...jest.requireActual('services/variables'),
+  getLabelsVariable: jest.fn().mockReturnValue({ state: { filterExpression: 'foo="bar"' } }),
+}));
+
+const explorationMock = {} as any;
+
+describe('PatternNameLabel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (sceneGraph.getTimeRange as jest.Mock).mockReturnValue({
+      state: { value: { from: 'now-1h', to: 'now' } },
+    });
+  });
+
+  it('calls data source query correctly', async () => {
+    render(<PatternNameLabel exploration={explorationMock} pattern="test <_> pattern" />);
+
+    const patternElement = screen.getByText('<_>');
+    userEvent.click(patternElement);
+
+    await waitFor(() => {
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targets: [
+            expect.objectContaining({
+              expr: expect.stringContaining('{foo="bar"} |> `test <_> pattern` | pattern `test <field_1> pattern`'),
+            }),
+          ],
+        })
+      );
+    });
+  });
+
+  it('calls datasource query', async () => {
+    render(<PatternNameLabel exploration={explorationMock} pattern="test <_> pattern" />);
+
+    const patternElement = screen.getByText('<_>');
+    userEvent.click(patternElement);
+
+    // Wait for the data fetching to complete
+    await waitFor(() => {
+      expect(mockQuery).toHaveBeenCalled();
+    });
+  });
+
+  it('avoids duplicate queries for the same pattern and time range', async () => {
+    render(<PatternNameLabel exploration={explorationMock} pattern="test <_> pattern" />);
+
+    const patternElement = screen.getByText('<_>');
+    userEvent.click(patternElement);
+
+    await waitFor(() => {
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    userEvent.click(patternElement);
+    expect(mockQuery).toHaveBeenCalledTimes(1); // still 1 because no new query is fired
+  });
+});

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
@@ -160,5 +160,5 @@ function constructQuery(pattern: string, patternIndices: number[], filters: AdHo
   const patternExtractor = pattern.replace(/<_>/g, () => `<field_${fieldIndex++}>`);
   const filterExpression = filters.state.filterExpression;
   const fields = patternIndices.map((_value, index) => `field_${index + 1}`).join(' ,');
-  return `${filterExpression} |> \`${pattern}\` | pattern \`${patternExtractor}\` | keep ${fields} | line_format ""`;
+  return `{${filterExpression}} |> \`${pattern}\` | pattern \`${patternExtractor}\` | keep ${fields} | line_format ""`;
 }

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -370,7 +370,7 @@ test.describe('explore services breakdown page', () => {
       refIds: ['A'],
     });
     await page.getByTestId(testIds.exploreServiceDetails.tabPatterns).click();
-    const key = page.getByText('<_>').first().click();
+    const key = page.getByText('<_>').last().click();
     // `From a sample of` is the indicator that the underlying query perfomed successfully
     await expect(page.getByText(`From a sample of`)).toBeVisible();
   });

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -365,6 +365,16 @@ test.describe('explore services breakdown page', () => {
     await expect(page.getByTestId(`data-testid Dashboard template variables submenu Label ${fieldName}`)).toBeVisible();
   });
 
+  test('should show sample table on `<_>` click in patterns', async ({ page }) => {
+    explorePage.blockAllQueriesExcept({
+      refIds: ['A'],
+    });
+    await page.getByTestId(testIds.exploreServiceDetails.tabPatterns).click();
+    const key = page.getByText('<_>').first().click();
+    // `From a sample of` is the indicator that the underlying query perfomed successfully
+    await expect(page.getByText(`From a sample of`)).toBeVisible();
+  });
+
   test('should filter patterns in table on legend click', async ({ page }) => {
     await page.getByTestId(testIds.exploreServiceDetails.tabPatterns).click();
     const row = page.getByTestId(testIds.patterns.tableWrapper).getByRole('table').getByRole('row');


### PR DESCRIPTION
The query expression used to create pattern-key breakdowns is currently broken and missing the enclosing brackets (`{` and `}`).