### PR TITLE
Bundlewatch: add main as base branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
         "path": "dist/module.js",
         "maxSize": "30kB"
       }
-    ]
+    ],
+    "ci": {
+      "trackBranches": ["main"]
+    }
   },
   "description": "Query less exploration of log data stored in Loki",
   "scripts": {


### PR DESCRIPTION
Looks like I forgot to specify the base branch: https://bundlewatch.io/#/getting-started/diffing-against-branches-other-than-master