### PR TITLE
Shard query splitting: use dynamic grouping

### DIFF
--- a/src/services/logql.ts
+++ b/src/services/logql.ts
@@ -43,18 +43,18 @@ export const addShardingPlaceholderSelector = (query: string) => {
   return query.replace('}', `, __stream_shard__=~"${SHARDING_PLACEHOLDER}"}`);
 };
 
-export const interpolateShardingSelector = (queries: LokiQuery[], shards?: number[][], i?: number) => {
-  if (shards === undefined || i === undefined) {
+export const interpolateShardingSelector = (queries: LokiQuery[], shards?: number[]) => {
+  if (shards === undefined || shards.length === 0) {
     return queries.map((query) => ({
       ...query,
       expr: query.expr.replace(`, __stream_shard__=~"${SHARDING_PLACEHOLDER}"}`, '}'),
     }));
   }
 
-  let shardValue = shards[i].join('|');
+  let shardValue = shards.join('|');
 
   // -1 means empty shard value
-  if (shardValue === '-1' || shards[i].length === 1) {
+  if (shardValue === '-1' || shards.length === 1) {
     shardValue = shardValue === '-1' ? '' : shardValue;
     return queries.map((query) => ({
       ...query,

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -83,28 +83,28 @@ describe('runShardSplitQuery()', () => {
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"20|3"}[1m])', refId: 'A' }],
+        requestId: 'TEST_shard_0_2',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"20|10"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_1',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"10|2"}[1m])', refId: 'A' }],
+        requestId: 'TEST_shard_2_2',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"3|2"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_2',
+        requestId: 'TEST_shard_4_2',
         targets: [{ expr: 'count_over_time({a="b", __stream_shard__="1"}[1m])', refId: 'A' }],
       });
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_3',
+        requestId: 'TEST_shard_5_2',
         targets: [{ expr: 'count_over_time({a="b", __stream_shard__=""}[1m])', refId: 'A' }],
       });
     });
@@ -128,9 +128,9 @@ describe('runShardSplitQuery()', () => {
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0',
+        requestId: 'TEST_shard_0_2',
         targets: [
-          { expr: 'count_over_time({service_name="test", filter="true", __stream_shard__=~"20|3"}[1m])', refId: 'A' },
+          { expr: 'count_over_time({service_name="test", filter="true", __stream_shard__=~"20|10"}[1m])', refId: 'A' },
         ],
       });
     });
@@ -162,7 +162,7 @@ describe('runShardSplitQuery()', () => {
     });
   });
 
-  test('For time ranges over a day queries shards independently', async () => {
+  test('Adjusts the group size based on errors and execution time', async () => {
     const request = createRequest([{ expr: 'count_over_time($SELECTOR[1m])', refId: 'A' }], {
       range: {
         from: dateTime('2024-11-13T05:00:00.000Z'),
@@ -174,47 +174,205 @@ describe('runShardSplitQuery()', () => {
       },
     });
 
+    datasource.languageProvider.fetchLabelValues.mockResolvedValue([
+      '1',
+      '10',
+      '2',
+      '20',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+    ]);
+
+    // @ts-expect-error
+    jest.spyOn(global, 'setTimeout').mockImplementationOnce((callback) => {
+      callback();
+    });
+
+    const { metricFrameA } = getMockFrames();
+
+    // @ts-expect-error
+    jest.mocked(datasource.runQuery).mockReset();
+
+    // Doubles group size
+    // @ts-expect-error
+    jest.mocked(datasource.runQuery).mockReturnValueOnce(
+      of({
+        data: [
+          {
+            ...metricFrameA,
+            meta: {
+              ...metricFrameA.meta,
+              stats: [
+                ...metricFrameA.meta!.stats!,
+                {
+                  displayName: 'Summary: exec time',
+                  unit: 's',
+                  value: 0.5,
+                },
+              ],
+            },
+          },
+        ],
+      })
+    );
+
+    // Decreases group size
+    // @ts-expect-error
+    jest
+      .mocked(datasource.runQuery)
+      .mockReturnValueOnce(of({ state: LoadingState.Error, error: { refId: 'A', message: 'timeout' }, data: [] }));
+
+    // Increases group size by 2
+    // @ts-expect-error
+    jest.mocked(datasource.runQuery).mockReturnValueOnce(
+      of({
+        data: [
+          {
+            ...metricFrameA,
+            meta: {
+              ...metricFrameA.meta,
+              stats: [
+                ...metricFrameA.meta!.stats!,
+                {
+                  displayName: 'Summary: exec time',
+                  unit: 's',
+                  value: 5,
+                },
+              ],
+            },
+          },
+        ],
+      })
+    );
+
+    // Increases group size by 1
+    // @ts-expect-error
+    jest.mocked(datasource.runQuery).mockReturnValueOnce(
+      of({
+        data: [
+          {
+            ...metricFrameA,
+            meta: {
+              ...metricFrameA.meta,
+              stats: [
+                ...metricFrameA.meta!.stats!,
+                {
+                  displayName: 'Summary: exec time',
+                  unit: 's',
+                  value: 15,
+                },
+              ],
+            },
+          },
+        ],
+      })
+    );
+
+    // Decreases group size by 1
+    // @ts-expect-error
+    jest.mocked(datasource.runQuery).mockReturnValueOnce(
+      of({
+        data: [
+          {
+            ...metricFrameA,
+            meta: {
+              ...metricFrameA.meta,
+              stats: [
+                ...metricFrameA.meta!.stats!,
+                {
+                  displayName: 'Summary: exec time',
+                  unit: 's',
+                  value: 19,
+                },
+              ],
+            },
+          },
+        ],
+      })
+    );
+
+    // Halves group size
+    // @ts-expect-error
+    jest.mocked(datasource.runQuery).mockReturnValueOnce(
+      of({
+        data: [
+          {
+            ...metricFrameA,
+            meta: {
+              ...metricFrameA.meta,
+              stats: [
+                ...metricFrameA.meta!.stats!,
+                {
+                  displayName: 'Summary: exec time',
+                  unit: 's',
+                  value: 21,
+                },
+              ],
+            },
+          },
+        ],
+      })
+    );
+
+    // @ts-expect-error
+    jest.mocked(datasource.runQuery).mockReturnValueOnce(of({ data: [metricFrameA] }));
+
     await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith(() => {
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="20"}[1m])', refId: 'A' }],
+        requestId: 'TEST_shard_0_3',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"20|10|9"}[1m])', refId: 'A' }],
       });
+
+      // Doubled
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_1',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="3"}[1m])', refId: 'A' }],
+        requestId: 'TEST_shard_3_6',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"8|7|6|5|4|3"}[1m])', refId: 'A' }],
       });
+
+      // Decreased
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_2',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="10"}[1m])', refId: 'A' }],
+        requestId: 'TEST_shard_3_2',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"8|7"}[1m])', refId: 'A' }],
       });
+
+      // Increased by 2
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_3',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="2"}[1m])', refId: 'A' }],
+        requestId: 'TEST_shard_5_4',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"6|5|4|3"}[1m])', refId: 'A' }],
       });
+
+      // Increased by 1
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_4',
-        targets: [{ expr: 'count_over_time({a="b", __stream_shard__="1"}[1m])', refId: 'A' }],
+        requestId: 'TEST_shard_9_5',
+        targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"2|1"}[1m])', refId: 'A' }],
       });
+
+      // Decreased by 1
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_5',
+        requestId: 'TEST_shard_11_4',
         targets: [{ expr: 'count_over_time({a="b", __stream_shard__=""}[1m])', refId: 'A' }],
       });
     });

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -319,9 +319,6 @@ describe('runShardSplitQuery()', () => {
       })
     );
 
-    // @ts-expect-error
-    jest.mocked(datasource.runQuery).mockReturnValueOnce(of({ data: [metricFrameA] }));
-
     await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith(() => {
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
@@ -340,7 +337,7 @@ describe('runShardSplitQuery()', () => {
         targets: [{ expr: 'count_over_time({a="b", __stream_shard__=~"8|7|6|5|4|3"}[1m])', refId: 'A' }],
       });
 
-      // Decreased
+      // Error, decreased
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -145,7 +145,7 @@ describe('runShardSplitQuery()', () => {
   });
 
   test('Retries failed requests', async () => {
-    jest.mocked(datasource.languageProvider.fetchLabelValues).mockResolvedValue([1]);
+    jest.mocked(datasource.languageProvider.fetchLabelValues).mockResolvedValue(['1']);
     jest
       // @ts-expect-error
       .spyOn(datasource, 'runQuery')

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -222,8 +222,8 @@ describe('runShardSplitQuery()', () => {
     );
 
     // Decreases group size
-    // @ts-expect-error
     jest
+      // @ts-expect-error
       .mocked(datasource.runQuery)
       .mockReturnValueOnce(of({ state: LoadingState.Error, error: { refId: 'A', message: 'timeout' }, data: [] }));
 

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -272,7 +272,7 @@ function getInitialGroupSize(shards: number[]) {
 }
 
 // Enable to output debugging logs
-const DEBUG_ENABLED = Boolean(localStorage.getItem(`${pluginJson.id}.harding_debug_enabled`));
+const DEBUG_ENABLED = Boolean(localStorage.getItem(`${pluginJson.id}.sharding_debug_enabled`));
 function debug(message: string) {
   if (!DEBUG_ENABLED) {
     return;

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -208,7 +208,6 @@ function splitQueriesByStreamShard(
       })
       .catch((e: unknown) => {
         logger.error(e, { msg: 'failed to fetch label values for __stream_shard__' });
-        shouldStop = true;
         runNonSplitRequest(subscriber);
       });
     return () => {

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -1,3 +1,4 @@
+import pluginJson from '../plugin.json';
 import { Observable, Subscriber, Subscription } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -268,7 +269,7 @@ function getInitialGroupSize(shards: number[]) {
 }
 
 // Enable to output debugging logs
-const DEBUG_ENABLED = false;
+const DEBUG_ENABLED = Boolean(localStorage.getItem(`${pluginJson.id}.harding_debug_enabled`));
 function debug(message: string) {
   if (!DEBUG_ENABLED) {
     return;

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -1,13 +1,8 @@
 import { Observable, Subscriber, Subscription } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
-import { DataQueryRequest, LoadingState, DataQueryResponse, TimeRange } from '@grafana/data';
-import {
-  addShardingPlaceholderSelector,
-  getSelectorForShardValues,
-  interpolateShardingSelector,
-  isLogsQuery,
-} from './logql';
+import { DataQueryRequest, LoadingState, DataQueryResponse, QueryResultMetaStat } from '@grafana/data';
+import { addShardingPlaceholderSelector, getSelectorForShardValues, interpolateShardingSelector } from './logql';
 import { combineResponses } from './combineResponses';
 import { DataSourceWithBackend } from '@grafana/runtime';
 import { LokiQuery } from './lokiQuery';
@@ -67,8 +62,14 @@ function splitQueriesByStreamShard(
   let retriesMap = new Map<number, number>();
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
-  const runNextRequest = (subscriber: Subscriber<DataQueryResponse>, cycle: number, shardRequests: number[][]) => {
-    if (subquerySubscription) {
+  const runNextRequest = (
+    subscriber: Subscriber<DataQueryResponse>,
+    cycle: number,
+    shards: number[],
+    groupSize: number
+  ) => {
+    let nextGroupSize = groupSize;
+    if (subquerySubscription != null) {
       subquerySubscription.unsubscribe();
       subquerySubscription = null;
     }
@@ -85,9 +86,9 @@ function splitQueriesByStreamShard(
     };
 
     const nextRequest = () => {
-      const nextCycle = cycle + 1;
-      if (nextCycle < shardRequests.length) {
-        runNextRequest(subscriber, nextCycle, shardRequests);
+      const nextCycle = Math.min(cycle + groupSize, shards.length);
+      if (cycle < shards.length && nextCycle <= shards.length) {
+        runNextRequest(subscriber, nextCycle, shards, nextGroupSize);
         return;
       }
       done();
@@ -95,36 +96,44 @@ function splitQueriesByStreamShard(
 
     const retry = (errorResponse?: DataQueryResponse) => {
       if (errorResponse?.errors && errorResponse.errors[0].message?.includes('maximum of series')) {
-        console.log(`Maximum series reached, skipping retry`);
+        logger.info(`Maximum series reached, skipping retry`);
         return false;
+      } else if (errorResponse?.errors && errorResponse.errors[0].message?.includes('parse error')) {
+        logger.info(`Parse error, skipping retry`);
+        shouldStop = true;
+        return false;
+      }
+
+      if (groupSize > 1) {
+        groupSize = Math.floor(Math.sqrt(groupSize));
+        debug(`Possible time out, new group size ${groupSize}`);
+        runNextRequest(subscriber, cycle, shards, groupSize);
+        return true;
       }
 
       const retries = retriesMap.get(cycle) ?? 0;
       if (retries > 3) {
+        shouldStop = true;
         return false;
       }
 
       retriesMap.set(cycle, retries + 1);
 
       retryTimer = setTimeout(() => {
-        console.log(`Retrying ${cycle} (${retries + 1})`);
-        runNextRequest(subscriber, cycle, shardRequests);
+        logger.info(`Retrying ${cycle} (${retries + 1})`);
+        runNextRequest(subscriber, cycle, shards, groupSize);
         retryTimer = null;
       }, 1500 * Math.pow(2, retries)); // Exponential backoff
 
       return true;
     };
 
-    const targets = adjustTargetsFromResponseState(splittingTargets, mergedResponse);
-    if (!targets.length) {
-      nextRequest();
-      return;
-    }
-
-    const subRequest = { ...request, targets: interpolateShardingSelector(targets, shardRequests, cycle) };
+    const shardsToQuery = groupShardRequests(shards, cycle, groupSize);
+    debug(`Querying ${shardsToQuery.join(', ')}`);
+    const subRequest = { ...request, targets: interpolateShardingSelector(splittingTargets, shardsToQuery) };
     // Request may not have a request id
     if (request.requestId) {
-      subRequest.requestId = `${request.requestId}_shard_${cycle}`;
+      subRequest.requestId = `${request.requestId}_shard_${cycle}_${groupSize}`;
     }
 
     // @ts-expect-error
@@ -134,6 +143,10 @@ function splitQueriesByStreamShard(
           if (retry(partialResponse)) {
             return;
           }
+        }
+        nextGroupSize = updateGroupSizeFromResponse(partialResponse, groupSize);
+        if (nextGroupSize !== groupSize) {
+          debug(`New group size ${nextGroupSize}`);
         }
         mergedResponse = combineResponses(mergedResponse, partialResponse);
       },
@@ -156,7 +169,8 @@ function splitQueriesByStreamShard(
   };
 
   const runNonSplitRequest = (subscriber: Subscriber<DataQueryResponse>) => {
-    subquerySubscription = datasource.query(request).subscribe({
+    // @ts-expect-error
+    subquerySubscription = datasource.runQuery(request).subscribe({
       next: (partialResponse: DataQueryResponse) => {
         mergedResponse = partialResponse;
       },
@@ -180,11 +194,12 @@ function splitQueriesByStreamShard(
       .then((values: string[]) => {
         const shards = values.map((value) => parseInt(value, 10));
         if (!shards || !shards.length) {
-          console.warn(`Shard splitting not supported. Issuing a regular query.`);
+          logger.warn(`Shard splitting not supported. Issuing a regular query.`);
           runNonSplitRequest(subscriber);
         } else {
-          const shardRequests = groupShardRequests(shards, request.range);
-          runNextRequest(subscriber, 0, shardRequests);
+          shards.sort((a, b) => b - a);
+          debug(`Querying ${shards.join(', ')} shards`);
+          runNextRequest(subscriber, 0, shards, getInitialGroupSize(shards));
         }
       })
       .catch((e: unknown) => {
@@ -196,7 +211,6 @@ function splitQueriesByStreamShard(
       shouldStop = true;
       if (retryTimer) {
         clearTimeout(retryTimer);
-        retryTimer = null;
       }
       if (subquerySubscription != null) {
         subquerySubscription.unsubscribe();
@@ -208,79 +222,56 @@ function splitQueriesByStreamShard(
   return response;
 }
 
-function groupShardRequests(shards: number[], range: TimeRange) {
-  const hours = range.to.diff(range.from, 'hour');
+function updateGroupSizeFromResponse(response: DataQueryResponse, currentSize: number) {
+  if (!response.data.length) {
+    // Empty response, increase group size
+    return currentSize + 1;
+  }
 
-  // Spread low and high volume around
-  shards = spreadSort(shards);
-  console.log(`Querying ${shards.join(', ')} shards`);
+  const metaExecutionTime: QueryResultMetaStat | undefined = response.data[0].meta?.stats?.find(
+    (stat: QueryResultMetaStat) => stat.displayName === 'Summary: exec time'
+  );
 
-  const maxRequests = calculateMaxRequests(shards.length, hours);
-  const groupSize = Math.ceil(shards.length / maxRequests);
-  const requests: number[][] = [];
-
-  for (let i = 0; i < shards.length; i += groupSize) {
-    const request: number[] = [];
-    for (let j = i; j < i + groupSize && j < shards.length; j += 1) {
-      request.push(shards[j]);
+  if (metaExecutionTime) {
+    debug(`${metaExecutionTime.value}`);
+    // Positive scenarios
+    if (metaExecutionTime.value < 1) {
+      return currentSize * 2;
+    } else if (metaExecutionTime.value < 6) {
+      return currentSize + 2;
+    } else if (metaExecutionTime.value < 16) {
+      return currentSize + 1;
     }
-    requests.push(request);
+
+    // Negative scenarios
+    if (currentSize === 1) {
+      return currentSize;
+    } else if (metaExecutionTime.value < 20) {
+      return currentSize - 1;
+    } else {
+      return Math.floor(currentSize / 2);
+    }
   }
 
-  requests.push([-1]);
-
-  return requests;
+  return currentSize;
 }
 
-/**
- * Simple approach to calculate a maximum amount of requests to send based on
- * the available shards and the requested interval.
- */
-function calculateMaxRequests(shards: number, hours: number) {
-  if (hours < 24) {
-    return Math.max(Math.min(Math.ceil(Math.sqrt(shards)), shards - 1), 1);
+function groupShardRequests(shards: number[], start: number, groupSize: number) {
+  if (start === shards.length) {
+    return [-1];
   }
-  return shards;
+  return shards.slice(start, start + groupSize);
 }
 
-function spreadSort(shards: number[]) {
-  shards.sort((a, b) => b - a);
-  let mid = Math.floor(shards.length / 2);
-  let result = [];
-  for (let i = 0; i < mid; i++) {
-    result.push(shards[i], shards[mid + i]);
-  }
-  if (shards.length % 2 !== 0) {
-    result.push(shards[shards.length - 1]);
-  }
-  return result;
+function getInitialGroupSize(shards: number[]) {
+  return Math.floor(Math.sqrt(shards.length));
 }
 
-/**
- * Based in the state of the current response, if any, adjust target parameters such as `maxLines`.
- * For `maxLines`, we will update it as `maxLines - current amount of lines`.
- * At the end, we will filter the targets that don't need to be executed in the next request batch,
- * because, for example, the `maxLines` have been reached.
- */
-function adjustTargetsFromResponseState(targets: LokiQuery[], response: DataQueryResponse | null): LokiQuery[] {
-  if (!response) {
-    return targets;
+// Enable to output debugging logs
+const DEBUG_ENABLED = true;
+function debug(message: string) {
+  if (!DEBUG_ENABLED) {
+    return;
   }
-
-  return targets
-    .map((target) => {
-      if (!target.maxLines || !isLogsQuery(target.expr)) {
-        return target;
-      }
-      const targetFrame = response.data.find((frame) => frame.refId === target.refId);
-      if (!targetFrame) {
-        return target;
-      }
-      const updatedMaxLines = target.maxLines - targetFrame.length;
-      return {
-        ...target,
-        maxLines: updatedMaxLines < 0 ? 0 : updatedMaxLines,
-      };
-    })
-    .filter((target) => target.maxLines === undefined || target.maxLines > 0);
+  console.log(message);
 }

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -25,19 +25,22 @@ import { logger } from './logger';
  * - Requests the __stream_shard__ values of the selected service:
  *   . If there are no shard values, it falls back to the standard querying approach of the data source in runNonSplitRequest()
  *   . If there are shards:
- *     - It groups the shard requests in an array of arrays of shard numbers in groupShardRequests()
- *     - It begins the querying loop with runNextRequest()
- * - runNextRequest() will send a query using the nth (cycle) shard group, and has the following internal structure:
- *   . adjustTargetsFromResponseState() will filter log queries targets that already received the requested maxLines
- *   . interpolateShardingSelector() will update the stream selector with the current shard numbers
+ *     - It sorts them by value, descending. Higher shard numbers correspond with the least volume.
+ *     - It defines an initial group size, roughly Math.sqrt(amountOfShards).
+ *     - It begins the querying loop with runNextRequest().
+ * - runNextRequest() will create a group of groupSize shards from the nth shard (cycle), and has the following internal structure:
+ *   . groupShardRequests() returns an array of shards from cycle to cycle + groupSize.
+ *   . interpolateShardingSelector() will update the stream selector with the shard numbers in the current group.
  *   . After query execution:
  *     - If the response is successful:
  *       . It will add new data to the response with combineResponses()
- *       . nextRequest() will use the current cycle and the total groups to determine the next request or complete execution with done()
+ *       . Using the data and meta data of the response, updateGroupSizeFromResponse() will increase or decrease the group size.
+ *       . nextRequest() will use the current cycle and group size to determine the next request or complete execution with done().
  *     - If the response is unsuccessful:
- *       . If there are retry attempts, it will retry the current cycle, or else continue with the next cycle
- *       . If the returned error is Maximum series reached, it will not retry
- * - Once all request groups have been executed, it will be done()
+ *       . If the response is not a query error, and the group size bigger than 1, it will decrease the group size.
+ *       . If the group size is already 1, it will retry the request up to 4 times.
+ *       . If there are retry attempts, it will retry the current cycle, or else stop querying.
+ * - Once all request groups have been executed, it will be done().
  */
 
 export function runShardSplitQuery(datasource: DataSourceWithBackend<LokiQuery>, request: DataQueryRequest<LokiQuery>) {

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -173,8 +173,7 @@ function splitQueriesByStreamShard(
   };
 
   const runNonSplitRequest = (subscriber: Subscriber<DataQueryResponse>) => {
-    // @ts-expect-error
-    subquerySubscription = datasource.runQuery(request).subscribe({
+    subquerySubscription = datasource.query(request).subscribe({
       next: (partialResponse: DataQueryResponse) => {
         mergedResponse = partialResponse;
       },

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -268,7 +268,7 @@ function getInitialGroupSize(shards: number[]) {
 }
 
 // Enable to output debugging logs
-const DEBUG_ENABLED = true;
+const DEBUG_ENABLED = false;
 function debug(message: string) {
   if (!DEBUG_ENABLED) {
     return;

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -268,7 +268,7 @@ function getInitialGroupSize(shards: number[]) {
 }
 
 // Enable to output debugging logs
-const DEBUG_ENABLED = false;
+const DEBUG_ENABLED = true;
 function debug(message: string) {
   if (!DEBUG_ENABLED) {
     return;


### PR DESCRIPTION
Data is going to be distributed exponentially in shards, but there is no heuristic that can suggest, based in the shard identifier, what the approximately volume is, so there is no safe way to group shards in a way that prevents querying a huge amount of data. In addition, once the groups have been stablished, other than retrying, there is no way of changing the original group definition, and the query ends up taking a lot of time or failing.

To improve this, a new shard grouping approach has been implemented, where the groups are dynamically generated based on the query execution time that is returned as meta data, with the following method:

Initial group shard: `Math.sqrt(shards.length)`. Square root will be significantly small for low or high number of shards, without being 1 (semi-optimistic start).

Then, when data is returned:

- If it's an empty response, increase the group by 1
- If the execution time is `less than 1 second`, double the group size
- If the execution time is `less than 6 seconds`, increase by 2
- If the execution time is `less than 15 seconds`, increase by 1
- If the execution time is `more than 15 seconds and less than 20 seconds`, decrease by 1
- If the execution time is `more than 20 seconds and less than 30 seconds (timeout)`, halve the group size
- if the query timed out, `groupSize = Math.floor(Math.sqrt(groupSize));`

When locally testing, more debug data is available by setting `localStorage.setItem('grafana-lokiexplore-app.sharding_debug_enabled', '1')`.