### PR TITLE
chore: cleanup faro error messages

### DIFF
--- a/src/Components/AppConfig/AppConfig.tsx
+++ b/src/Components/AppConfig/AppConfig.tsx
@@ -117,7 +117,7 @@ const updatePluginAndReload = async (pluginId: string, data: Partial<PluginMeta<
     // This is not ideal, however unfortunately currently there is no supported way for updating the plugin state.
     locationService.reload();
   } catch (e) {
-    logger.error('Error while updating the plugin');
+    logger.error(e, { msg: 'Error while updating the plugin' });
   }
 };
 

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -315,6 +315,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
         const error = new Error(`Unknown variable type: ${variableType}`);
         logger.error(error, {
           variableType,
+          msg: `getFieldsTagValuesExpression: Unknown variable type: ${variableType}`,
         });
         throw error;
     }

--- a/src/Components/Pages.tsx
+++ b/src/Components/Pages.tsx
@@ -137,7 +137,12 @@ export function makeBreakdownValuePage(
 
   if (!breakdownLabel) {
     const e = new Error('Breakdown value missing!');
-    logger.error(e, { labelName, labelValue, breakdownLabel: breakdownLabel ?? '' });
+    logger.error(e, {
+      msg: 'makeBreakdownValuePage: Breakdown value missing!',
+      labelName,
+      labelValue,
+      breakdownLabel: breakdownLabel ?? '',
+    });
     throw e;
   }
 

--- a/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
@@ -445,7 +445,7 @@ function getUnitOptions(fieldType: 'duration' | 'bytes'): Array<SelectableValue<
   }
 
   const error = new Error(`invalid field type: ${fieldType}`);
-  logger.error(error);
+  logger.error(error, { msg: 'getUnitOptions, invalid field type' });
   throw error;
 }
 

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsLogsSampleScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsLogsSampleScene.tsx
@@ -143,6 +143,7 @@ export class PatternsLogsSampleScene extends SceneObjectBase<PatternsLogsSampleS
           pattern: this.state.pattern,
           traceIds: JSON.stringify(value.data.traceIds),
           request: JSON.stringify(value.data.request),
+          msg: 'onQueryError',
         };
       } catch (e) {
         logContext = {

--- a/src/Components/ServiceScene/Breakdowns/SelectLabelActionScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SelectLabelActionScene.tsx
@@ -267,7 +267,7 @@ export class SelectLabelActionScene extends SceneObjectBase<SelectLabelActionSce
 
     if (!fieldType || fieldType === 'string' || fieldType === 'boolean' || fieldType === 'int') {
       const error = new Error(`Incorrect field type: ${fieldType}`);
-      logger.error(error);
+      logger.error(error, { msg: `onClickNumericFilter invalid field type ${fieldType}` });
       throw error;
     }
 

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -486,7 +486,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
           children: [...body.state.children.slice(0, 1), valueBreakdownViewDef.getScene(this.state.drillDownLabel)],
         });
       } else {
-        logger.error(new Error('not setting breakdown view'));
+        logger.error(new Error('not setting breakdown view'), { msg: 'setBreakdownView error' });
       }
     }
   }

--- a/src/services/TagValuesProviders.ts
+++ b/src/services/TagValuesProviders.ts
@@ -87,10 +87,9 @@ export const getDetectedFieldValuesTagValuesProvider = async (
         values = [];
       }
     } catch (e) {
-      logger.error(e);
-      logger.warn(
-        'getDetectedFieldValuesTagValuesProvider: loki missing detected_field/.../values endpoint. Upgrade to Loki 3.3.0 or higher.'
-      );
+      logger.error(e, {
+        msg: 'getDetectedFieldValuesTagValuesProvider: loki missing detected_field/.../values endpoint. Upgrade to Loki 3.3.0 or higher.',
+      });
       values = [];
     }
   } else {

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -107,7 +107,12 @@ function splitQueriesByStreamShard(
           return false;
         }
       } catch (e) {
-        logger.error(e);
+        logger.error(e, {
+          msg: 'sharding retry error',
+          error: errorResponse?.error?.message ?? '',
+          errors: errorResponse?.errors?.map((e) => e.message).join(' | ') ?? '',
+          traces: errorResponse?.traceIds?.join('|') ?? '',
+        });
         shouldStop = true;
         return false;
       }


### PR DESCRIPTION
Seeing some errors in faro come back as `console.error: [object Object] [object Object]`, be nice to be able to filter them out easier, and have more context for other errors in the future.