### PR TITLE
Aggregated metrics: Use sum_over_time query for aggregated metric queries

### DIFF
--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -29,12 +29,12 @@ import { getFavoriteServicesFromStorage } from 'services/store';
 import {
   getDataSourceVariable,
   getLabelsVariable,
-  getServiceNameVariable,
+  getServiceLabelVariable,
   getServiceSelectionStringVariable,
   LEVEL_VARIABLE_VALUE,
   SERVICE_NAME,
-  SERVICE_NAME_EXPR,
-  SERVICE_NAME_VAR,
+  SERVICE_LABEL_EXPR,
+  SERVICE_LABEL_VAR,
   VAR_SERVICE,
   VAR_SERVICE_EXPR,
 } from 'services/variables';
@@ -85,9 +85,9 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
             value: '',
             skipUrlSync: true,
           }),
-          // Service name variable
+          // variable to store the service label to use
           new CustomConstantVariable({
-            name: SERVICE_NAME_VAR,
+            name: SERVICE_LABEL_VAR,
             label: '',
             hide: VariableHide.hideLabel,
             value: SERVICE_NAME,
@@ -106,7 +106,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
         ],
       }),
       $data: getSceneQueryRunner({
-        queries: [buildResourceQuery(`{${SERVICE_NAME_EXPR}=~\`.*${VAR_SERVICE_EXPR}.*\`}`, 'volume')],
+        queries: [buildResourceQuery(`{${SERVICE_LABEL_EXPR}=~\`.*${VAR_SERVICE_EXPR}.*\`}`, 'volume')],
         runQueriesMode: 'manual',
       }),
       serviceLevel: new Map<string, string[]>(),
@@ -179,7 +179,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
 
       // agg metrics need parser and unwrap, have to tear down and rebuild panels when the variable changes
       this._subs.add(
-        getServiceNameVariable(this).subscribeToState((newState, prevState) => {
+        getServiceLabelVariable(this).subscribeToState((newState, prevState) => {
           if (newState.value !== prevState.value) {
             // Clear the body panels
             this.setState({
@@ -232,12 +232,11 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
     const aggregatedMetricsActive =
       !toolbar?.state.options.aggregatedMetrics.disabled && toolbar?.state.options.aggregatedMetrics.active;
 
+    const serviceLabelVar = getServiceLabelVariable(this);
     if ((!this.isTimeRangeTooEarlyForAggMetrics() || !aggregatedMetricsEnabled) && aggregatedMetricsActive) {
-      const serviceName = getServiceNameVariable(this);
-      serviceName.changeValueTo(AGGREGATED_SERVICE_NAME);
+      serviceLabelVar.changeValueTo(AGGREGATED_SERVICE_NAME);
     } else {
-      const serviceName = getServiceNameVariable(this);
-      serviceName.changeValueTo(SERVICE_NAME);
+      serviceLabelVar.changeValueTo(SERVICE_NAME);
     }
     this.state.$data.runQueries();
   }
@@ -252,7 +251,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       const newChildren: SceneCSSGridItem[] = [];
       const existingChildren: SceneCSSGridItem[] = this.state.body.state.children as SceneCSSGridItem[];
       const timeRange = sceneGraph.getTimeRange(this).state.value;
-      const serviceNameVar = getServiceNameVariable(this);
+      const serviceLabelVar = getServiceLabelVariable(this);
 
       for (const service of servicesToQuery.slice(0, SERVICES_LIMIT)) {
         const existing = existingChildren.filter((child) => {
@@ -266,7 +265,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
         } else {
           // for each service, we create a layout with timeseries and logs panel
           newChildren.push(
-            this.buildServiceLayout(service, timeRange, serviceNameVar),
+            this.buildServiceLayout(service, timeRange, serviceLabelVar),
             this.buildServiceLogsLayout(service)
           );
         }
@@ -310,8 +309,8 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
     return `{${SERVICE_NAME}=\`${service}\`}${levelFilter}`;
   }
 
-  private getMetricExpression(service: string, serviceName: CustomConstantVariable) {
-    if (serviceName.state.value === AGGREGATED_SERVICE_NAME) {
+  private getMetricExpression(service: string, serviceLabelVar: CustomConstantVariable) {
+    if (serviceLabelVar.state.value === AGGREGATED_SERVICE_NAME) {
       return `sum by (${LEVEL_VARIABLE_VALUE}) (sum_over_time({${AGGREGATED_SERVICE_NAME}=\`${service}\`} | logfmt | unwrap count [$__auto]))`;
     }
     return `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME}=\`${service}\`} [$__auto]))`;
@@ -332,7 +331,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
   };
 
   // Creates a layout with timeseries panel
-  buildServiceLayout(service: string, timeRange: TimeRange, serviceName: CustomConstantVariable) {
+  buildServiceLayout(service: string, timeRange: TimeRange, serviceLabelVar: CustomConstantVariable) {
     let splitDuration;
     if (timeRange.to.diff(timeRange.from, 'hours') >= 4 && timeRange.to.diff(timeRange.from, 'hours') <= 26) {
       splitDuration = '2h';
@@ -342,7 +341,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       .setTitle(service)
       .setData(
         getQueryRunner([
-          buildDataQuery(this.getMetricExpression(service, serviceName), {
+          buildDataQuery(this.getMetricExpression(service, serviceLabelVar), {
             legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}`,
             splitDuration,
             refId: `ts-${service}`,

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -312,9 +312,9 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
 
   private getMetricExpression(service: string, serviceName: CustomConstantVariable) {
     if (serviceName.state.value === AGGREGATED_SERVICE_NAME) {
-      return `sum by (${LEVEL_VARIABLE_VALUE}) (sum_over_time({${AGGREGATED_SERVICE_NAME}=\`${service}\`} | logfmt | drop __error__ | unwrap count [$__auto]))`;
+      return `sum by (${LEVEL_VARIABLE_VALUE}) (sum_over_time({${AGGREGATED_SERVICE_NAME}=\`${service}\`} | logfmt | unwrap count [$__auto]))`;
     }
-    return `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`;
+    return `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME}=\`${service}\`} [$__auto]))`;
   }
 
   private extendTimeSeriesLegendBus = (service: string, context: PanelContext, panel: VizPanel) => {

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -314,7 +314,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
     if (serviceName.state.value === AGGREGATED_SERVICE_NAME) {
       return `sum by (${LEVEL_VARIABLE_VALUE}) (sum_over_time({${AGGREGATED_SERVICE_NAME}=\`${service}\`} | logfmt | drop __error__ | unwrap count [$__auto]))`;
     }
-    return `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME_EXPR}=\`${service}\`} | drop __error__ [$__auto]))`;
+    return `sum by (${LEVEL_VARIABLE_VALUE}) (count_over_time({${SERVICE_NAME}=\`${service}\`} | drop __error__ [$__auto]))`;
   }
 
   private extendTimeSeriesLegendBus = (service: string, context: PanelContext, panel: VizPanel) => {

--- a/src/services/variables.ts
+++ b/src/services/variables.ts
@@ -39,8 +39,8 @@ export const EXPLORATION_DS = { uid: VAR_DATASOURCE_EXPR };
 export const ALL_VARIABLE_VALUE = '$__all';
 export const LEVEL_VARIABLE_VALUE = 'detected_level';
 export const SERVICE_NAME = 'service_name';
-export const SERVICE_NAME_VAR = 'service_name_var';
-export const SERVICE_NAME_EXPR = '${service_name_var}';
+export const SERVICE_LABEL_VAR = 'service_label_var';
+export const SERVICE_LABEL_EXPR = '${service_label_var}';
 export const EMPTY_VARIABLE_VALUE = '""';
 
 export type ParserType = 'logfmt' | 'json' | 'mixed' | 'structuredMetadata';
@@ -108,10 +108,10 @@ export function getLabelGroupByVariable(scene: SceneObject) {
   return variable;
 }
 
-export function getServiceNameVariable(scene: SceneObject) {
-  const variable = sceneGraph.lookupVariable(SERVICE_NAME_VAR, scene);
+export function getServiceLabelVariable(scene: SceneObject) {
+  const variable = sceneGraph.lookupVariable(SERVICE_LABEL_VAR, scene);
   if (!(variable instanceof CustomConstantVariable)) {
-    throw new Error('SERVICE_NAME_VAR not found');
+    throw new Error('SERVICE_LABEL_VAR not found');
   }
   return variable;
 }


### PR DESCRIPTION
Current log counts being displayed are incorrect, the updated sum_over_time query unwrapping by count should return the correct volume counts.