### PR TITLE
Line Filter: increase debounce time and add enter support

### DIFF
--- a/src/Components/ServiceScene/LineFilterScene.tsx
+++ b/src/Components/ServiceScene/LineFilterScene.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Field } from '@grafana/ui';
 import { debounce, escapeRegExp } from 'lodash';
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, KeyboardEvent } from 'react';
 import { getLineFilterVariable } from 'services/variables';
 import { testIds } from 'services/testIds';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
@@ -44,15 +44,25 @@ export class LineFilterScene extends SceneObjectBase<LineFilterState> {
     });
   };
 
-  updateFilter(lineFilter: string) {
+  updateFilter(lineFilter: string, debounced = true) {
     this.setState({
       lineFilter,
     });
-    this.updateVariable(lineFilter);
+    if (debounced) {
+      this.updateVariableDebounced(lineFilter);
+    } else {
+      this.updateVariable(lineFilter);
+    }
   }
 
   handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     this.updateFilter(e.target.value);
+  };
+
+  handleEnter = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      this.updateVariable(this.state.lineFilter);
+    }
   };
 
   onCaseSensitiveToggle = (newState: 'sensitive' | 'insensitive') => {
@@ -63,7 +73,11 @@ export class LineFilterScene extends SceneObjectBase<LineFilterState> {
     this.updateFilter(this.state.lineFilter);
   };
 
-  updateVariable = debounce((search: string) => {
+  updateVariableDebounced = debounce((search: string) => {
+    this.updateVariable(search);
+  }, 1000);
+
+  updateVariable = (search: string) => {
     const variable = getLineFilterVariable(this);
     if (search === '') {
       variable.changeValueTo('');
@@ -83,7 +97,7 @@ export class LineFilterScene extends SceneObjectBase<LineFilterState> {
         containsLevel: search.toLowerCase().includes('level'),
       }
     );
-  }, 350);
+  };
 }
 
 function LineFilterRenderer({ model }: SceneComponentProps<LineFilterScene>) {
@@ -98,8 +112,9 @@ function LineFilterRenderer({ model }: SceneComponentProps<LineFilterScene>) {
         suffix={<LineFilterIcon caseSensitive={caseSensitive} onCaseSensitiveToggle={model.onCaseSensitiveToggle} />}
         placeholder="Search in log lines"
         onClear={() => {
-          model.updateFilter('');
+          model.updateFilter('', false);
         }}
+        onKeyUp={model.handleEnter}
       />
     </Field>
   );

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -155,7 +155,7 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
     const parentModel = sceneGraph.getAncestor(this, LogsListScene);
     const lineFilterScene = parentModel.getLineFilterScene();
     if (lineFilterScene) {
-      lineFilterScene.updateFilter(value);
+      lineFilterScene.updateFilter(value, false);
       reportAppInteraction(
         USER_EVENTS_PAGES.service_details,
         USER_EVENTS_ACTIONS.service_details.logs_popover_line_filter,


### PR DESCRIPTION
To decrease the chance of firing a lot of requests while a user is typing:

- Increased debounce time to 1 second.
- Added support for running the query immediately with `Enter` if the user needs it.