### PR TITLE
chore(intercept-banner): move into `container`

### DIFF
--- a/src/Components/IndexScene/InterceptBanner.tsx
+++ b/src/Components/IndexScene/InterceptBanner.tsx
@@ -1,10 +1,13 @@
-import { Alert } from '@grafana/ui';
+import { Alert, useStyles2 } from '@grafana/ui';
 import React from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
+import { css } from '@emotion/css';
 
 export function InterceptBanner(props: { onRemove: () => void }) {
+  const styles = useStyles2(getStyles);
   return (
     <>
-      <Alert severity={'info'} title={'Welcome to Explore Logs!'} onRemove={props.onRemove}>
+      <Alert className={styles.alert} severity={'info'} title={'Welcome to Explore Logs!'} onRemove={props.onRemove}>
         <div>
           Check out our{' '}
           <a
@@ -43,4 +46,12 @@ export function InterceptBanner(props: { onRemove: () => void }) {
       </Alert>
     </>
   );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    alert: css({
+      flex: 'none',
+    }),
+  };
 }

--- a/src/Components/IndexScene/LayoutScene.tsx
+++ b/src/Components/IndexScene/LayoutScene.tsx
@@ -44,14 +44,14 @@ export class LayoutScene extends SceneObjectBase<LayoutSceneState> {
     const styles = useStyles2(getStyles);
     return (
       <div className={styles.bodyContainer}>
-        {!interceptDismissed && (
-          <InterceptBanner
-            onRemove={() => {
-              model.dismiss();
-            }}
-          />
-        )}
         <div className={styles.container}>
+          {!interceptDismissed && (
+            <InterceptBanner
+              onRemove={() => {
+                model.dismiss();
+              }}
+            />
+          )}
           {controls && (
             <div className={styles.controlsContainer}>
               <div className={styles.filters}>


### PR DESCRIPTION
Moves the intercept banner into the main `container` so it gets the same margins as the rest of the app.
<img width="1564" alt="image" src="https://github.com/user-attachments/assets/73480721-753b-4775-af1d-3c814c9c6a9a">
