### PR TITLE
docs: Copyedit and replacing relrefs

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -69,7 +69,7 @@ With Explore Logs, you get the same powerful insights, by just viewing and click
 Our new experiences are in their early stages, and we'd love to hear your feedback.
 
 - You'll find a **Give feedback** link on each Explore Logs page.
-- You can also fill out [this Google form](https://forms.gle/1sYWCTPvD72T1dPH9) to send your thoughts directly to the team building the apps.
+- You can also fill out [this Google form](https://forms.gle/1sYWCTPvD72T1dPH9) to send your thoughts directly to the team building Explore Logs.
 
 ## What's next?
 

--- a/docs/sources/access/_index.md
+++ b/docs/sources/access/_index.md
@@ -61,7 +61,7 @@ GF_INSTALL_PLUGINS=https://storage.googleapis.com/integration-artifacts/grafana-
 
 ### Install using grafana-cli
 
-You can install Explore Logs in your own Grafana instance using `grafana-cli`.  For more information about `grafana-cli` refer to the [documentation](https://grafana.com/docs/grafana/latest/cli/.)
+You can install Explore Logs in your own Grafana instance using `grafana-cli`. For more information about `grafana-cli` refer to the [documentation](https://grafana.com/docs/grafana/latest/cli/.)
 
 Using `grafana-cli` run the following command:
 

--- a/docs/sources/access/_index.md
+++ b/docs/sources/access/_index.md
@@ -40,8 +40,8 @@ For Enterprise and OSS Grafana users, you can install Explore Logs via the [Graf
 
 The following Loki and Grafana version and configuration are required:
 
-- Grafana v11.0.0+
-- Loki v3.0.0+
+- Grafana v11.2.0 or later
+- Loki v3.2.0 or later
 
   - Enable pattern ingestion by setting `--pattern-ingester.enabled=true` in your Loki configuration.
   - Enable the volume endpoint in your Loki configuration:
@@ -61,7 +61,7 @@ GF_INSTALL_PLUGINS=https://storage.googleapis.com/integration-artifacts/grafana-
 
 ### Install using grafana-cli
 
-You can install Explore Logs in your own Grafana instance using `grafana-cli`.
+You can install Explore Logs in your own Grafana instance using `grafana-cli`.  For more information about `grafana-cli` refer to the [documentation](https://grafana.com/docs/grafana/latest/cli/.)
 
 Using `grafana-cli` run the following command:
 
@@ -85,8 +85,9 @@ Once the docker container has started, navigate to `http://localhost:3000/a/graf
 
 ## Having trouble?
 
-Check out our [troubleshooting guides]({{< relref "../troubleshooting" >}}) for tips on how to solve common issues.
+Refer to the [troubleshooting guide]({{< relref "../troubleshooting" >}}) for tips on how to solve common issues.
 
 ## What next?
 
-Once you're set up, you'll need to configure a data source in order to access your logs in Explore Logs. Our Get Started guide includes a section on how to [set up a new Loki datasource]({{< relref "../get-started#set-up-a-new-loki-datasource" >}}).
+Before you can use Explore Logs, an administrator must configure a Loki data source in order to access your logs in Explore Logs.
+Refer to the [Loki data source documentation](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/loki/) for instructions.

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -14,7 +14,7 @@ weight: 300
 # Get started with Explore Logs
 
 The best way to see what Explore Logs can do for you is to use it to explore your own data.
-If you have a Grafana Cloud account can access Explore logs in Grafana Cloud by selecting **Explore** > **Logs**, or you can [install Explore Logs]({{< relref "../access" >}}) in your own Grafana instance.
+If you have a Grafana Cloud account, you can access Explore logs by selecting **Explore** > **Logs**, or you can [install Explore Logs](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/access/) in your own Grafana instance.
 
 To learn more, check out our overview video:
 
@@ -24,27 +24,27 @@ To learn more, check out our overview video:
 
 We will walk through a simple step-by-step guided tour of Explore Logs.
 
-While you are browsing around the app, look out for any unexpected spikes in your logs. Or perhaps one of your services is down and has stopped logging. Maybe you're seeing an increase in errors after a recent release.
+While you are browsing your log data in Explore Logs, watch for any unexpected spikes in your logs. Or perhaps one of your services is down and has stopped logging. Maybe you're seeing an increase in errors after a recent release.
 
 {{< figure alt="Explore Logs Service overview page" width="900px" align="center" src="../images/service_index.png" caption="Service Overview page" >}}
 
 To take a tour of Explore Logs, follow these steps:
 
 1. From the Grafana main menu, select **Explore** > **Logs**.
-1. This opens the **Service overview page** showing time series and log visualizations for all the services in your selected Loki instance. ([No services?]({{< relref "../troubleshooting#there-are-no-services" >}}))
-1. Change your data source from the menu on the top left, then select a recent time range. You can modify your time range in two ways:
+1. This opens the **Service overview page** showing time series and log visualizations for all the services in your selected Loki instance. ([No services?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-services))
+1. Change your **Data source** from the menu on the top left, then select a recent time range. You can modify your time range in two ways:
    - With the standard time range picker on the top right.
    - By clicking and dragging the time range on any time series visualization.
 1. Services are shown based on the volume of logs, or you can use the **Search Services** field to search for the service by name.
 1. To explore logs for a service, slick the **Select** button on the service graph.
-1. On the service details page, click the **Labels** tab to see visualizations of the log volume for each label. ([No labels?]({{< relref "../troubleshooting/#there-are-no-labels" >}}))
+1. On the service details page, click the **Labels** tab to see visualizations of the log volume for each label. ([No labels?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-labels))
 1. On the **Labels** tab, select a label to see the log volume for each value of that label.
-   Explore Logs shows you the volume of logs with specific labels and fields. Learn more about [Labels and Fields]({{< relref "../labels-and-fields" >}}).
+   Explore Logs shows you the volume of logs with specific labels and fields. Learn more about [Labels and Fields](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/labels-and-fields/).
 1. Select the **Fields** tab to see visualizations of the log volume for each field. You can select fields to drill down into the details in the same way as labels.
 1. Click the **Patterns** tab to see the log volume for each automatically detected pattern.
-   Log patterns let you work with groups of similar log lines. You can hide log patterns that are noisy, or focus only on the patterns that are most useful. Learn more about [Log Patterns]({{< relref "../patterns" >}}).
+   Log patterns let you work with groups of similar log lines. You can hide log patterns that are noisy, or focus only on the patterns that are most useful. Learn more about [Log Patterns](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/patterns/).
 
-If you're having trouble using Explore Logs, check out our [troubleshooting guide]({{< relref "../troubleshooting" >}}).
+If you're having trouble using Explore Logs, refer to the [troubleshooting page](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/).
 
 ## What do you think?
 

--- a/docs/sources/labels-and-fields/_index.md
+++ b/docs/sources/labels-and-fields/_index.md
@@ -1,6 +1,6 @@
 ---
 canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/labels-and-fields/
-description: Learn how breaking logs down by Labels and Fields can help you find the signal in the noise.
+description: Learn how breaking logs down by labels and fields can help you find the signal in the noise.
 keywords:
   - Logs
   - Explore
@@ -31,21 +31,21 @@ The type of data being expressed in a label or field may require different treat
 To explore labels with your own data, follow these steps:
 
 1. From the Grafana main menu, select **Explore** > **Logs**.
-1. Click the **Select** button for the **Service** you want to explore. ([No services?]({{< relref "../troubleshooting#there-are-no-services" >}}))
+1. Click the **Select** button for the **Service** you want to explore. ([No services?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-services))
 1. Click the **Labels** tab.
-1. Browse the labels detected for this service. ([No labels?]({{< relref "../troubleshooting#there-are-no-labels" >}}))
+1. Browse the labels detected for this service. ([No labels?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-labels))
 1. Look for an interesting label and click the **Select** button.
 
-You will see a selection of visualizations showing the volume of each one.
+You will see a selection of visualizations showing the volume of each label.
 
-These visualizations are great for;
+These visualizations are great for:
 
 - Spotting unexpected spikes in log volume.
 - Noticing dips or outages in your services.
 - Understanding the distribution of log lines across your labels.
 - Identifying labels that might be useful for filtering or grouping your logs.
 
-You also have a range of [sorting and ordering options]({{< relref "../ordering" >}}) to help you focus on the most important areas.
+You also have a range of [sorting and ordering options](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/ordering/) to help you focus on the most important areas.
 
 You can repeat the same steps in the **Fields** tab to see fields that were extracted from your log lines.
 
@@ -53,4 +53,4 @@ You can repeat the same steps in the **Fields** tab to see fields that were extr
 
 ## What next?
 
-Learn about how [Log patterns]({{< relref "../patterns" >}}) can help you deal with different types of log lines in bulk.
+Learn about how [Log patterns](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/patterns/) can help you deal with different types of log lines in bulk.

--- a/docs/sources/ordering/_index.md
+++ b/docs/sources/ordering/_index.md
@@ -16,7 +16,7 @@ weight: 400
 
 # Sorting and ordering
 
-If you find yourself on a page with lots of graphs, you might want to sort them differently depending on what you're looking for. You can do this in Explore Logs using the **Sort by** menu in the top right toolbar.
+Some pages in Explore Logs can display a large number of graphs.  You may want to sort the graphs differently, depending on what you're looking for. These pages let you modify the default sort oder using the **Sort by** menu in the top right toolbar.
 
 You can use the **Asc/Desc** menu to change the direction of the sort.
 

--- a/docs/sources/ordering/_index.md
+++ b/docs/sources/ordering/_index.md
@@ -16,7 +16,7 @@ weight: 400
 
 # Sorting and ordering
 
-Some pages in Explore Logs can display a large number of graphs.  You may want to sort the graphs differently, depending on what you're looking for. These pages let you modify the default sort oder using the **Sort by** menu in the top right toolbar.
+Some pages in Explore Logs can display a large number of graphs. You may want to sort the graphs differently, depending on what you're looking for. These pages let you modify the default sort oder using the **Sort by** menu in the top right toolbar.
 
 You can use the **Asc/Desc** menu to change the direction of the sort.
 

--- a/docs/sources/patterns/_index.md
+++ b/docs/sources/patterns/_index.md
@@ -18,13 +18,13 @@ weight: 600
 
 Log patterns let you work with groups of similar log lines. You can hide log patterns that are noisy, or focus only on the patterns that are most useful.
 
-Loki automatically extracts patterns when your logs are ingested. Patterns are ephemeral and are only mined from the past 3 hours of your logs.
+Loki automatically extracts patterns when your logs are ingested. Patterns are ephemeral and are only mined from the previous three hours of your logs.
 
 {{< figure alt="Explore Logs Patterns tab" width="900px" align="center" src="../images/patterns.png" caption="Patterns tab" >}}
 
 The Explore Logs app shows you the patterns alongside their log volumes. From this view, you can investigate spikes and include or exclude specific log lines from your view.
 
-Patterns are ephemeral and can change over time as your logging evolves.
+Patterns can change over time as your logging evolves.
 
 ## Use cases
 
@@ -40,7 +40,7 @@ Log patterns let you:
 
 ## Guided tour of log patterns
 
-We've outlined the steps you'll need to take to perform these common use cases.
+We've outlined the steps you'll need to take to perform some common use cases.
 
 ### Browse log volumes by type
 
@@ -48,27 +48,29 @@ Explore Logs proactively visualizes your log volume data per detected pattern, b
 
 For example, if your HTTP service is suffering from a DDoS attack, the relevant graphs will clearly show the spikes. From here you can drill down to discover enough details about the attack to counter it.
 
-### Targeted analysis
+### Target your analysis
 
 If you know the kind of log line you're looking for, log patterns are an easy way to remove unwanted log lines from the view.
 
 To view only a specific set of patterns, perform the following steps:
 
 1. From the Grafana main menu, select **Explore** > **Logs**.
-1. Select the relevant **Service**. ([No services?]({{< relref "../troubleshooting#there-are-no-services" >}}))
+1. Select the relevant **Service**. ([No services?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-services))
 1. On the service details page, click the **Patterns** tab.
-1. Identify a pattern that matches the type of logs you're interested in viewing. ([No patterns?]({{< relref "../troubleshooting#there-are-no-patterns" >}}))
+1. Identify a pattern that matches the type of logs you're interested in viewing. ([No patterns?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-patterns))
 1. Click the **Include** button for the pattern.
 1. Return to the **Logs** tab and notice the filtered view.
+
+You can repeat steps 4 and 5 to include multiple patterns.
 
 ### Hide noisy log lines
 
 To hide noisy log lines, perform the following steps:
 
 1. From the Grafana main menu, select **Explore** > **Logs**.
-1. Select the relevant **Service**. ([No services?]({{< relref "../troubleshooting#there-are-no-services" >}}))
+1. Select the relevant **Service**. ([No services?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-services))
 1. On the service details page, click the **Patterns** tab.
-1. Identify a pattern that represents noise in the logs that you want to remove. ([No patterns?]({{< relref "../troubleshooting#there-are-no-patterns" >}}))
+1. Identify a pattern that represents noise in the logs that you want to remove. ([No patterns?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-patterns))
 1. Click the **Exclude** button to exclude that pattern.
 1. Return to the **Logs** tab and notice the noisy pattern has been removed.
 
@@ -80,7 +82,7 @@ Loki extracts patterns from a stream of log lines.
 
 For example, if your service logs lines like this:
 
-```
+```console
 duration=255ms trace_id=abc001 GET /path/to/endpoint/2
 user loaded: 25666
 user loaded: 14544
@@ -102,9 +104,9 @@ Pattern 1: `duration=<_> trace_id=<_> <_> /path/to/endpoint/<_>`
 Pattern 2: `user loaded: <_>`
 
 {{< admonition type="note" >}}
-Since Loki 3.0, you can make queries using this simplified template format which is much faster than using regex.
+Since Loki 3.0, you can make queries using this simplified [pattern match filter operator](https://grafana.com/docs/loki/latest/query/#pattern-match-filter-operators) which is much faster than using regex.
 {{< /admonition >}}
 
 ## What next?
 
-See how Explore Logs works on your own data by following our [Get started guide]({{< relref "../get-started" >}}).
+See how Explore Logs works on your own data by following our [Get started guide](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/get-started/).

--- a/docs/sources/troubleshooting/_index.md
+++ b/docs/sources/troubleshooting/_index.md
@@ -17,7 +17,7 @@ This page address common issues when getting started and using Explore Logs.
 
 ## Ensure Loki is properly configured
 
-To use Explore Logs, you need to have Loki properly configured. You can find full instructions on how to do this when [installing Explore Logs]({{< relref "../access" >}}).
+To use Explore Logs, you need to have Loki properly configured. You can find full instructions on how to do this when [installing Explore Logs](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/access/).
 
 ## There are no services
 
@@ -42,11 +42,11 @@ To learn more about Labels, refer to the [Loki labels documentation](https://gra
 
 ## There are no patterns
 
-Patterns are ephemeral and will only be available for the last 3 hours.
+Patterns are ephemeral and will only be available for the previous three hours.
 
 If you aren't getting any patterns, you can try the following fixes:
 
-1. Ensure pattern extraction is enabled by setting `--pattern-ingester.enabled=true` in your Loki config. [Learn about other necessary config](../get-started/#install-using-grafana-cli).
+1. Ensure pattern extraction is enabled by setting `--pattern-ingester.enabled=true` in your Loki config. [Learn about other necessary config](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/access/).
 1. It is possible that no patterns were detected, although this is rare - please [open an issue on GitHub](https://github.com/grafana/explore-logs/issues/new) or [get in touch privately](https://forms.gle/1sYWCTPvD72T1dPH9) so we can see what's going on.
 
 ## I cannot find something


### PR DESCRIPTION
I took a pass through the docs today to validate that they matched the UI.
Replaced all the relrefs with full URLs as relrefs are being phased out.
Made a few other small edits and stylistic changes.