### PR TITLE
label values: fix label values stuck in loading state

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ByFrameRepeater.tsx
@@ -49,8 +49,12 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
       const data = sceneGraph.getData(this);
 
       this._subs.add(
-        data.subscribeToState((data) => {
-          if (data.data?.state === LoadingState.Done) {
+        data.subscribeToState((data, prevData) => {
+          if (
+            data.data?.state === LoadingState.Done ||
+            (data.data?.state === LoadingState.Streaming &&
+              data.data.series.length > (prevData.data?.series.length ?? 0))
+          ) {
             this.performRepeat(data.data);
           }
         })

--- a/src/Components/ServiceScene/Breakdowns/FieldValuesBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldValuesBreakdownScene.tsx
@@ -7,6 +7,7 @@ import {
   SceneFlexItem,
   SceneFlexLayout,
   sceneGraph,
+  SceneObject,
   SceneObjectBase,
   SceneObjectState,
   SceneReactObject,
@@ -30,7 +31,7 @@ import { getDetectedFieldsFrame, ServiceScene } from '../ServiceScene';
 import { DEFAULT_SORT_BY } from '../../../services/sorting';
 
 export interface FieldValuesBreakdownSceneState extends SceneObjectState {
-  body?: LayoutSwitcher | SceneReactObject;
+  body?: (LayoutSwitcher & SceneObject) | (SceneReactObject & SceneObject);
   $data?: SceneDataProvider;
   lastFilterEvent?: AddFilterEvent;
 }
@@ -52,10 +53,7 @@ export class FieldValuesBreakdownScene extends SceneObjectBase<FieldValuesBreakd
 
   public static Component = ({ model }: SceneComponentProps<FieldValuesBreakdownScene>) => {
     const { body } = model.useState();
-    // @todo why are the types like this?
-    if (body instanceof LayoutSwitcher) {
-      return <>{body && <body.Component model={body} />}</>;
-    } else if (body instanceof SceneReactObject) {
+    if (body) {
       return <>{body && <body.Component model={body} />}</>;
     }
 

--- a/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
@@ -124,7 +124,7 @@ export class LabelValuesBreakdownScene extends SceneObjectBase<LabelValueBreakdo
     // If we're in an error state
     if (newState.data?.state === LoadingState.Error && this.activeLayoutContainsNoPanels()) {
       const activeLayout = this.getActiveLayout();
-      // And the active layout is not showing panels
+      // And the active layout is grid or rows, and doesn't have any panels
       if (activeLayout instanceof ByFrameRepeater) {
         const errorState = this.getErrorStateAlert(newState.data.errors);
         // Replace the loading or error state with new error

--- a/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
@@ -161,7 +161,7 @@ export class LabelValuesBreakdownScene extends SceneObjectBase<LabelValueBreakdo
     return new SceneReactObject({
       reactNode: (
         <Alert title={'Something went wrong with your request'} severity={'error'}>
-          {errors?.map((err, key) => this.getErrorJSX(key, err))}
+          {errors?.map((err, key) => this.renderError(key, err))}
         </Alert>
       ),
     });
@@ -279,7 +279,7 @@ export class LabelValuesBreakdownScene extends SceneObjectBase<LabelValueBreakdo
       if (!this.activeLayoutContainsNoPanels()) {
         appEvents.publish({
           type: AppEvents.alertError.name,
-          payload: errorArray?.map((err, key) => this.getErrorJSX(key, err)),
+          payload: errorArray?.map((err, key) => this.renderError(key, err)),
         });
       }
       this.setState({
@@ -288,7 +288,7 @@ export class LabelValuesBreakdownScene extends SceneObjectBase<LabelValueBreakdo
     }
   }
 
-  private getErrorJSX(key: number, err: DataQueryError) {
+  private renderError(key: number, err: DataQueryError) {
     return (
       <div key={key}>
         {err.status && (


### PR DESCRIPTION
Fix bug in the label values where errors are not being surfaced to users and the loading state is left up indefinitely.

If panels are visible, the error will be surfaced within the viz panel, and as a toast message, if panels are not visible the error will be added to the body and remain visible until the next query response.

<img width="861" alt="image" src="https://github.com/user-attachments/assets/75aed416-7d79-468b-b0f3-f25bb3d7240a">
