### PR TITLE
fix: fall back to mixed parser if the field is missing parser in url parameter

### DIFF
--- a/src/services/variables.ts
+++ b/src/services/variables.ts
@@ -148,6 +148,14 @@ export function getValueFromFieldsFilter(filter: AdHocVariableFilter, variableNa
     return JSON.parse(filter.value);
   } catch (e) {
     console.error(`Failed to parse ${variableName}`, e);
+
+    // If the user has a URL from before 0.1.4 where detected_fields changed the format of the fields value to include the parser, fall back to mixed parser if we have a value
+    if (filter.value) {
+      return {
+        value: filter.value,
+        parser: 'mixed',
+      };
+    }
     throw e;
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/grafana/explore-logs/issues/787

To repro: either add `&page_attr_var_fields=user_id|=|123` to the end of an explore logs url, or create a url on a version of explore logs from before  containing fields from before https://github.com/grafana/explore-logs/pull/736 was merged (e.g. [0.1.3](https://github.com/grafana/explore-logs/releases/tag/v0.1.3))