### PR TITLE
Chore: Rename the sorting option in explore metrics

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -34,8 +34,8 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
         },
         {
           value: 'outliers',
-          label: 'Detected outliers',
-          description: 'Order by the amount of detected outliers in the data',
+          label: 'Outlying values',
+          description: 'Order by the amount of outlying values in the data',
         },
         {
           value: ReducerID.stdDev,


### PR DESCRIPTION
**What is this feature?**

Just a rename

The slack discussion: https://raintank-corp.slack.com/archives/C0630AYC4SY/p1731012871057899?thread_ts=1730815868.075449&cid=C0630AYC4SY