### PR TITLE
LogsVolumePanel: Add infinite scroll for logs and display visible range

### DIFF
--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -17,7 +17,7 @@ import { getVariableForLabel } from '../../services/fields';
 import { VAR_FIELDS, VAR_LABELS, VAR_LEVELS, VAR_METADATA } from '../../services/variables';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../services/analytics';
 import { getAdHocFiltersVariable, getValueFromFieldsFilter } from '../../services/variableGetters';
-import { copyText, generateLogShortlink } from 'services/text';
+import { copyText, generateLogShortlink, resolveRowTimeRangeForSharing } from 'services/text';
 import { CopyLinkButton } from './CopyLinkButton';
 import { getLogsPanelSortOrder, LogOptionsScene } from './LogOptionsScene';
 
@@ -132,15 +132,15 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
   private handleShareLogLineClick = (event: MouseEvent<HTMLElement>, row?: LogRowModel) => {
     if (row?.rowId && this.state.body) {
       const parent = this.getParentScene();
-      const timeRange = sceneGraph.getTimeRange(this.state.body);
       const buttonRef = event.currentTarget instanceof HTMLButtonElement ? event.currentTarget : undefined;
+      const timeRange = resolveRowTimeRangeForSharing(sceneGraph.getTimeRange(this.state.body).state.value, row);
       copyText(
         generateLogShortlink(
           'panelState',
           {
             logs: { id: row.uid, displayedFields: parent.state.displayedFields },
           },
-          timeRange.state.value
+          timeRange
         ),
         buttonRef
       );

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -118,7 +118,8 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
         .setOption('sortOrder', getLogsPanelSortOrder())
         .setOption('wrapLogMessage', Boolean(getLogOption<boolean>('wrapLogMessage', false)))
         .setOption('showLogContextToggle', true)
-
+        // @ts-expect-error
+        .setOption('enableInfiniteScrolling', true)
         // @ts-expect-error
         .setOption('logRowMenuIconsAfter', [<CopyLinkButton onClick={this.handleShareLogLineClick} key={0} />])
         .setHeaderActions(

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -119,11 +119,11 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
         .setOption('sortOrder', getLogsPanelSortOrder())
         .setOption('wrapLogMessage', Boolean(getLogOption<boolean>('wrapLogMessage', false)))
         .setOption('showLogContextToggle', true)
-        // @ts-expect-error
+        // @ts-expect-error Requires Grafana 11.4
         .setOption('enableInfiniteScrolling', true)
-        // @ts-expect-error
+        // @ts-expect-error Grafana 11.4
         .setOption('onNewLogsReceived', this.updateVisibleRange)
-        // @ts-expect-error
+        // @ts-expect-error Grafana 11.4
         .setOption('logRowMenuIconsAfter', [<CopyLinkButton onClick={this.handleShareLogLineClick} key={0} />])
         .setHeaderActions(
           new LogOptionsScene({ visualizationType, onChangeVisualizationType: parentModel.setVisualizationType })
@@ -143,7 +143,7 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
     if (row?.rowId && this.state.body) {
       const parent = this.getParentScene();
       const buttonRef = event.currentTarget instanceof HTMLButtonElement ? event.currentTarget : undefined;
-      const timeRange = resolveRowTimeRangeForSharing(sceneGraph.getTimeRange(this.state.body).state.value, row);
+      const timeRange = resolveRowTimeRangeForSharing(row);
       copyText(
         generateLogShortlink(
           'panelState',

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -20,6 +20,7 @@ import { getAdHocFiltersVariable, getValueFromFieldsFilter } from '../../service
 import { copyText, generateLogShortlink, resolveRowTimeRangeForSharing } from 'services/text';
 import { CopyLinkButton } from './CopyLinkButton';
 import { getLogsPanelSortOrder, LogOptionsScene } from './LogOptionsScene';
+import { LogsVolumePanel, logsVolumePanelKey } from './LogsVolumePanel';
 
 interface LogsPanelSceneState extends SceneObjectState {
   body?: VizPanel;
@@ -121,6 +122,8 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
         // @ts-expect-error
         .setOption('enableInfiniteScrolling', true)
         // @ts-expect-error
+        .setOption('onNewLogsReceived', this.updateVisibleRange)
+        // @ts-expect-error
         .setOption('logRowMenuIconsAfter', [<CopyLinkButton onClick={this.handleShareLogLineClick} key={0} />])
         .setHeaderActions(
           new LogOptionsScene({ visualizationType, onChangeVisualizationType: parentModel.setVisualizationType })
@@ -128,6 +131,13 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
         .build()
     );
   }
+
+  private updateVisibleRange = (newLogs: DataFrame[]) => {
+    const logsVolumeScene = sceneGraph.findByKeyAndType(this, logsVolumePanelKey, LogsVolumePanel);
+    if (logsVolumeScene instanceof LogsVolumePanel) {
+      logsVolumeScene.updateVisibleRange(newLogs);
+    }
+  };
 
   private handleShareLogLineClick = (event: MouseEvent<HTMLElement>, row?: LogRowModel) => {
     if (row?.rowId && this.state.body) {

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -124,7 +124,8 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     if (
       !panel ||
       !panel.state.$data?.state.data ||
-      panel.state.$data?.state.data.state !== LoadingState.Done ||
+      panel.state.$data?.state.data.state === LoadingState.Streaming ||
+      panel.state.$data?.state.data.state === LoadingState.Loading ||
       !this.updatedLogSeries
     ) {
       return;

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -99,8 +99,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
     this._subs.add(
       serviceScene.subscribeToState((newState) => {
-        console.log(newState);
-        if (newState.$data?.state.data?.state === LoadingState.Done && panel.state.$data?.state.data) {
+        if (newState.$data?.state.data?.state === LoadingState.Done) {
           this.updatedLogSeries = newState.$data?.state.data.series;
           this.displayVisibleRange();
         }

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -88,12 +88,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
 
     this._subs.add(
       panel.state.$data?.subscribeToState((newState) => {
-        // With sharding, state can be error but still show data
-        if (
-          !newState.data ||
-          newState.data.state === LoadingState.Streaming ||
-          newState.data.state === LoadingState.Loading
-        ) {
+        if (newState.data?.state !== LoadingState.Done) {
           return;
         }
         this.displayVisibleRange();
@@ -124,8 +119,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     if (
       !panel ||
       !panel.state.$data?.state.data ||
-      panel.state.$data?.state.data.state === LoadingState.Streaming ||
-      panel.state.$data?.state.data.state === LoadingState.Loading ||
+      panel.state.$data?.state.data.state !== LoadingState.Done ||
       !this.updatedLogSeries
     ) {
       return;

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -88,7 +88,12 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
 
     this._subs.add(
       panel.state.$data?.subscribeToState((newState) => {
-        if (newState.data?.state !== LoadingState.Done) {
+        // With sharding, state can be error but still show data
+        if (
+          !newState.data ||
+          newState.data.state === LoadingState.Streaming ||
+          newState.data.state === LoadingState.Loading
+        ) {
           return;
         }
         this.displayVisibleRange();

--- a/src/services/logsFrame.ts
+++ b/src/services/logsFrame.ts
@@ -210,15 +210,10 @@ export function getVisibleRangeFrame(start: number, end: number) {
   const frame = arrayToDataFrame([
     {
       time: start,
-      timeEnd: start,
-      text: 'Time of the oldest log',
-      color: 'rgb(56, 113, 220, 0.7)',
-    },
-    {
-      time: end,
       timeEnd: end,
-      text: 'Time of the newest log',
-      color: 'rgb(56, 113, 220, 0.7)',
+      isRegion: true,
+      text: 'Range from oldest to newest logs in display',
+      color: 'rgba(58, 113, 255, 0.3)',
     },
   ]);
   frame.name = VISIBLE_RANGE_NAME;

--- a/src/services/logsFrame.ts
+++ b/src/services/logsFrame.ts
@@ -197,11 +197,11 @@ export function getSeriesVisibleRange(series: DataFrame[]) {
 
   const timeField = series[0]?.fields.find((field) => field.type === FieldType.time);
   if (timeField) {
-    const oldestFirst = timeField.values[0] < timeField.values[timeField.values.length - 1];
-    start = oldestFirst ? timeField.values[0] : timeField.values[timeField.values.length - 1];
-    end = oldestFirst ? timeField.values[timeField.values.length - 1] : timeField.values[0];
+    const values = timeField.values.sort();
+    const oldestFirst = values[0] < values[values.length - 1];
+    start = oldestFirst ? values[0] : values[values.length - 1];
+    end = oldestFirst ? values[values.length - 1] : values[0];
   }
-
   return { start, end };
 }
 

--- a/src/services/logsFrame.ts
+++ b/src/services/logsFrame.ts
@@ -210,9 +210,15 @@ export function getVisibleRangeFrame(start: number, end: number) {
   const frame = arrayToDataFrame([
     {
       time: start,
+      timeEnd: start,
+      text: 'Time of the oldest log',
+      color: 'rgb(56, 113, 220, 0.7)',
+    },
+    {
+      time: end,
       timeEnd: end,
-      isRegion: true,
-      color: 'rgba(120, 120, 120, 0.1)',
+      text: 'Time of the newest log',
+      color: 'rgb(56, 113, 220, 0.7)',
     },
   ]);
   frame.name = VISIBLE_RANGE_NAME;

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -83,7 +83,7 @@ export function setLevelSeriesOverrides(levels: string[], overrideConfig: FieldC
 }
 
 export function syncLogsPanelVisibleSeries(panel: VizPanel, series: DataFrame[], sceneRef: SceneObject) {
-  const focusedLevels = [...getVisibleLevels(getLabelsFromSeries(series), sceneRef)];
+  const focusedLevels = getVisibleLevels(getLabelsFromSeries(series), sceneRef);
   if (focusedLevels?.length) {
     const config = setLogsVolumeFieldConfigs(FieldConfigBuilders.timeseries()).setOverrides(
       setLevelSeriesOverrides.bind(null, focusedLevels)

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -83,7 +83,7 @@ export function setLevelSeriesOverrides(levels: string[], overrideConfig: FieldC
 }
 
 export function syncLogsPanelVisibleSeries(panel: VizPanel, series: DataFrame[], sceneRef: SceneObject) {
-  const focusedLevels = getVisibleLevels(getLabelsFromSeries(series), sceneRef);
+  const focusedLevels = [...getVisibleLevels(getLabelsFromSeries(series), sceneRef)];
   if (focusedLevels?.length) {
     const config = setLogsVolumeFieldConfigs(FieldConfigBuilders.timeseries()).setOverrides(
       setLevelSeriesOverrides.bind(null, focusedLevels)

--- a/src/services/routing.ts
+++ b/src/services/routing.ts
@@ -89,6 +89,7 @@ export const DRILLDOWN_URL_KEYS = [
   'visualizationType',
   'selectedLine',
   'displayedFields',
+  'panelState',
   VAR_PATTERNS,
   `var-${VAR_PATTERNS}`,
   `var-${VAR_DATASOURCE}`,

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -1,6 +1,6 @@
 import { locationService } from '@grafana/runtime';
 import { logger } from './logger';
-import { TimeRange } from '@grafana/data';
+import { dateTime, LogRowModel, TimeRange } from '@grafana/data';
 
 export const copyText = async (
   text: string,
@@ -70,4 +70,17 @@ export function capitalizeFirstLetter(input: string) {
 
 export function truncateText(input: string, length: number, ellipsis: boolean) {
   return input.substring(0, length) + (ellipsis && input.length > length ? '…' : '');
+}
+
+export function resolveRowTimeRangeForSharing(timeRange: TimeRange, row: LogRowModel): TimeRange {
+  const from = dateTime(row.timeEpochMs - 1);
+  const to = dateTime(row.timeEpochMs + 1);
+  return {
+    from,
+    to,
+    raw: {
+      from,
+      to,
+    },
+  };
 }

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -72,10 +72,12 @@ export function truncateText(input: string, length: number, ellipsis: boolean) {
   return input.substring(0, length) + (ellipsis && input.length > length ? '…' : '');
 }
 
-export function resolveRowTimeRangeForSharing(timeRange: TimeRange, row: LogRowModel): TimeRange {
+export function resolveRowTimeRangeForSharing(row: LogRowModel): TimeRange {
+  // With infinite scrolling, we cannot rely on the time picker range, so we use a time range around the shared log line.
   const from = dateTime(row.timeEpochMs - 1);
   const to = dateTime(row.timeEpochMs + 1);
-  return {
+
+  const range = {
     from,
     to,
     raw: {
@@ -83,4 +85,6 @@ export function resolveRowTimeRangeForSharing(timeRange: TimeRange, row: LogRowM
       to,
     },
   };
+
+  return range;
 }


### PR DESCRIPTION
This PR integrates infinite scrolling support using the updated Logs Panel, and displays the visible range of logs, using two annotations to show the time of the oldes and newest log in the list.

The visible range of logs will be updated when infinite scroll is used.

Demo:

https://github.com/user-attachments/assets/a446fe5a-6d5d-4f25-adcb-f4292db56f2d

Requires https://github.com/grafana/grafana/pull/97095 for infinite scrolling + updating the visible range when new logs arrive.

Additionally, it fixes sharing link to log lines, which were being stripped from the URL, causing the Logs Panel to not receive the required parameters.

https://github.com/user-attachments/assets/f5ccd353-8e70-4c81-a3e1-39719ff00092

Closes #919
