### PR TITLE
Shard query splitting: send the whole stream selector to fetch shard values

### DIFF
--- a/src/services/logql.ts
+++ b/src/services/logql.ts
@@ -159,19 +159,12 @@ export const interpolateShardingSelector = (queries: LokiQuery[], shards?: numbe
   }));
 };
 
-export const getServiceNameFromQuery = (query: string) => {
-  const matchers = getNodesFromQuery(query, [Matcher]);
-  for (let i = 0; i < matchers.length; i++) {
-    const idNode = matchers[i].getChild(Identifier);
-    const stringNode = matchers[i].getChild(String);
-    if (!idNode || !stringNode) {
-      continue;
-    }
-    const identifier = query.substring(idNode.from, idNode.to);
-    const value = query.substring(stringNode.from, stringNode.to);
-    if (identifier === 'service_name') {
-      return value;
-    }
+export const getSelectorForShardValues = (query: string) => {
+  const selector = getNodesFromQuery(query, [Selector]);
+  if (selector.length > 0) {
+    return query
+      .substring(selector[0].from, selector[0].to)
+      .replace(`, __stream_shard__=~"${SHARDING_PLACEHOLDER}"}`, '}');
   }
   return '';
 };

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -5,7 +5,7 @@ import { DataQueryRequest, LoadingState, DataQueryResponse, TimeRange } from '@g
 import { LokiQuery } from './query';
 import {
   addShardingPlaceholderSelector,
-  getServiceNameFromQuery,
+  getSelectorForShardValues,
   interpolateShardingSelector,
   isLogsQuery,
 } from './logql';
@@ -167,11 +167,11 @@ function splitQueriesByStreamShard(
   };
 
   const response = new Observable<DataQueryResponse>((subscriber) => {
-    const serviceName = getServiceNameFromQuery(splittingTargets[0].expr);
+    const selector = getSelectorForShardValues(splittingTargets[0].expr);
     datasource.languageProvider
       .fetchLabelValues('__stream_shard__', {
         timeRange: request.range,
-        streamSelector: serviceName ? `{service_name=${serviceName}}` : undefined,
+        streamSelector: selector ? selector : undefined,
       })
       .then((values: string[]) => {
         const shards = values.map((value) => parseInt(value, 10));


### PR DESCRIPTION
Seen in some recent tests in ops, where with filters applied that generated a new stream selector, we were getting all the shard values instead of those that correspond to that particular query.