### PR TITLE
feat(explorations): remove disabled state

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/AddToExplorationButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToExplorationButton.tsx
@@ -16,7 +16,6 @@ export interface AddToExplorationButtonState extends SceneObjectState {
   fieldName?: string;
   context?: ExtensionContext;
 
-  disabledLinks: string[];
   queries: DataQuery[];
 }
 
@@ -35,8 +34,8 @@ type ExtensionContext = {
 };
 
 export class AddToExplorationButton extends SceneObjectBase<AddToExplorationButtonState> {
-  constructor(state: Omit<AddToExplorationButtonState, 'disabledLinks' | 'queries'>) {
-    super({ ...state, disabledLinks: [], queries: [] });
+  constructor(state: Omit<AddToExplorationButtonState, 'queries'>) {
+    super({ ...state, queries: [] });
     this.addActivationHandler(this.onActivate);
   }
 
@@ -94,7 +93,7 @@ export class AddToExplorationButton extends SceneObjectBase<AddToExplorationButt
   };
 
   public static Component = ({ model }: SceneComponentProps<AddToExplorationButton>) => {
-    const { context, disabledLinks } = model.useState();
+    const { context } = model.useState();
     const { links } = usePluginLinks({ extensionPointId: ExtensionPoints.MetricExploration, context });
 
     return (
@@ -104,7 +103,6 @@ export class AddToExplorationButton extends SceneObjectBase<AddToExplorationButt
           .map((link) => (
             <IconButton
               tooltip={link.description}
-              disabled={link.category === 'disabled' || disabledLinks.includes(link.id)}
               aria-label="extension-link-to-open-exploration"
               key={link.id}
               name={link.icon ?? 'panel-add'}
@@ -112,7 +110,6 @@ export class AddToExplorationButton extends SceneObjectBase<AddToExplorationButt
                 if (link.onClick) {
                   link.onClick(e);
                 }
-                model.setState({ disabledLinks: [...disabledLinks, link.id] });
               }}
             />
           ))}


### PR DESCRIPTION
With multiple investigations having a disabled state doesn't work properly. This PR just removes this state for now.