### PR TITLE
Frontend logging: more generic context

### DIFF
--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -8,19 +8,17 @@ import { ConsoleMessage } from '@playwright/test';
 test.describe('explore services page', () => {
   let explorePage: ExplorePage;
 
-  test.beforeEach(async ({ page }) => {
-    explorePage = new ExplorePage(page);
+  test.beforeEach(async ({ page }, testInfo) => {
+    explorePage = new ExplorePage(page, testInfo);
     await explorePage.setDefaultViewportSize();
     await explorePage.clearLocalStorage();
-    await explorePage.measurePerformanceStart();
     await explorePage.gotoServices();
     explorePage.captureConsoleLogs();
   });
 
   test.afterEach(async ({ page }) => {
     await explorePage.unroute();
-    await explorePage.measurePerformanceStop();
-    explorePage.echoConsoleLogs();
+    explorePage.echoConsoleLogsOnRetry();
   });
 
   test('should filter service labels on search', async ({ page }) => {

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -3,6 +3,7 @@ import { ExplorePage } from './fixtures/explore';
 import { testIds } from '../src/services/testIds';
 import { mockVolumeApiResponse } from './mocks/mockVolumeApiResponse';
 import { mockLabelsResponse } from './mocks/mockLabelsResponse';
+import { ConsoleMessage } from '@playwright/test';
 
 test.describe('explore services page', () => {
   let explorePage: ExplorePage;
@@ -10,12 +11,16 @@ test.describe('explore services page', () => {
   test.beforeEach(async ({ page }) => {
     explorePage = new ExplorePage(page);
     await explorePage.setDefaultViewportSize();
-    await page.evaluate(() => window.localStorage.clear());
+    await explorePage.clearLocalStorage();
+    await explorePage.measurePerformanceStart();
     await explorePage.gotoServices();
+    explorePage.captureConsoleLogs();
   });
 
   test.afterEach(async ({ page }) => {
-    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    await explorePage.unroute();
+    await explorePage.measurePerformanceStop();
+    explorePage.echoConsoleLogs();
   });
 
   test('should filter service labels on search', async ({ page }) => {

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -12,17 +12,22 @@ test.describe('explore services breakdown page', () => {
 
   test.beforeEach(async ({ page }) => {
     explorePage = new ExplorePage(page);
+
     await explorePage.setExtraTallViewportSize();
-    await page.evaluate(() => window.localStorage.clear());
+    await explorePage.clearLocalStorage();
+    await explorePage.measurePerformanceStart();
     await explorePage.gotoServicesBreakdown();
     explorePage.blockAllQueriesExcept({
       refIds: ['logsPanelQuery', fieldName],
       legendFormats: [`{{${levelName}}}`],
     });
+    explorePage.captureConsoleLogs();
   });
 
   test.afterEach(async ({ page }) => {
-    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    await explorePage.unroute();
+    await explorePage.measurePerformanceStop();
+    explorePage.echoConsoleLogs();
   });
 
   test('should filter logs panel on search for broadcast field', async ({ page }) => {

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -10,12 +10,11 @@ const labelName = 'cluster';
 test.describe('explore services breakdown page', () => {
   let explorePage: ExplorePage;
 
-  test.beforeEach(async ({ page }) => {
-    explorePage = new ExplorePage(page);
+  test.beforeEach(async ({ page }, testInfo) => {
+    explorePage = new ExplorePage(page, testInfo);
 
     await explorePage.setExtraTallViewportSize();
     await explorePage.clearLocalStorage();
-    await explorePage.measurePerformanceStart();
     await explorePage.gotoServicesBreakdown();
     explorePage.blockAllQueriesExcept({
       refIds: ['logsPanelQuery', fieldName],
@@ -26,8 +25,7 @@ test.describe('explore services breakdown page', () => {
 
   test.afterEach(async ({ page }) => {
     await explorePage.unroute();
-    await explorePage.measurePerformanceStop();
-    explorePage.echoConsoleLogs();
+    explorePage.echoConsoleLogsOnRetry();
   });
 
   test('should filter logs panel on search for broadcast field', async ({ page }) => {

--- a/tests/exploreServicesJsonBreakDown.spec.ts
+++ b/tests/exploreServicesJsonBreakDown.spec.ts
@@ -10,15 +10,19 @@ test.describe('explore nginx-json breakdown pages ', () => {
   test.beforeEach(async ({ page }) => {
     explorePage = new ExplorePage(page);
     await explorePage.setExtraTallViewportSize();
-    await page.evaluate(() => window.localStorage.clear());
+    await explorePage.clearLocalStorage();
+    await explorePage.measurePerformanceStart();
     await explorePage.gotoServicesBreakdown('nginx-json');
     explorePage.blockAllQueriesExcept({
       refIds: ['logsPanelQuery', fieldName],
     });
+    explorePage.captureConsoleLogs();
   });
 
   test.afterEach(async ({ page }) => {
-    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    await explorePage.unroute();
+    await explorePage.measurePerformanceStop();
+    explorePage.echoConsoleLogs();
   });
 
   test(`should exclude ${fieldName}, request should contain json`, async ({ page }) => {

--- a/tests/exploreServicesJsonBreakDown.spec.ts
+++ b/tests/exploreServicesJsonBreakDown.spec.ts
@@ -7,11 +7,10 @@ const fieldName = 'method';
 test.describe('explore nginx-json breakdown pages ', () => {
   let explorePage: ExplorePage;
 
-  test.beforeEach(async ({ page }) => {
-    explorePage = new ExplorePage(page);
+  test.beforeEach(async ({ page }, testInfo) => {
+    explorePage = new ExplorePage(page, testInfo);
     await explorePage.setExtraTallViewportSize();
     await explorePage.clearLocalStorage();
-    await explorePage.measurePerformanceStart();
     await explorePage.gotoServicesBreakdown('nginx-json');
     explorePage.blockAllQueriesExcept({
       refIds: ['logsPanelQuery', fieldName],
@@ -21,8 +20,7 @@ test.describe('explore nginx-json breakdown pages ', () => {
 
   test.afterEach(async ({ page }) => {
     await explorePage.unroute();
-    await explorePage.measurePerformanceStop();
-    explorePage.echoConsoleLogs();
+    explorePage.echoConsoleLogsOnRetry();
   });
 
   test(`should exclude ${fieldName}, request should contain json`, async ({ page }) => {

--- a/tests/exploreServicesJsonMixedBreakDown.spec.ts
+++ b/tests/exploreServicesJsonMixedBreakDown.spec.ts
@@ -13,7 +13,8 @@ test.describe('explore nginx-json-mixed breakdown pages ', () => {
   test.beforeEach(async ({ page }) => {
     explorePage = new ExplorePage(page);
     await explorePage.setExtraTallViewportSize();
-    await page.evaluate(() => window.localStorage.clear());
+    await explorePage.clearLocalStorage();
+    await explorePage.measurePerformanceStart();
     await explorePage.gotoServicesBreakdown(serviceName);
     explorePage.blockAllQueriesExcept({
       refIds: ['logsPanelQuery', mixedFieldName],
@@ -21,7 +22,9 @@ test.describe('explore nginx-json-mixed breakdown pages ', () => {
   });
 
   test.afterEach(async ({ page }) => {
-    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    await explorePage.unroute();
+    await explorePage.measurePerformanceStop();
+    explorePage.echoConsoleLogs();
   });
 
   test(`should exclude ${mixedFieldName}, request should contain both parsers`, async ({ page }) => {

--- a/tests/exploreServicesJsonMixedBreakDown.spec.ts
+++ b/tests/exploreServicesJsonMixedBreakDown.spec.ts
@@ -10,11 +10,10 @@ const serviceName = 'nginx-json-mixed';
 test.describe('explore nginx-json-mixed breakdown pages ', () => {
   let explorePage: ExplorePage;
 
-  test.beforeEach(async ({ page }) => {
-    explorePage = new ExplorePage(page);
+  test.beforeEach(async ({ page }, testInfo) => {
+    explorePage = new ExplorePage(page, testInfo);
     await explorePage.setExtraTallViewportSize();
     await explorePage.clearLocalStorage();
-    await explorePage.measurePerformanceStart();
     await explorePage.gotoServicesBreakdown(serviceName);
     explorePage.blockAllQueriesExcept({
       refIds: ['logsPanelQuery', mixedFieldName],
@@ -23,8 +22,7 @@ test.describe('explore nginx-json-mixed breakdown pages ', () => {
 
   test.afterEach(async ({ page }) => {
     await explorePage.unroute();
-    await explorePage.measurePerformanceStop();
-    explorePage.echoConsoleLogs();
+    explorePage.echoConsoleLogsOnRetry();
   });
 
   test(`should exclude ${mixedFieldName}, request should contain both parsers`, async ({ page }) => {

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -1,4 +1,4 @@
-import { ConsoleMessage, Locator, Page } from '@playwright/test';
+import { ConsoleMessage, Locator, Page, TestInfo } from '@playwright/test';
 import pluginJson from '../../src/plugin.json';
 import { testIds } from '../../src/services/testIds';
 import { expect } from '@grafana/plugin-e2e';
@@ -17,7 +17,7 @@ export class ExplorePage {
   refreshPicker: Locator;
   logs: Array<{ msg: ConsoleMessage; type: string }> = [];
 
-  constructor(public readonly page: Page) {
+  constructor(public readonly page: Page, public readonly testInfo: TestInfo) {
     this.firstServicePageSelect = this.page.getByText('Select').first();
     this.logVolumeGraph = this.page.getByText('Log volume');
     this.servicesSearch = this.page.getByTestId(testIds.exploreServiceSearch.search);
@@ -32,8 +32,10 @@ export class ExplorePage {
     });
   }
 
-  echoConsoleLogs() {
-    console.log('logs', this.logs);
+  echoConsoleLogsOnRetry() {
+    if (this.testInfo.retry > 0) {
+      console.log('logs', this.logs);
+    }
   }
 
   /**

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -38,29 +38,6 @@ export class ExplorePage {
     }
   }
 
-  /**
-   * Don't know how accurate or helpful these are yet, but figured it won't hurt to log the results for now as we continue to iterate on performance measurement
-   */
-  async measurePerformanceStart() {
-    await this.page.evaluate(() => {
-      window.performance.mark('start');
-    });
-  }
-
-  async measurePerformanceStop() {
-    const resourceUsage = await this.page.evaluate(() => {
-      return {
-        cpuUsage: window.performance.now(), // Example CPU usage metric
-        //@ts-expect-error
-        usedJSHeapSize: window.performance?.memory?.usedJSHeapSize,
-        //@ts-expect-error
-        totalJSHeapSize: window.performance?.memory?.totalJSHeapSize,
-      };
-    });
-
-    console.log('Resource usage:', resourceUsage);
-  }
-
   async clearLocalStorage() {
     await this.page.evaluate(() => window.localStorage.clear());
   }


### PR DESCRIPTION
Narrowing each prop individually was cumbersome and not very scalable, this attempts to grab string/numeric/boolean properties from errors that are Records