### PR TITLE
fix(routing): check for sluggified value in URL

### DIFF
--- a/src/services/routing.ts
+++ b/src/services/routing.ts
@@ -188,7 +188,7 @@ export function checkPrimaryLabel(sceneRef: SceneObject) {
     });
   }
 
-  const primaryLabelValue = labelsVariable.state.filters.find((filter) => filter.value === labelValue);
+  const primaryLabelValue = labelsVariable.state.filters.find((filter) => replaceSlash(filter.value) === labelValue);
   if (!primaryLabelValue) {
     const location = locationService.getLocation();
 


### PR DESCRIPTION
For label values with slashes, we replace them with dashes, so we need to account for that when we check for the value.

![imagen](https://github.com/user-attachments/assets/c688dccd-3f62-4bb7-a3dc-9945fac66015)
