### PR TITLE
feat(combineResponses): improve label comparison performance

### DIFF
--- a/src/services/combineResponses.test.ts
+++ b/src/services/combineResponses.test.ts
@@ -206,6 +206,7 @@ describe('combineResponses', () => {
             ],
           },
           refId: 'A',
+          name: '{"level":"debug"}',
         },
       ],
     });
@@ -251,6 +252,7 @@ describe('combineResponses', () => {
             ],
           },
           refId: 'A',
+          name: '{"level":"debug"}',
         },
         metricFrameC,
       ],
@@ -662,6 +664,7 @@ describe('combineResponses', () => {
             ],
           },
           refId: 'A',
+          name: '{"level":"debug"}',
         },
       ],
     });
@@ -775,6 +778,7 @@ describe('mergeFrames', () => {
             ],
           },
           refId: 'A',
+          name: '{"level":"debug"}',
         },
       ],
     });
@@ -824,6 +828,7 @@ describe('mergeFrames', () => {
             ],
           },
           refId: 'A',
+          name: '{"level":"debug"}',
         },
       ],
     });
@@ -869,6 +874,7 @@ describe('mergeFrames', () => {
             ],
           },
           refId: 'A',
+          name: '{"level":"debug"}',
         },
         metricFrameC,
       ],

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -99,7 +99,7 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
               ...dest.fields[f].values[destIdx],
               ...sourceField.values[i],
             };
-          } else if (sourceField.values[i]) {
+          } else if (sourceField.values[i] != null) {
             dest.fields[f].values[destIdx] = sourceField.values[i];
           }
         } else {
@@ -130,7 +130,7 @@ function resolveIdx(destField: Field, sourceField: Field, index: number) {
   if (idx < 0) {
     return 0;
   }
-  if (sourceField.values[index] === destField.values[idx] && sourceField.nanos && destField.nanos) {
+  if (sourceField.values[index] === destField.values[idx] && sourceField.nanos != null && destField.nanos != null) {
     return sourceField.nanos[index] > destField.nanos[idx] ? idx + 1 : idx;
   }
   if (sourceField.values[index] > destField.values[idx]) {
@@ -151,7 +151,7 @@ function compareEntries(
   if (!sameTimestamp) {
     return false;
   }
-  if (!destIdField || !sourceIdField) {
+  if (destIdField == null || sourceIdField == null) {
     return true;
   }
   // Log frames, check indexes
@@ -230,7 +230,7 @@ function shouldCombine(frame1: DataFrame, frame2: DataFrame): boolean {
   if (frame1.refId !== frame2.refId) {
     return false;
   }
-  if (frame1.name && frame2.name && frame1.name !== frame2.name) {
+  if (frame1.name != null && frame2.name != null && frame1.name !== frame2.name) {
     return false;
   }
 
@@ -271,10 +271,11 @@ function compareLabels(frame1: DataFrame, frame2: DataFrame) {
     // should never happen
     return false;
   }
-  if (!frame1.name) {
+  // undefined == null
+  if (frame1.name == null) {
     frame1.name = JSON.stringify(field1.labels);
   }
-  if (!frame2.name) {
+  if (frame2.name == null) {
     frame2.name = JSON.stringify(field2.labels);
   }
   return frame1.name === frame2.name;

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -227,7 +227,10 @@ function cloneDataFrame(frame: DataQueryResponseData): DataQueryResponseData {
 }
 
 function shouldCombine(frame1: DataFrame, frame2: DataFrame): boolean {
-  if (frame1.refId !== frame2.refId || frame1.name !== frame2.name) {
+  if (frame1.refId !== frame2.refId) {
+    return false;
+  }
+  if (frame1.name && frame2.name && frame1.name !== frame2.name) {
     return false;
   }
 
@@ -268,10 +271,10 @@ function compareLabels(frame1: DataFrame, frame2: DataFrame) {
     // should never happen
     return false;
   }
-  if (!frame1.name && field1.labels) {
+  if (!frame1.name) {
     frame1.name = JSON.stringify(field1.labels);
   }
-  if (!frame2.name && field2.labels) {
+  if (!frame2.name) {
     frame2.name = JSON.stringify(field2.labels);
   }
   return frame1.name === frame2.name;


### PR DESCRIPTION
This PR adds a performance optimization to the label comparison method, which is a function that gets called very often in the recombination code.

## Measurements before

1 minute of profiling

![Before 2](https://github.com/user-attachments/assets/68f89e4e-0572-4cc8-a7f9-5f2cc38266d7)

Slightly different method but still comparing label keys.

![Before 1](https://github.com/user-attachments/assets/beaeb1d9-1498-4e22-815a-ae2adec969fd)

Start and end of `mergeResponses`
![Worst cases original](https://github.com/user-attachments/assets/ddbf011c-7dbf-45cc-9623-1a6741bc5fcc)

## Measurements after

1 minute of profiling

![After](https://github.com/user-attachments/assets/0d0c8569-3190-48d1-b873-d3115da19779)

Start and end of `mergeResponses`
![Worst cases after](https://github.com/user-attachments/assets/5f071877-8099-4925-8ade-69b29c440120)
