### PR TITLE
Shard splitting: improve combineResponses performance

### DIFF
--- a/src/services/combineResponses.test.ts
+++ b/src/services/combineResponses.test.ts
@@ -216,6 +216,7 @@ describe('combineResponses', () => {
     const responseA: DataQueryResponse = {
       data: [metricFrameA],
     };
+    metricFrameC.refId = 'B';
     const responseB: DataQueryResponse = {
       data: [metricFrameB, metricFrameC],
     };
@@ -572,22 +573,8 @@ describe('combineResponses', () => {
     const responseB: DataQueryResponse = {
       data: [metricFrameB],
     };
-    expect(combineResponses(responseA, responseB)).toEqual({
-      data: [metricFrameA, metricFrameB],
-    });
-  });
-
-  it('does not combine frames with different refId', () => {
-    const { metricFrameA, metricFrameB } = getMockFrames();
-    metricFrameA.name = 'A';
-    metricFrameB.name = 'B';
-    const responseA: DataQueryResponse = {
-      data: [metricFrameA],
-    };
-    const responseB: DataQueryResponse = {
-      data: [metricFrameB],
-    };
-    expect(combineResponses(responseA, responseB)).toEqual({
+    const result = combineResponses(responseA, responseB);
+    expect(result).toEqual({
       data: [metricFrameA, metricFrameB],
     });
   });
@@ -825,52 +812,6 @@ describe('mergeFrames', () => {
           },
           refId: 'A',
         },
-      ],
-    });
-  });
-
-  it('combines and identifies new frames in the response', () => {
-    const { metricFrameA, metricFrameB, metricFrameC } = getMockFrames();
-    const responseA: DataQueryResponse = {
-      data: [metricFrameB],
-    };
-    const responseB: DataQueryResponse = {
-      data: [metricFrameA, metricFrameC],
-    };
-    expect(combineResponses(responseA, responseB)).toEqual({
-      data: [
-        {
-          fields: [
-            {
-              config: {},
-              name: 'Time',
-              type: 'time',
-              values: [1000000, 2000000, 3000000, 4000000],
-            },
-            {
-              config: {},
-              name: 'Value',
-              type: 'number',
-              values: [6, 7, 5, 4],
-              labels: {
-                level: 'debug',
-              },
-            },
-          ],
-          length: 4,
-          meta: {
-            type: 'timeseries-multi',
-            stats: [
-              {
-                displayName: 'Summary: total bytes processed',
-                unit: 'decbytes',
-                value: 33,
-              },
-            ],
-          },
-          refId: 'A',
-        },
-        metricFrameC,
       ],
     });
   });

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -1,7 +1,6 @@
 import {
   closestIdx,
   DataFrame,
-  DataFrameType,
   DataQueryResponse,
   DataQueryResponseData,
   Field,

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -232,43 +232,5 @@ function cloneDataFrame(frame: DataQueryResponseData): DataQueryResponseData {
 }
 
 function shouldCombine(frame1: DataFrame, frame2: DataFrame): boolean {
-  if (frame1.refId !== frame2.refId || frame1.name !== frame2.name) {
-    return false;
-  }
-
-  const frameType1 = frame1.meta?.type;
-  const frameType2 = frame2.meta?.type;
-
-  if (frameType1 !== frameType2) {
-    // we do not join things that have a different type
-    return false;
-  }
-
-  // metric range query data
-  if (frameType1 === DataFrameType.TimeSeriesMulti) {
-    const field1 = frame1.fields.find((f) => f.type === FieldType.number);
-    const field2 = frame2.fields.find((f) => f.type === FieldType.number);
-    if (field1 === undefined || field2 === undefined) {
-      // should never happen
-      return false;
-    }
-
-    return shallowCompare(field1.labels ?? {}, field2.labels ?? {});
-  }
-
-  // logs query data
-  // logs use a special attribute in the dataframe's "custom" section
-  // because we do not have a good "frametype" value for them yet.
-  const customType1 = frame1.meta?.custom?.frameType;
-  const customType2 = frame2.meta?.custom?.frameType;
-  // Legacy frames have this custom type
-  if (customType1 === 'LabeledTimeValues' && customType2 === 'LabeledTimeValues') {
-    return true;
-  } else if (customType1 === customType2) {
-    // Data plane frames don't
-    return true;
-  }
-
-  // should never reach here
-  return false;
+  return frame1.refId === frame2.refId;
 }


### PR DESCRIPTION
We recently noticed a performance degradation in the field breakdown pages, for some services, which was narrowed down to the `shouldCombine` function that was doing a lot of extra work for something that should have been only comparing the data frame refId.

Measuring `combineResponses()` in ms.

Before:

![Before](https://github.com/user-attachments/assets/803f5b3a-c987-426a-88ca-d88a599bbcd6)

After:

![After](https://github.com/user-attachments/assets/03d4ea42-67cc-4791-a4b6-916e357d7136)
