### PR TITLE
Go to Explore button: keep visual preferences in Explore link

### DIFF
--- a/src/Components/ServiceScene/ActionBarScene.tsx
+++ b/src/Components/ServiceScene/ActionBarScene.tsx
@@ -42,7 +42,7 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
         <div className={styles.actions}>
           <Stack gap={1}>
             {config.featureToggles.appSidecar && <ToolbarExtensionsRenderer serviceScene={serviceScene} />}
-            <GoToExploreButton exploration={exploration} />
+            <GoToExploreButton exploration={exploration} sceneRef={serviceScene} />
           </Stack>
         </div>
 

--- a/src/Components/ServiceScene/ActionBarScene.tsx
+++ b/src/Components/ServiceScene/ActionBarScene.tsx
@@ -42,7 +42,7 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
         <div className={styles.actions}>
           <Stack gap={1}>
             {config.featureToggles.appSidecar && <ToolbarExtensionsRenderer serviceScene={serviceScene} />}
-            <GoToExploreButton exploration={exploration} sceneRef={serviceScene} />
+            <GoToExploreButton exploration={exploration} />
           </Stack>
         </div>
 

--- a/src/Components/ServiceScene/GoToExploreButton.test.tsx
+++ b/src/Components/ServiceScene/GoToExploreButton.test.tsx
@@ -25,27 +25,51 @@ jest.mock('@grafana/scenes', () => {
   };
 });
 jest.mock('services/scenes');
-
 beforeAll(() => {
   jest.spyOn(window, 'open').mockImplementation(jest.fn());
-  jest.mocked(getDisplayedFields).mockReturnValue(['field1', 'field2']);
-  jest.mocked(getLogsVisualizationType).mockReturnValue('table');
-  jest.mocked(getDataSource).mockReturnValue('gdev-loki');
+  jest.spyOn(URLSearchParams.prototype, 'get').mockImplementation(() => null);
   jest.mocked(getQueryExpr).mockReturnValue('{place="luna"} | logfmt');
+  jest.mocked(getDataSource).mockReturnValue('gdev-loki');
 });
 afterAll(() => {
   jest.mocked(window.open).mockReset();
+  jest.mocked(URLSearchParams.prototype.get).mockReset();
 });
 
 describe('GoToExploreButton', () => {
-  test('Opens a new window with the current state in the Explore URL', async () => {
-    render(<GoToExploreButton exploration={{} as IndexScene} />);
+  describe('With logs visualization', () => {
+    beforeEach(() => {
+      jest.mocked(getDisplayedFields).mockReturnValue(['field1', 'field2']);
+      jest.mocked(getLogsVisualizationType).mockReturnValue('logs');
+      jest.mocked(window.open).mockClear();
+    });
+    test('Opens a new window with the current state in the Explore URL', async () => {
+      render(<GoToExploreButton exploration={{} as IndexScene} />);
 
-    await userEvent.click(screen.getByText('Open in Explore'));
+      await userEvent.click(screen.getByText('Open in Explore'));
 
-    expect(window.open).toHaveBeenCalledWith(
-      '/explore?panes=%7B%22loki-explore%22:%7B%22range%22:%7B%22from%22:123456789,%22to%22:987654321%7D,%22queries%22:%5B%7B%22refId%22:%22logs%22,%22expr%22:%22%7Bplace%3D%5C%22luna%5C%22%7D%20%7C%20logfmt%22,%22datasource%22:%22gdev-loki%22%7D%5D,%22panelsState%22:%7B%22logs%22:%7B%22displayedFields%22:%5B%22field1%22,%22field2%22%5D,%22visualisationType%22:%22table%22%7D%7D,%22datasource%22:%22gdev-loki%22%7D%7D&schemaVersion=1',
-      '_blank'
-    );
+      expect(window.open).toHaveBeenCalledWith(
+        '/explore?panes=%7B%22loki-explore%22:%7B%22range%22:%7B%22from%22:123456789,%22to%22:987654321%7D,%22queries%22:%5B%7B%22refId%22:%22logs%22,%22expr%22:%22%7Bplace%3D%5C%22luna%5C%22%7D%20%7C%20logfmt%22,%22datasource%22:%22gdev-loki%22%7D%5D,%22panelsState%22:%7B%22logs%22:%7B%22displayedFields%22:%5B%22field1%22,%22field2%22%5D,%22visualisationType%22:%22logs%22%7D%7D,%22datasource%22:%22gdev-loki%22%7D%7D&schemaVersion=1',
+        '_blank'
+      );
+    });
+  });
+  describe('With table visualization', () => {
+    beforeEach(() => {
+      jest.mocked(getDisplayedFields).mockReturnValue([]);
+      jest.mocked(getLogsVisualizationType).mockReturnValue('table');
+      jest.mocked(URLSearchParams.prototype.get).mockReturnValue('["field1", "field2"]');
+      jest.mocked(window.open).mockClear();
+    });
+    test('Opens a new window with the current state in the Explore URL', async () => {
+      render(<GoToExploreButton exploration={{} as IndexScene} />);
+
+      await userEvent.click(screen.getByText('Open in Explore'));
+
+      expect(window.open).toHaveBeenCalledWith(
+        '/explore?panes=%7B%22loki-explore%22:%7B%22range%22:%7B%22from%22:123456789,%22to%22:987654321%7D,%22queries%22:%5B%7B%22refId%22:%22logs%22,%22expr%22:%22%7Bplace%3D%5C%22luna%5C%22%7D%20%7C%20logfmt%22,%22datasource%22:%22gdev-loki%22%7D%5D,%22panelsState%22:%7B%22logs%22:%7B%22displayedFields%22:%5B%5D,%22visualisationType%22:%22table%22,%22columns%22:%7B%220%22:%22field1%22,%221%22:%22field2%22%7D%7D%7D,%22datasource%22:%22gdev-loki%22%7D%7D&schemaVersion=1',
+        '_blank'
+      );
+    });
   });
 });

--- a/src/Components/ServiceScene/GoToExploreButton.test.tsx
+++ b/src/Components/ServiceScene/GoToExploreButton.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GoToExploreButton } from './GoToExploreButton';
+import { getDisplayedFields, getLogsVisualizationType } from 'services/store';
+import { getDataSource, getQueryExpr } from 'services/scenes';
+import React from 'react';
+import { IndexScene } from 'Components/IndexScene/IndexScene';
+
+jest.mock('services/analytics', () => ({
+  ...jest.requireActual('services/analytics'),
+  reportInteraction: jest.fn(),
+}));
+jest.mock('services/store');
+jest.mock('@grafana/scenes', () => {
+  const actualScenes = jest.requireActual('@grafana/scenes');
+
+  return {
+    ...actualScenes,
+    sceneGraph: {
+      ...actualScenes.sceneGraph,
+      getTimeRange: jest.fn().mockReturnValue({
+        state: { value: { from: 'now-1h', to: 'now', raw: { from: 123456789, to: 987654321 } } },
+      }),
+    },
+  };
+});
+jest.mock('services/scenes');
+
+beforeAll(() => {
+  jest.spyOn(window, 'open').mockImplementation(jest.fn());
+  jest.mocked(getDisplayedFields).mockReturnValue(['field1', 'field2']);
+  jest.mocked(getLogsVisualizationType).mockReturnValue('table');
+  jest.mocked(getDataSource).mockReturnValue('gdev-loki');
+  jest.mocked(getQueryExpr).mockReturnValue('{place="luna"} | logfmt');
+});
+afterAll(() => {
+  jest.mocked(window.open).mockReset();
+});
+
+describe('GoToExploreButton', () => {
+  test('Opens a new window with the current state in the Explore URL', async () => {
+    render(<GoToExploreButton exploration={{} as IndexScene} />);
+
+    await userEvent.click(screen.getByText('Open in Explore'));
+
+    expect(window.open).toHaveBeenCalledWith(
+      '/explore?panes=%7B%22loki-explore%22:%7B%22range%22:%7B%22from%22:123456789,%22to%22:987654321%7D,%22queries%22:%5B%7B%22refId%22:%22logs%22,%22expr%22:%22%7Bplace%3D%5C%22luna%5C%22%7D%20%7C%20logfmt%22,%22datasource%22:%22gdev-loki%22%7D%5D,%22panelsState%22:%7B%22logs%22:%7B%22displayedFields%22:%5B%22field1%22,%22field2%22%5D,%22visualisationType%22:%22table%22%7D%7D,%22datasource%22:%22gdev-loki%22%7D%7D&schemaVersion=1',
+      '_blank'
+    );
+  });
+});

--- a/src/Components/ServiceScene/GoToExploreButton.tsx
+++ b/src/Components/ServiceScene/GoToExploreButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { toURLRange, urlUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { sceneGraph, SceneObject } from '@grafana/scenes';
+import { sceneGraph } from '@grafana/scenes';
 import { ToolbarButton } from '@grafana/ui';
 
 import { getDataSource, getQueryExpr } from 'services/scenes';
@@ -12,10 +12,9 @@ import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'se
 import { getDisplayedFields, getLogsVisualizationType } from 'services/store';
 interface GoToExploreButtonState {
   exploration: IndexScene;
-  sceneRef: SceneObject;
 }
 
-export const GoToExploreButton = ({ exploration, sceneRef }: GoToExploreButtonState) => {
+export const GoToExploreButton = ({ exploration }: GoToExploreButtonState) => {
   const onClick = () => {
     reportAppInteraction(
       USER_EVENTS_PAGES.service_details,
@@ -24,7 +23,7 @@ export const GoToExploreButton = ({ exploration, sceneRef }: GoToExploreButtonSt
     const datasource = getDataSource(exploration);
     const expr = getQueryExpr(exploration).replace(/\s+/g, ' ').trimEnd();
     const timeRange = sceneGraph.getTimeRange(exploration).state.value;
-    const displayedFields = getDisplayedFields(sceneRef);
+    const displayedFields = getDisplayedFields(exploration);
     const visualisationType = getLogsVisualizationType();
     const exploreState = JSON.stringify({
       ['loki-explore']: {

--- a/src/Components/ServiceScene/GoToExploreButton.tsx
+++ b/src/Components/ServiceScene/GoToExploreButton.tsx
@@ -25,11 +25,12 @@ export const GoToExploreButton = ({ exploration }: GoToExploreButtonState) => {
     const timeRange = sceneGraph.getTimeRange(exploration).state.value;
     const displayedFields = getDisplayedFields(exploration);
     const visualisationType = getLogsVisualizationType();
+    const columns = getUrlColumns();
     const exploreState = JSON.stringify({
       ['loki-explore']: {
         range: toURLRange(timeRange.raw),
         queries: [{ refId: 'logs', expr, datasource }],
-        panelsState: { logs: { displayedFields, visualisationType } },
+        panelsState: { logs: { displayedFields, visualisationType, columns } },
         datasource,
       },
     });
@@ -49,3 +50,21 @@ export const GoToExploreButton = ({ exploration }: GoToExploreButtonState) => {
     </ToolbarButton>
   );
 };
+
+function getUrlColumns() {
+  const params = new URLSearchParams(window.location.search);
+  const urlColumns = params.get('urlColumns');
+  if (urlColumns) {
+    try {
+      const columns: string[] = JSON.parse(urlColumns);
+      let columnsParam: Record<number, string> = {};
+      for (const key in columns) {
+        columnsParam[key] = columns[key];
+      }
+      return columnsParam;
+    } catch (e) {
+      console.error(e);
+    }
+  }
+  return undefined;
+}

--- a/src/Components/ServiceScene/GoToExploreButton.tsx
+++ b/src/Components/ServiceScene/GoToExploreButton.tsx
@@ -2,18 +2,20 @@ import React from 'react';
 
 import { toURLRange, urlUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { sceneGraph } from '@grafana/scenes';
+import { sceneGraph, SceneObject } from '@grafana/scenes';
 import { ToolbarButton } from '@grafana/ui';
 
 import { getDataSource, getQueryExpr } from 'services/scenes';
 import { testIds } from 'services/testIds';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
 import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
+import { getDisplayedFields, getLogsVisualizationType } from 'services/store';
 interface GoToExploreButtonState {
   exploration: IndexScene;
+  sceneRef: SceneObject;
 }
 
-export const GoToExploreButton = ({ exploration }: GoToExploreButtonState) => {
+export const GoToExploreButton = ({ exploration, sceneRef }: GoToExploreButtonState) => {
   const onClick = () => {
     reportAppInteraction(
       USER_EVENTS_PAGES.service_details,
@@ -22,10 +24,13 @@ export const GoToExploreButton = ({ exploration }: GoToExploreButtonState) => {
     const datasource = getDataSource(exploration);
     const expr = getQueryExpr(exploration).replace(/\s+/g, ' ').trimEnd();
     const timeRange = sceneGraph.getTimeRange(exploration).state.value;
+    const displayedFields = getDisplayedFields(sceneRef);
+    const visualisationType = getLogsVisualizationType();
     const exploreState = JSON.stringify({
       ['loki-explore']: {
         range: toURLRange(timeRange.raw),
         queries: [{ refId: 'logs', expr, datasource }],
+        panelsState: { logs: { displayedFields, visualisationType } },
         datasource,
       },
     });

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -18,7 +18,12 @@ import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '..
 import { locationService } from '@grafana/runtime';
 import { LogOptionsScene } from './LogOptionsScene';
 import { LogsPanelScene } from './LogsPanelScene';
-import { getDisplayedFields } from 'services/store';
+import {
+  getDisplayedFields,
+  getLogsVisualizationType,
+  LogsVisualizationType,
+  setLogsVisualizationType,
+} from 'services/store';
 import { logger } from '../../services/logger';
 
 export interface LogsListSceneState extends SceneObjectState {
@@ -31,10 +36,6 @@ export interface LogsListSceneState extends SceneObjectState {
   displayedFields: string[];
 }
 
-export type LogsVisualizationType = 'logs' | 'table';
-// If we use the local storage key from explore the user will get more consistent UX?
-const VISUALIZATION_TYPE_LOCALSTORAGE_KEY = 'grafana.explore.logs.visualisationType';
-
 export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, {
     keys: ['urlColumns', 'selectedLine', 'visualizationType', 'displayedFields'],
@@ -44,7 +45,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
   constructor(state: Partial<LogsListSceneState>) {
     super({
       ...state,
-      visualizationType: (localStorage.getItem(VISUALIZATION_TYPE_LOCALSTORAGE_KEY) as LogsVisualizationType) ?? 'logs',
+      visualizationType: getLogsVisualizationType(),
       displayedFields: [],
     });
 
@@ -175,7 +176,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
         visualisationType: type,
       }
     );
-    localStorage.setItem(VISUALIZATION_TYPE_LOCALSTORAGE_KEY, type);
+    setLogsVisualizationType(type);
   };
 
   private getVizPanel() {

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -130,13 +130,14 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
 
   private handleShareLogLineClick = (event: MouseEvent<HTMLElement>, row?: LogRowModel) => {
     if (row?.rowId && this.state.body) {
+      const parent = this.getParentScene();
       const timeRange = sceneGraph.getTimeRange(this.state.body);
       const buttonRef = event.currentTarget instanceof HTMLButtonElement ? event.currentTarget : undefined;
       copyText(
         generateLogShortlink(
           'panelState',
           {
-            logs: { id: row.uid },
+            logs: { id: row.uid, displayedFields: parent.state.displayedFields },
           },
           timeRange.state.value
         ),

--- a/src/Components/Table/LogsHeaderActions.tsx
+++ b/src/Components/Table/LogsHeaderActions.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { RadioButtonGroup } from '@grafana/ui';
 import { css } from '@emotion/css';
-import { LogsVisualizationType } from '../ServiceScene/LogsListScene';
+import { LogsVisualizationType } from 'services/store';
 
 export function LogsPanelHeaderActions(props: {
   vizType: LogsVisualizationType;

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -212,3 +212,21 @@ export function setDisplayedFields(sceneRef: SceneObject, fields: string[]) {
   const PREFIX = getExplorationPrefix(sceneRef);
   localStorage.setItem(`${pluginJson.id}.${PREFIX}.logs.fields`, JSON.stringify(fields));
 }
+
+export type LogsVisualizationType = 'logs' | 'table';
+
+const VISUALIZATION_TYPE_LOCALSTORAGE_KEY = 'grafana.explore.logs.visualisationType';
+export function getLogsVisualizationType(): LogsVisualizationType {
+  const storedType = localStorage.getItem(VISUALIZATION_TYPE_LOCALSTORAGE_KEY) ?? '';
+  switch (storedType) {
+    case 'table':
+    case 'logs':
+      return storedType;
+    default:
+      return 'logs';
+  }
+}
+
+export function setLogsVisualizationType(type: string) {
+  localStorage.setItem(VISUALIZATION_TYPE_LOCALSTORAGE_KEY, type);
+}

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -33,7 +33,17 @@ export enum UrlParameterType {
   To = 'to',
 }
 
-type PermalinkDataType = Record<string, string | number | Record<string, string | number>>;
+type PermalinkDataType =
+  | {
+      id?: string;
+      row?: number;
+    }
+  | {
+      logs: {
+        id: string;
+        displayedFields: string[];
+      };
+    };
 
 export const generateLogShortlink = (paramName: string, data: PermalinkDataType, timeRange: TimeRange) => {
   const location = locationService.getLocation();


### PR DESCRIPTION
This PR extends the GoToExploreButton to respect the selected displayedFields, visualizationType, and table columns, which was a source of confusion for users switching between apps.

Part of #884
Requires https://github.com/grafana/grafana/pull/96242