### PR TITLE
feat(shardSplitting): improve error handling

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -488,3 +488,4 @@ pangea
 primarylabels
 Shortlink
 uninterpolated
+Retriable

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -175,7 +175,7 @@ describe('runShardSplitQuery()', () => {
     jest
       // @ts-expect-error
       .spyOn(datasource, 'runQuery')
-      .mockReturnValue(of({ state: LoadingState.Error, error: { refId: 'A', message: 'max entries' }, data: [] }));
+      .mockReturnValue(of({ state: LoadingState.Error, error: { refId: 'A', message: 'parse error' }, data: [] }));
     await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith((response: DataQueryResponse[]) => {
       expect(response[0].state).toBe(LoadingState.Error);
     });

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -17,6 +17,7 @@ const originalWarn = console.warn;
 beforeAll(() => {
   jest.spyOn(console, 'log').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
 });
 afterAll(() => {
   console.log = originalLog;
@@ -156,7 +157,7 @@ describe('runShardSplitQuery()', () => {
     jest
       // @ts-expect-error
       .spyOn(datasource, 'runQuery')
-      .mockReturnValueOnce(of({ state: LoadingState.Error, error: { refId: 'A', message: 'Error' }, data: [] }));
+      .mockReturnValueOnce(of({ state: LoadingState.Error, error: { refId: 'A', message: 'timeout' }, data: [] }));
     // @ts-expect-error
     jest.spyOn(global, 'setTimeout').mockImplementationOnce((callback) => {
       callback();
@@ -166,6 +167,17 @@ describe('runShardSplitQuery()', () => {
       expect(response).toHaveLength(3);
       // @ts-expect-error
       expect(datasource.runQuery).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  test('Failed requests have loading state Error', async () => {
+    jest.mocked(datasource.languageProvider.fetchLabelValues).mockResolvedValue(['1']);
+    jest
+      // @ts-expect-error
+      .spyOn(datasource, 'runQuery')
+      .mockReturnValue(of({ state: LoadingState.Error, error: { refId: 'A', message: 'max entries' }, data: [] }));
+    await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith((response: DataQueryResponse[]) => {
+      expect(response[0].state).toBe(LoadingState.Error);
     });
   });
 

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -81,16 +81,16 @@ function splitQueriesByStreamShard(
       subquerySubscription = null;
     }
 
-    if (shouldStop) {
-      subscriber.complete();
-      return;
-    }
-
     const done = () => {
-      mergedResponse.state = LoadingState.Done;
+      mergedResponse.state = shouldStop ? LoadingState.Error : LoadingState.Done;
       subscriber.next(mergedResponse);
       subscriber.complete();
     };
+
+    if (shouldStop) {
+      done();
+      return;
+    }
 
     const nextRequest = () => {
       const nextCycle = Math.min(cycle + groupSize, shards.length);
@@ -102,11 +102,12 @@ function splitQueriesByStreamShard(
     };
 
     const retry = (errorResponse?: DataQueryResponse) => {
-      if (errorResponse?.errors && errorResponse.errors[0].message?.includes('maximum of series')) {
-        logger.info(`Maximum series reached, skipping retry`);
-        return false;
-      } else if (errorResponse?.errors && errorResponse.errors[0].message?.includes('parse error')) {
-        logger.info(`Parse error, skipping retry`);
+      try {
+        if (errorResponse && !isRetriableError(errorResponse)) {
+          return false;
+        }
+      } catch (e) {
+        logger.error(e);
         shouldStop = true;
         return false;
       }
@@ -204,7 +205,7 @@ function splitQueriesByStreamShard(
     const selector = getSelectorForShardValues(splittingTargets[0].expr);
 
     if (!isValidQuery(selector)) {
-      console.log(`Skipping invalid selector: ${selector}`);
+      debug(`Skipping invalid selector: ${selector}`);
       subscriber.complete();
       return;
     }
@@ -294,6 +295,23 @@ function groupShardRequests(shards: number[], start: number, groupSize: number) 
 
 function getInitialGroupSize(shards: number[]) {
   return Math.floor(Math.sqrt(shards.length));
+}
+
+function isRetriableError(errorResponse: DataQueryResponse) {
+  const message = errorResponse.errors
+    ? (errorResponse.errors[0].message ?? '').toLowerCase()
+    : errorResponse.error?.message ?? '';
+  if (message.includes('timeout')) {
+    return true;
+  } else if (
+    message.includes('parse error') ||
+    message.includes('max entries') ||
+    message.includes('maximum of series')
+  ) {
+    // If the error is a parse error, we want to signal to stop querying.
+    throw new Error(message);
+  }
+  return false;
 }
 
 // Enable to output debugging logs

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -303,11 +303,7 @@ function isRetriableError(errorResponse: DataQueryResponse) {
     : errorResponse.error?.message ?? '';
   if (message.includes('timeout')) {
     return true;
-  } else if (
-    message.includes('parse error') ||
-    message.includes('max entries') ||
-    message.includes('maximum of series')
-  ) {
+  } else if (message.includes('parse error')) {
     // If the error is a parse error, we want to signal to stop querying.
     throw new Error(message);
   }


### PR DESCRIPTION
This PR improves error handling in the shard splitting implementation. This is done by:

- Removing the Streaming state when sharding should stop.
- Assigning the Error state on the merged response.