### PR TITLE
Field labels: histogram option for numeric fields

### DIFF
--- a/src/Components/Panels/PanelMenu.tsx
+++ b/src/Components/Panels/PanelMenu.tsx
@@ -90,6 +90,8 @@ function addHistogramItem(items: PanelMenuItem[], sceneRef: PanelMenu) {
       if (fieldsAggregatedBreakdownScene) {
         fieldsAggregatedBreakdownScene.rebuildAvgFields();
       }
+
+      onSwitchVizTypeTracking(newPanelType);
     },
   });
 }
@@ -188,6 +190,12 @@ const getExploreLink = (sceneRef: SceneObject) => {
 
 const onExploreLinkClickTracking = () => {
   reportAppInteraction(USER_EVENTS_PAGES.all, USER_EVENTS_ACTIONS.all.open_in_explore_menu_clicked);
+};
+
+const onSwitchVizTypeTracking = (newVizType: AvgFieldPanelType) => {
+  reportAppInteraction(USER_EVENTS_PAGES.service_details, USER_EVENTS_ACTIONS.service_details.change_viz_type, {
+    newVizType,
+  });
 };
 
 const getInvestigationLink = (addToExplorations: AddToExplorationButton) => {

--- a/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
@@ -40,8 +40,9 @@ import {
   getFieldsVariable,
   getValueFromFieldsFilter,
 } from '../../../services/variableGetters';
-import { PanelMenu, getPanelWrapperStyles } from '../../Panels/PanelMenu';
+import { AvgFieldPanelType, getPanelWrapperStyles, PanelMenu } from '../../Panels/PanelMenu';
 import { logger } from '../../../services/logger';
+import { getPanelOption } from '../../../services/store';
 
 export interface FieldsAggregatedBreakdownSceneState extends SceneObjectState {
   body?: LayoutSwitcher;
@@ -116,12 +117,7 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
         }
 
         const fieldsToAdd = Array.from(newFieldsSet);
-        const options = fieldsToAdd.map((fieldName) => {
-          return {
-            label: fieldName,
-            value: fieldName,
-          };
-        });
+        const options = fieldsToAdd.map((fieldName) => fieldName);
 
         updatedChildren.push(...this.buildChildren(options));
         updatedChildren.sort(this.sortChildren(cardinalityMap));
@@ -197,9 +193,9 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
     });
   }
 
-  private build() {
+  public build() {
     const groupByVariable = getFieldGroupByVariable(this);
-    const options = groupByVariable.state.options.map((opt) => ({ label: opt.label, value: String(opt.value) }));
+    const options = groupByVariable.state.options.map((opt) => opt.label);
 
     const fieldsBreakdownScene = sceneGraph.getAncestor(this, FieldsBreakdownScene);
     fieldsBreakdownScene.state.search.reset();
@@ -254,52 +250,98 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
     }
   }
 
-  private buildChildren(options: Array<{ label: string; value: string }>): SceneCSSGridItem[] {
+  public rebuildAvgFields() {
+    const detectedFieldsFrame = getDetectedFieldsFrame(this);
+    const activeLayout = this.getActiveGridLayouts();
+    const children: SceneCSSGridItem[] = [];
+    const panelType = getPanelOption('panelType') ?? undefined;
+
+    activeLayout?.state.children.forEach((child) => {
+      if (child instanceof SceneCSSGridItem) {
+        const panels = sceneGraph.findDescendents(child, VizPanel);
+        if (panels.length) {
+          // Will only be one panel as a child of CSSGridItem
+          const panel = panels[0];
+          const labelName = panel.state.title;
+          const fieldType = getDetectedFieldType(labelName, detectedFieldsFrame);
+          if (isAvgField(fieldType)) {
+            const newChild = this.buildChild(labelName, detectedFieldsFrame, panelType);
+            if (newChild) {
+              children.push(newChild);
+            }
+          } else {
+            children.push(child);
+          }
+        }
+      }
+    });
+
+    if (children.length) {
+      activeLayout?.setState({
+        children,
+      });
+    }
+  }
+
+  private buildChildren(options: string[]): SceneCSSGridItem[] {
     const children: SceneCSSGridItem[] = [];
     const detectedFieldsFrame = getDetectedFieldsFrame(this);
-
+    const panelType = getPanelOption('panelType') ?? undefined;
     for (const option of options) {
-      const { value: optionValue } = option;
-      if (optionValue === ALL_VARIABLE_VALUE || !optionValue) {
-        continue;
+      const child = this.buildChild(option, detectedFieldsFrame, panelType);
+      if (child) {
+        children.push(child);
       }
-
-      const fieldType = getDetectedFieldType(optionValue, detectedFieldsFrame);
-      const dataTransformer = this.getDataTransformerForPanel(optionValue, detectedFieldsFrame, fieldType);
-      let body = PanelBuilders.timeseries()
-        .setTitle(optionValue)
-        .setData(dataTransformer)
-        .setMenu(new PanelMenu({ labelName: optionValue }));
-
-      const headerActions = [];
-      if (!isAvgField(fieldType)) {
-        body = body
-          .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
-          .setCustomFieldConfig('fillOpacity', 100)
-          .setCustomFieldConfig('lineWidth', 0)
-          .setCustomFieldConfig('pointSize', 0)
-          .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
-          .setOverrides(setLevelColorOverrides);
-        headerActions.push(new SelectLabelActionScene({ labelName: String(optionValue), fieldType: ValueSlugs.field }));
-      } else {
-        headerActions.push(
-          new SelectLabelActionScene({
-            labelName: String(optionValue),
-            hideValueDrilldown: true,
-            fieldType: ValueSlugs.field,
-          })
-        );
-      }
-      body.setHeaderActions(headerActions);
-
-      const viz = body.build();
-      const gridItem = new SceneCSSGridItem({
-        body: viz,
-      });
-
-      children.push(gridItem);
     }
     return children;
+  }
+
+  private buildChild(labelName: string, detectedFieldsFrame: DataFrame | undefined, panelType?: AvgFieldPanelType) {
+    if (labelName === ALL_VARIABLE_VALUE || !labelName) {
+      return;
+    }
+
+    const fieldType = getDetectedFieldType(labelName, detectedFieldsFrame);
+    const dataTransformer = this.getDataTransformerForPanel(labelName, detectedFieldsFrame, fieldType);
+    let body;
+
+    const headerActions = [];
+    if (!isAvgField(fieldType)) {
+      body = PanelBuilders.timeseries()
+        .setTitle(labelName)
+        .setData(dataTransformer)
+        .setMenu(new PanelMenu({ labelName: labelName }))
+        .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
+        .setCustomFieldConfig('fillOpacity', 100)
+        .setCustomFieldConfig('lineWidth', 0)
+        .setCustomFieldConfig('pointSize', 0)
+        .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
+        .setOverrides(setLevelColorOverrides);
+      headerActions.push(new SelectLabelActionScene({ labelName: String(labelName), fieldType: ValueSlugs.field }));
+    } else {
+      if (panelType === 'histogram') {
+        body = PanelBuilders.histogram();
+      } else {
+        body = PanelBuilders.timeseries();
+      }
+      body
+        .setTitle(labelName)
+        .setData(dataTransformer)
+        .setMenu(new PanelMenu({ labelName: labelName, panelType }));
+      headerActions.push(
+        new SelectLabelActionScene({
+          labelName: String(labelName),
+          hideValueDrilldown: true,
+          fieldType: ValueSlugs.field,
+        })
+      );
+    }
+    body.setHeaderActions(headerActions);
+
+    const viz = body.build();
+    return new SceneCSSGridItem({
+      body: viz,
+    });
   }
 
   private getDataTransformerForPanel(
@@ -322,9 +364,14 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
     });
   }
 
+  private getActiveGridLayouts() {
+    return (this.state.body?.state.layouts.find((l) => l.isActive) ?? this.state.body?.state.layouts[0]) as
+      | SceneCSSGridLayout
+      | undefined;
+  }
+
   private updateFieldCount() {
-    const activeLayout = (this.state.body?.state.layouts.find((l) => l.isActive) ??
-      this.state.body?.state.layouts[0]) as SceneCSSGridLayout | undefined;
+    const activeLayout = this.getActiveGridLayouts();
     const activeLayoutChildren = activeLayout?.state.children as SceneCSSGridItem[] | undefined;
     const activePanels = activeLayoutChildren?.filter((child) => !child.state.isHidden);
 

--- a/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
@@ -257,7 +257,7 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
     const panelType = getPanelOption('panelType') ?? AvgFieldPanelType.timeseries;
 
     activeLayout?.state.children.forEach((child) => {
-      if (child instanceof SceneCSSGridItem) {
+      if (child instanceof SceneCSSGridItem && !child.state.isHidden) {
         const panels = sceneGraph.findDescendents(child, VizPanel);
         if (panels.length) {
           // Will only be one panel as a child of CSSGridItem

--- a/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
@@ -254,7 +254,9 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
     const detectedFieldsFrame = getDetectedFieldsFrame(this);
     const activeLayout = this.getActiveGridLayouts();
     const children: SceneCSSGridItem[] = [];
-    const panelType = getPanelOption('panelType') ?? AvgFieldPanelType.timeseries;
+    const panelType =
+      getPanelOption('panelType', [AvgFieldPanelType.histogram, AvgFieldPanelType.timeseries]) ??
+      AvgFieldPanelType.timeseries;
 
     activeLayout?.state.children.forEach((child) => {
       if (child instanceof SceneCSSGridItem && !child.state.isHidden) {
@@ -286,7 +288,9 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
   private buildChildren(options: string[]): SceneCSSGridItem[] {
     const children: SceneCSSGridItem[] = [];
     const detectedFieldsFrame = getDetectedFieldsFrame(this);
-    const panelType = getPanelOption('panelType') ?? AvgFieldPanelType.timeseries;
+    const panelType =
+      getPanelOption('panelType', [AvgFieldPanelType.timeseries, AvgFieldPanelType.histogram]) ??
+      AvgFieldPanelType.timeseries;
     for (const option of options) {
       if (option === ALL_VARIABLE_VALUE || !option) {
         continue;

--- a/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
@@ -195,7 +195,7 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
 
   public build() {
     const groupByVariable = getFieldGroupByVariable(this);
-    const options = groupByVariable.state.options.map((opt) => opt.label);
+    const options = groupByVariable.state.options.map((opt) => String(opt.value));
 
     const fieldsBreakdownScene = sceneGraph.getAncestor(this, FieldsBreakdownScene);
     fieldsBreakdownScene.state.search.reset();
@@ -288,6 +288,10 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
     const detectedFieldsFrame = getDetectedFieldsFrame(this);
     const panelType = getPanelOption('panelType') ?? undefined;
     for (const option of options) {
+      if (option === ALL_VARIABLE_VALUE || !option) {
+        continue;
+      }
+
       const child = this.buildChild(option, detectedFieldsFrame, panelType);
       if (child) {
         children.push(child);

--- a/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
@@ -42,7 +42,7 @@ import {
 } from '../../../services/variableGetters';
 import { AvgFieldPanelType, getPanelWrapperStyles, PanelMenu } from '../../Panels/PanelMenu';
 import { logger } from '../../../services/logger';
-import { getPanelOption, PanelOptions } from '../../../services/store';
+import { getPanelOption } from '../../../services/store';
 
 export interface FieldsAggregatedBreakdownSceneState extends SceneObjectState {
   body?: LayoutSwitcher;

--- a/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
@@ -42,7 +42,7 @@ import {
 } from '../../../services/variableGetters';
 import { AvgFieldPanelType, getPanelWrapperStyles, PanelMenu } from '../../Panels/PanelMenu';
 import { logger } from '../../../services/logger';
-import { getPanelOption } from '../../../services/store';
+import { getPanelOption, PanelOptions } from '../../../services/store';
 
 export interface FieldsAggregatedBreakdownSceneState extends SceneObjectState {
   body?: LayoutSwitcher;
@@ -254,7 +254,7 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
     const detectedFieldsFrame = getDetectedFieldsFrame(this);
     const activeLayout = this.getActiveGridLayouts();
     const children: SceneCSSGridItem[] = [];
-    const panelType = getPanelOption('panelType') ?? undefined;
+    const panelType = getPanelOption('panelType') ?? AvgFieldPanelType.timeseries;
 
     activeLayout?.state.children.forEach((child) => {
       if (child instanceof SceneCSSGridItem) {
@@ -286,7 +286,7 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
   private buildChildren(options: string[]): SceneCSSGridItem[] {
     const children: SceneCSSGridItem[] = [];
     const detectedFieldsFrame = getDetectedFieldsFrame(this);
-    const panelType = getPanelOption('panelType') ?? undefined;
+    const panelType = getPanelOption('panelType') ?? AvgFieldPanelType.timeseries;
     for (const option of options) {
       if (option === ALL_VARIABLE_VALUE || !option) {
         continue;

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -71,6 +71,7 @@ export const USER_EVENTS_ACTIONS = {
     value_breakdown_sort_change: 'value_breakdown_sort_change',
     // Wasm not supported
     wasm_not_supported: 'wasm_not_supported',
+    change_viz_type: 'change_viz_type',
   },
   [USER_EVENTS_PAGES.all]: {
     interval_too_long: 'interval_too_long',

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -5,6 +5,7 @@ import { getDataSourceName, getServiceName } from './variableGetters';
 import { logger } from './logger';
 import { SERVICE_NAME } from './variables';
 import { Options } from '@grafana/schema/dist/esm/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen';
+import { AvgFieldPanelType } from '../Components/Panels/PanelMenu';
 
 const FAVORITE_PRIMARY_LABEL_VALUES_LOCALSTORAGE_KEY = `${pluginJson.id}.services.favorite`;
 const FAVORITE_PRIMARY_LABEL_NAME_LOCALSTORAGE_KEY = `${pluginJson.id}.primarylabels.tabs.favorite`;
@@ -180,20 +181,6 @@ export function setSortByPreference(target: string, sortBy: string, direction: s
   }
 }
 
-const LOG_OPTIONS_LOCALSTORAGE_KEY = `${pluginJson.id}.logs.option`;
-export function getLogOption<T>(option: keyof Options, defaultValue: T) {
-  const localStorageResult = localStorage.getItem(`${LOG_OPTIONS_LOCALSTORAGE_KEY}.${option}`);
-  return localStorageResult ? localStorageResult : defaultValue;
-}
-
-export function setLogOption(option: keyof Options, value: string | number | boolean) {
-  let storedValue = value.toString();
-  if (typeof value === 'boolean' && !value) {
-    storedValue = '';
-  }
-  localStorage.setItem(`${LOG_OPTIONS_LOCALSTORAGE_KEY}.${option}`, storedValue);
-}
-
 function getExplorationPrefix(sceneRef: SceneObject) {
   const ds = getDataSourceName(sceneRef);
   const serviceName = getServiceName(sceneRef);
@@ -214,6 +201,22 @@ export function setDisplayedFields(sceneRef: SceneObject, fields: string[]) {
   localStorage.setItem(`${pluginJson.id}.${PREFIX}.logs.fields`, JSON.stringify(fields));
 }
 
+// Log panel options
+const LOG_OPTIONS_LOCALSTORAGE_KEY = `${pluginJson.id}.logs.option`;
+export function getLogOption<T>(option: keyof Options, defaultValue: T) {
+  const localStorageResult = localStorage.getItem(`${LOG_OPTIONS_LOCALSTORAGE_KEY}.${option}`);
+  return localStorageResult ? localStorageResult : defaultValue;
+}
+
+export function setLogOption(option: keyof Options, value: string | number | boolean) {
+  let storedValue = value.toString();
+  if (typeof value === 'boolean' && !value) {
+    storedValue = '';
+  }
+  localStorage.setItem(`${LOG_OPTIONS_LOCALSTORAGE_KEY}.${option}`, storedValue);
+}
+
+// Log visualization options
 export type LogsVisualizationType = 'logs' | 'table';
 
 const VISUALIZATION_TYPE_LOCALSTORAGE_KEY = 'grafana.explore.logs.visualisationType';
@@ -230,4 +233,17 @@ export function getLogsVisualizationType(): LogsVisualizationType {
 
 export function setLogsVisualizationType(type: string) {
   localStorage.setItem(VISUALIZATION_TYPE_LOCALSTORAGE_KEY, type);
+}
+
+// Panel options
+const PANEL_OPTIONS_LOCALSTORAGE_KEY = `${pluginJson.id}.panel.option`;
+export interface PanelOptions {
+  panelType: AvgFieldPanelType;
+}
+export function getPanelOption<K extends keyof PanelOptions, V extends PanelOptions[K]>(option: K): V | null {
+  return localStorage.getItem(`${PANEL_OPTIONS_LOCALSTORAGE_KEY}.${option}`) as V | null;
+}
+
+export function setPanelOption<K extends keyof PanelOptions, V extends PanelOptions[K]>(option: K, value: V) {
+  localStorage.setItem(`${PANEL_OPTIONS_LOCALSTORAGE_KEY}.${option}`, value);
 }

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -241,8 +241,16 @@ const PANEL_OPTIONS_LOCALSTORAGE_KEY = `${pluginJson.id}.panel.option`;
 export interface PanelOptions {
   panelType: AvgFieldPanelType;
 }
-export function getPanelOption<K extends keyof PanelOptions, V extends PanelOptions[K]>(option: K): V | null {
-  return localStorage.getItem(`${PANEL_OPTIONS_LOCALSTORAGE_KEY}.${option}`) as V | null;
+export function getPanelOption<K extends keyof PanelOptions, V extends PanelOptions[K]>(
+  option: K,
+  values: V[]
+): V | null {
+  const result = localStorage.getItem(`${PANEL_OPTIONS_LOCALSTORAGE_KEY}.${option}`);
+  if (result !== null) {
+    return values.find((v) => result === v) ?? null;
+  }
+
+  return null;
 }
 
 export function setPanelOption<K extends keyof PanelOptions, V extends PanelOptions[K]>(option: K, value: V) {


### PR DESCRIPTION
Adds a new option for numeric fields to allow users to toggle between histogram and time series visualization types.
Also adds grouping categories to the PanelMenu.
Saves last selection in local storage as default viz for numeric panels.

<img width="443" alt="image" src="https://github.com/user-attachments/assets/907c484d-44c8-4d36-a2ce-1b34c16bd649">
<img width="433" alt="image" src="https://github.com/user-attachments/assets/8e66151f-6b2f-4410-aafd-835c5d5d165e">

Without investigations:
Numeric panel:
<img width="458" alt="image" src="https://github.com/user-attachments/assets/f027f4d9-f68c-4f94-9c5e-1bd0cb354ad2">
Regular panel:
<img width="444" alt="image" src="https://github.com/user-attachments/assets/4c21e3f9-593e-49f6-adf1-62f11c866363">



Fixes: https://github.com/grafana/explore-logs/issues/923

