### PR TITLE
chore: bump @bsull/augurs to 0.6.0

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,8 @@ module.exports = {
   ...config,
   moduleNameMapper: {
     ...config.moduleNameMapper,
-    '@bsull/augurs': '@bsull/augurs/augurs.js',
+    '/@bsull\/augurs\/changepoint/': '@bsull/augurs/changepoint.js',
+    '/@bsull\/augurs\/outlier/': '@bsull/augurs/outlier.js',
   },
   transformIgnorePatterns: [nodeModulesToTransform([...grafanaESModules, '@bsull/augurs'])],
 };

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@bsull/augurs": "^0.3.1",
+    "@bsull/augurs": "^0.6.0",
     "@emotion/css": "^11.10.6",
     "@grafana/data": "^11.3.0",
     "@grafana/lezer-logql": "^0.2.6",

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -9,12 +9,13 @@ const App = lazy(async () => {
   const { wasmSupported } = await import('services/sorting');
 
   const { default: initRuntimeDs } = await import('services/datasource');
-  const { default: init } = await import('@bsull/augurs');
+  const { default: initChangepoint } = await import('@bsull/augurs/changepoint');
+  const { default: initOutlier } = await import('@bsull/augurs/outlier');
 
   initRuntimeDs();
 
   if (wasmSupported()) {
-    await init();
+    await Promise.all([initChangepoint(), initOutlier()]);
   }
 
   return import('Components/App');

--- a/src/services/sorting.ts
+++ b/src/services/sorting.ts
@@ -1,4 +1,5 @@
-import { ChangepointDetector, OutlierDetector, OutlierOutput } from '@bsull/augurs';
+import { ChangepointDetector } from '@bsull/augurs/changepoint';
+import { OutlierDetector, OutlierOutput } from '@bsull/augurs/outlier';
 import { DataFrame, doStandardCalcs, fieldReducers, FieldType, outerJoinDataFrames, ReducerID } from '@grafana/data';
 import { getLabelValueFromDataFrame } from './levels';
 import { memoize } from 'lodash';
@@ -126,11 +127,10 @@ const initOutlierDetector = (series: DataFrame[]) => {
 
   // Get number fields: these are our series.
   const joinedSeries = joined.fields.filter((f) => f.type === FieldType.number);
-  const nTimestamps = joinedSeries[0].values.length;
-  const points = new Float64Array(joinedSeries.flatMap((series) => series.values as number[]));
+  const points = joinedSeries.flatMap((series) => new Float64Array(series.values));
 
   try {
-    const detector = OutlierDetector.dbscan({ sensitivity: 0.4 }).preprocess(points, nTimestamps);
+    const detector = OutlierDetector.dbscan({ sensitivity: 0.4 }).preprocess(points);
     outliers = detector.detect();
   } catch (e) {
     logger.error(e, { msg: 'initOutlierDetector: OutlierDetector error' });

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,10 +348,10 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-7.0.1.tgz#457233b0a18741b7711855044102b82bae7a070b"
   integrity sha512-URg8UM6lfC9ZYqFipItRSxYJdgpU5d2Z4KnjsJ+rj6tgAmGme7E+PQNCiud8g0HDaZKMovu2qjfa0f5Ge0Vlsg==
 
-"@bsull/augurs@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@bsull/augurs/-/augurs-0.3.1.tgz#97ab2495b574bd7ee5faf512ca17e7bf09bed660"
-  integrity sha512-4EjKRoisAzMWtxAWIl//25Oa9dGkP5WftrhW34WAa8aojWZdZei7RJXtvMcKoMr52MiL/LsLpZeU2kPifApIHg==
+"@bsull/augurs@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@bsull/augurs/-/augurs-0.6.0.tgz#aeb5b37fab20b7287edcaa79980c5c337d927273"
+  integrity sha512-bUk3qVS5OOyJjW5CN8gNe9EIGyj6sujAdp/FLeTgKBdOBnVlQuVpOuwFMojEwB9xXMpmovK2Q1xngwwVZcwbJQ==
 
 "@commitlint/cli@^19.2.2":
   version "19.2.2"


### PR DESCRIPTION
This release includes separate entry points for the various
parts of the library, which should reduce the amount of
WebAssembly that needs to be loaded by the user.

It also fixes build warnings related to circular dependencies.
