### PR TITLE
Combine responses: improve merging of duplicated entries

### DIFF
--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -70,19 +70,9 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
   const totalFields = Math.max(dest.fields.length, source.fields.length);
 
   for (let i = 0; i < sourceTimeValues.length; i++) {
-    const destTimeValues = destTimeField.values.slice(0) ?? [];
-    const destNanosValues = destTimeField.nanos?.slice(0);
-    const destIdValues = destIdField?.values.slice(0) ?? [];
     const destIdx = resolveIdx(destTimeField, sourceTimeField, i);
 
-    const entryExistsInDest = compareEntries(
-      { ...destTimeField, values: destTimeValues, nanos: destNanosValues },
-      destIdField ? { ...destIdField, values: destIdValues } : destIdField,
-      destIdx,
-      sourceTimeField,
-      sourceIdField,
-      i
-    );
+    const entryExistsInDest = compareEntries(destTimeField, destIdField, destIdx, sourceTimeField, sourceIdField, i);
 
     for (let f = 0; f < totalFields; f++) {
       // For now, skip undefined fields that exist in the new frame

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -59,7 +59,7 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
   const destTimeField = dest.fields.find((field) => field.type === FieldType.time);
   const destIdField = dest.fields.find((field) => field.type === FieldType.string && field.name === 'id');
   const sourceTimeField = source.fields.find((field) => field.type === FieldType.time);
-  const sourceIdField = dest.fields.find((field) => field.type === FieldType.string && field.name === 'id');
+  const sourceIdField = source.fields.find((field) => field.type === FieldType.string && field.name === 'id');
 
   if (!destTimeField || !sourceTimeField) {
     logger.error(new Error(`Time fields not found in the data frames`));
@@ -72,11 +72,12 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
   for (let i = 0; i < sourceTimeValues.length; i++) {
     const destTimeValues = destTimeField.values.slice(0) ?? [];
     const destNanosValues = destTimeField.nanos?.slice(0);
+    const destIdValues = destIdField?.values.slice(0) ?? [];
     const destIdx = resolveIdx(destTimeField, sourceTimeField, i);
 
-    const entryExistsInDest = compareTimestamps(
+    const entryExistsInDest = compareEntries(
       { ...destTimeField, values: destTimeValues, nanos: destNanosValues },
-      destIdField,
+      destIdField ? { ...destIdField, values: destIdValues } : destIdField,
       destIdx,
       sourceTimeField,
       sourceIdField,
@@ -137,18 +138,19 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
 
 function resolveIdx(destField: Field, sourceField: Field, index: number) {
   const idx = closestIdx(sourceField.values[index], destField.values);
-
+  if (idx < 0) {
+    return 0;
+  }
   if (sourceField.values[index] === destField.values[idx] && sourceField.nanos && destField.nanos) {
     return sourceField.nanos[index] > destField.nanos[idx] ? idx + 1 : idx;
   }
-
   if (sourceField.values[index] > destField.values[idx]) {
     return idx + 1;
   }
   return idx;
 }
 
-function compareTimestamps(
+function compareEntries(
   destTimeField: Field,
   destIdField: Field | undefined,
   destIndex: number,
@@ -163,19 +165,22 @@ function compareTimestamps(
   if (!destIdField || !sourceIdField) {
     return true;
   }
-
   // Log frames, check indexes
-  return destIdField.values[destIndex] === sourceIdField.values[sourceIndex];
+  return (
+    destIdField.values[destIndex] !== undefined && destIdField.values[destIndex] === sourceIdField.values[sourceIndex]
+  );
 }
 
 function compareNsTimestamps(destField: Field, destIndex: number, sourceField: Field, sourceIndex: number) {
   if (destField.nanos && sourceField.nanos) {
     return (
+      destField.values[destIndex] !== undefined &&
       destField.values[destIndex] === sourceField.values[sourceIndex] &&
+      destField.nanos[destIndex] !== undefined &&
       destField.nanos[destIndex] === sourceField.nanos[sourceIndex]
     );
   }
-  return destField.values[destIndex] === sourceField.values[sourceIndex];
+  return destField.values[destIndex] !== undefined && destField.values[destIndex] === sourceField.values[sourceIndex];
 }
 
 function findSourceField(referenceField: Field, sourceFields: Field[], index: number) {

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -104,6 +104,7 @@ function splitQueriesByStreamShard(
       retryTimer = setTimeout(() => {
         console.log(`Retrying ${cycle} (${retries + 1})`);
         runNextRequest(subscriber, cycle, shardRequests);
+        retryTimer = null;
       }, 1500 * Math.pow(2, retries)); // Exponential backoff
 
       return true;
@@ -137,9 +138,6 @@ function splitQueriesByStreamShard(
           subscriber.next(mergedResponse);
         }
         nextRequest();
-        if (retryTimer) {
-          clearTimeout(retryTimer);
-        }
       },
       error: (error: unknown) => {
         logger.error(error, { msg: 'failed to shard' });
@@ -191,6 +189,9 @@ function splitQueriesByStreamShard(
       });
     return () => {
       shouldStop = true;
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+      }
       if (subquerySubscription != null) {
         subquerySubscription.unsubscribe();
       }

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -191,6 +191,7 @@ function splitQueriesByStreamShard(
       shouldStop = true;
       if (retryTimer) {
         clearTimeout(retryTimer);
+        retryTimer = null;
       }
       if (subquerySubscription != null) {
         subquerySubscription.unsubscribe();


### PR DESCRIPTION
Found while working in grafana/grafana. Main fixes are:

- Improved field comparison, where `undefined === undefined` was causing false positives of existing entries.
- Fixed merging of log frames when they have overlapping or duplicated results.
- Added support for the case where `closestIdx()` returns -1 when the passed array is empty.
- Fixed request retrying, moving clearing the timeout to the correct place.