### PR TITLE
fix: fix broken tsc-files command

### DIFF
--- a/src/img/custom.d.ts
+++ b/src/img/custom.d.ts
@@ -1,0 +1,37 @@
+// Image declarations
+declare module '*.gif' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpeg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.png' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.webp' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}
+
+// Font declarations
+declare module '*.woff';
+declare module '*.woff2';
+declare module '*.eot';
+declare module '*.ttf';
+declare module '*.otf';


### PR DESCRIPTION
Fixes error:
```
✖ tsc-files --noEmit:
src/Components/ServiceScene/Breakdowns/AddToExplorationButton.tsx:9:22 - error TS2307: Cannot find module '../../../img/logo.svg' or its corresponding type declarations.
```