### PR TITLE
Chore: Better type safety with ts-reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@testing-library/jest-dom": "6.1.4",
     "@testing-library/react": "14.0.0",
     "@testing-library/user-event": "^14.5.2",
+    "@total-typescript/ts-reset": "^0.6.1",
     "@types/jest": "^29.5.0",
     "@types/lodash": "^4.14.194",
     "@types/node": "^20.8.7",

--- a/src/Components/ServiceScene/GoToExploreButton.tsx
+++ b/src/Components/ServiceScene/GoToExploreButton.tsx
@@ -10,6 +10,7 @@ import { testIds } from 'services/testIds';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
 import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 import { getDisplayedFields, getLogsVisualizationType } from 'services/store';
+import { unknownToStrings } from '../../services/narrowing';
 interface GoToExploreButtonState {
   exploration: IndexScene;
 }
@@ -69,7 +70,7 @@ function getUrlColumns() {
   const urlColumns = params.get('urlColumns');
   if (urlColumns) {
     try {
-      const columns: string[] = JSON.parse(urlColumns);
+      const columns = unknownToStrings(JSON.parse(urlColumns));
       let columnsParam: Record<number, string> = {};
       for (const key in columns) {
         columnsParam[key] = columns[key];

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -25,6 +25,7 @@ import {
 } from 'services/store';
 import { logger } from '../../services/logger';
 import { Options } from '@grafana/schema/dist/esm/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen';
+import { isPropType, isSelectedTableRow, PropType, unknownToStrings } from '../../services/narrowing';
 
 export interface LogsListSceneState extends SceneObjectState {
   loading?: boolean;
@@ -69,15 +70,18 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
     const stateUpdate: Partial<LogsListSceneState> = {};
     try {
       if (typeof values.urlColumns === 'string') {
-        const decodedUrlColumns: string[] = JSON.parse(values.urlColumns);
+        const decodedUrlColumns: string[] = unknownToStrings(JSON.parse(values.urlColumns));
         if (decodedUrlColumns !== this.state.urlColumns) {
           stateUpdate.urlColumns = decodedUrlColumns;
         }
       }
       if (typeof values.selectedLine === 'string') {
-        const decodedSelectedTableRow: SelectedTableRow = JSON.parse(values.selectedLine);
-        if (decodedSelectedTableRow !== this.state.selectedLine) {
-          stateUpdate.selectedLine = decodedSelectedTableRow;
+        const unknownTableRow = JSON.parse(values.selectedLine);
+        if (isSelectedTableRow(unknownTableRow)) {
+          const decodedSelectedTableRow: SelectedTableRow = unknownTableRow;
+          if (decodedSelectedTableRow !== this.state.selectedLine) {
+            stateUpdate.selectedLine = decodedSelectedTableRow;
+          }
         }
       }
 

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -25,7 +25,7 @@ import {
 } from 'services/store';
 import { logger } from '../../services/logger';
 import { Options } from '@grafana/schema/dist/esm/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen';
-import { isPropType, isSelectedTableRow, PropType, unknownToStrings } from '../../services/narrowing';
+import { narrowLogsVisualizationType, narrowSelectedTableRow, unknownToStrings } from '../../services/narrowing';
 
 export interface LogsListSceneState extends SceneObjectState {
   loading?: boolean;
@@ -76,8 +76,8 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
         }
       }
       if (typeof values.selectedLine === 'string') {
-        const unknownTableRow = JSON.parse(values.selectedLine);
-        if (isSelectedTableRow(unknownTableRow)) {
+        const unknownTableRow = narrowSelectedTableRow(JSON.parse(values.selectedLine));
+        if (unknownTableRow) {
           const decodedSelectedTableRow: SelectedTableRow = unknownTableRow;
           if (decodedSelectedTableRow !== this.state.selectedLine) {
             stateUpdate.selectedLine = decodedSelectedTableRow;
@@ -86,14 +86,14 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
       }
 
       if (typeof values.visualizationType === 'string') {
-        const decodedVisualizationType: LogsVisualizationType = JSON.parse(values.visualizationType);
-        if (decodedVisualizationType !== this.state.visualizationType) {
+        const decodedVisualizationType = narrowLogsVisualizationType(JSON.parse(values.visualizationType));
+        if (decodedVisualizationType && decodedVisualizationType !== this.state.visualizationType) {
           stateUpdate.visualizationType = decodedVisualizationType;
         }
       }
 
       if (typeof values.displayedFields === 'string') {
-        const displayedFields = JSON.parse(values.displayedFields);
+        const displayedFields = unknownToStrings(JSON.parse(values.displayedFields));
         if (displayedFields && displayedFields.length) {
           stateUpdate.displayedFields = displayedFields;
         }

--- a/src/reset.d.ts
+++ b/src/reset.d.ts
@@ -1,0 +1,2 @@
+// Do not add any other lines of code to this file!
+import '@total-typescript/ts-reset';

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -2,6 +2,7 @@ import { LogContext } from '@grafana/faro-web-sdk';
 import { FetchError, logError, logInfo, logWarning } from '@grafana/runtime';
 import pluginJson from '../plugin.json';
 import packageJson from '../../package.json';
+import { isRecord } from './narrowing';
 
 const defaultContext = {
   app: pluginJson.id,
@@ -41,8 +42,6 @@ const attemptFaroWarn = (msg: string, context?: LogContext) => {
     console.warn('Failed to log faro warning!', { msg, context });
   }
 };
-
-const isRecord = (obj: unknown): obj is Record<string, unknown> => typeof obj === 'object';
 /**
  * Checks unknown error for properties from Records like FetchError and adds them to the context
  * @param err

--- a/src/services/narrowing.test.ts
+++ b/src/services/narrowing.test.ts
@@ -1,0 +1,108 @@
+import { SelectedTableRow } from 'Components/Table/LogLineCellComponent';
+import {
+  narrowFieldValue,
+  narrowLogsVisualizationType,
+  narrowRecordStringNumber,
+  narrowSelectedTableRow,
+  unknownToStrings,
+} from './narrowing';
+import { FieldValue, ParserType } from './variables';
+import { LogsVisualizationType } from './store';
+
+describe('unknownToStrings', () => {
+  test.each([
+    [undefined, []],
+    [
+      ['uno', 'dos', 3],
+      ['uno', 'dos', ''],
+    ],
+    [
+      [null, -1, NaN, Infinity, {}, Symbol('3')],
+      ['', '', '', '', '', ''],
+    ],
+  ])('Processes unknown values and returns an array of strings', (input: unknown, output: string[]) => {
+    expect(unknownToStrings(input)).toEqual(output);
+  });
+});
+
+describe('narrowSelectedTableRow', () => {
+  test.each([
+    [undefined, false],
+    [{}, false],
+    [{ row: '1' }, false],
+    [{ id: 1 }, false],
+    [
+      { row: 1, id: '1 ' },
+      { row: 1, id: '1 ' },
+    ],
+  ])(
+    'Processes unknown values and returns SelectedTableRow or false',
+    (input: unknown, output: SelectedTableRow | boolean) => {
+      expect(narrowSelectedTableRow(input)).toEqual(output);
+    }
+  );
+});
+
+describe('narrowLogsVisualizationType', () => {
+  const logs: LogsVisualizationType = 'logs';
+  const table: LogsVisualizationType = 'table';
+  test.each([
+    [undefined, false],
+    ['taebl', false],
+    [logs, logs],
+    [table, table],
+  ])(
+    'Processes unknown values and returns an array of strings',
+    (input: unknown, output: LogsVisualizationType | boolean) => {
+      expect(narrowLogsVisualizationType(input)).toEqual(output);
+    }
+  );
+});
+
+describe('narrowFieldValue', () => {
+  const parser: ParserType = 'json';
+  test.each([
+    [undefined, false],
+    [{ parser: 1 }, false],
+    [{ value: 1 }, false],
+    [{ parser: 1, value: 1 }, false],
+    [{ parser: 'json', value: 1 }, false],
+    [
+      { parser: 'json', value: 'value' },
+      { parser, value: 'value' },
+    ],
+  ])('Processes unknown values and returns an array of strings', (input: unknown, output: FieldValue | boolean) => {
+    expect(narrowFieldValue(input)).toEqual(output);
+  });
+});
+
+describe('narrowRecordStringNumber', () => {
+  test.each([
+    [undefined, false],
+    [{}, {}],
+    [{ test: 'nope' }, {}],
+    [{ injection: () => {} }, {}],
+    [
+      {
+        get test() {
+          return 1;
+        },
+      },
+      { test: 1 },
+    ],
+    [
+      {
+        get test() {
+          return '1';
+        },
+      },
+      {},
+    ],
+    [{ test: 1 }, { test: 1 }],
+  ])(
+    'Processes unknown values and returns an array of strings',
+    (input: unknown, output: Record<string, number> | boolean) => {
+      expect(narrowRecordStringNumber(input)).toEqual(output);
+    }
+  );
+});

--- a/src/services/narrowing.ts
+++ b/src/services/narrowing.ts
@@ -1,0 +1,78 @@
+const isString = (s: unknown) => (typeof s === 'string' && s) || '';
+
+const isPropString = <P extends string, T extends Record<P, T[P]>>(
+  prop: P,
+  object: T
+): object is T & Record<P, string> => {
+  return typeof object[prop] === 'string';
+};
+
+export function unknownToStrings(a: unknown): string[] {
+  let strings: string[] = [];
+  if (Array.isArray(a)) {
+    for (let i = 0; i < a.length; i++) {
+      strings.push(isString(a[i]));
+    }
+  }
+  return strings;
+}
+
+export interface PropType {
+  name: string;
+  type: 'string' | 'number';
+}
+
+export function isPropType<T extends SelectedTableRow>(o: unknown, prop: PropType): o is T {
+  return isObj(o) && hasProp(o, prop.name) && typeof o[prop.name] === prop.type;
+}
+
+// Example
+type SelectedTableRow = {
+  row: number;
+  id: string;
+};
+
+const isObj = (o: unknown): o is object => typeof o === 'object' && o !== null;
+
+function hasProp<K extends PropertyKey>(data: object, prop: K): data is Record<K, unknown> {
+  return prop in data;
+}
+
+export function isSelectedTableRow(o: unknown) {
+  return isObj(o) && hasProp(o, 'row') && 'row' in o && typeof o.row === 'string';
+}
+
+export function isSelectedTableRowAssert<T>(o: unknown): o is T {
+  return isObj(o) && hasProp(o, 'row') && 'row' in o && typeof o.row === 'string';
+}
+
+const unknown: unknown = {
+  id: 'string-value',
+};
+
+// This is the closest to a solution, but requires inlining, also the row is not typed as string
+if (isObj(unknown) && hasProp(unknown, 'row') && 'row' in unknown && typeof unknown.row === 'string') {
+  const result = unknown; // type inferred  as Record<"row", unknown>
+  const row = result.row; // type inferred as unknown
+  const unknownRow = unknown.row; // type inferred as string
+  console.log(result.row); // No type error
+  console.log(result.id); // Type error, id does not exist
+
+  if (typeof result.row === 'string') {
+    const row = result.row;
+  }
+}
+
+// This fails to type the object at all
+if (isSelectedTableRow(unknown)) {
+  const result = unknown; // type inferred as unknown
+  console.log(result.row); // result is type unknown, type error
+  console.log(result.id); // result is type unknown, type error
+}
+
+// This asserts that the object is the Templated type (SelectedTableRow), it doesnt matter if the interface or implementation changes, you won't get type errors
+if (isSelectedTableRowAssert<SelectedTableRow>(unknown)) {
+  const result = unknown; // type inferred as SelectedTableRow
+  console.log(result.row); // no type error
+  console.log(result.id); // runtime error
+}

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -5,6 +5,7 @@ import { getDataSourceName, getServiceName } from './variableGetters';
 import { logger } from './logger';
 import { SERVICE_NAME } from './variables';
 import { Options } from '@grafana/schema/dist/esm/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen';
+import { unknownToStrings } from './narrowing';
 
 const FAVORITE_PRIMARY_LABEL_VALUES_LOCALSTORAGE_KEY = `${pluginJson.id}.services.favorite`;
 const FAVORITE_PRIMARY_LABEL_NAME_LOCALSTORAGE_KEY = `${pluginJson.id}.primarylabels.tabs.favorite`;
@@ -16,9 +17,9 @@ export function getFavoriteLabelValuesFromStorage(dsKey: string | unknown, label
     return [];
   }
   const key = createPrimaryLabelLocalStorageKey(dsKey, labelName);
-  let labelValues = [];
+  let labelValues: string[] = [];
   try {
-    labelValues = JSON.parse(localStorage.getItem(key) || '[]');
+    labelValues = unknownToStrings(JSON.parse(localStorage.getItem(key) || '[]'));
   } catch (e) {
     logger.error(e, { msg: 'Error parsing favorite services from local storage' });
   }
@@ -35,9 +36,9 @@ export function addToFavoriteLabelValueInStorage(dsKey: string | unknown, labelN
     return;
   }
   const key = createPrimaryLabelLocalStorageKey(dsKey, labelName);
-  let services = [];
+  let services: string[] = [];
   try {
-    services = JSON.parse(localStorage.getItem(key) || '[]');
+    services = unknownToStrings(JSON.parse(localStorage.getItem(key) || '[]'));
   } catch (e) {
     logger.error(e, { msg: 'Error parsing favorite services from local storage' });
   }
@@ -58,9 +59,9 @@ export function removeFromFavoritesInStorage(dsKey: VariableValue, labelName: st
     return;
   }
   const key = createPrimaryLabelLocalStorageKey(dsKey, labelName);
-  let services = [];
+  let services: string[] = [];
   try {
-    services = JSON.parse(localStorage.getItem(key) || '[]');
+    services = unknownToStrings(JSON.parse(localStorage.getItem(key) || '[]'));
   } catch (e) {
     logger.error(e, { msg: 'Error parsing favorite services from local storage' });
   }
@@ -79,9 +80,9 @@ export function addTabToLocalStorage(dsKey: string, labelName: string) {
 
   const key = createTabsLocalStorageKey(dsKey);
 
-  let services = [];
+  let services: string[] = [];
   try {
-    services = JSON.parse(localStorage.getItem(key) || '[]');
+    services = unknownToStrings(JSON.parse(localStorage.getItem(key) || '[]'));
   } catch (e) {
     logger.error(e, { msg: 'Error parsing saved tabs from local storage' });
   }
@@ -104,9 +105,9 @@ export function removeTabFromLocalStorage(dsKey: string, labelName: string) {
     return;
   }
   const key = createTabsLocalStorageKey(dsKey);
-  let services = [];
+  let services: string[] = [];
   try {
-    services = JSON.parse(localStorage.getItem(key) || '[]');
+    services = unknownToStrings(JSON.parse(localStorage.getItem(key) || '[]'));
   } catch (e) {
     logger.error(e, { msg: 'Error parsing favorite services from local storage' });
   }
@@ -123,9 +124,9 @@ export function getFavoriteTabsFromStorage(dsKey: string | unknown): string[] {
     return [];
   }
   const key = createTabsLocalStorageKey(dsKey);
-  let tabNames = [];
+  let tabNames: string[] = [];
   try {
-    tabNames = JSON.parse(localStorage.getItem(key) || '[]');
+    tabNames = unknownToStrings(JSON.parse(localStorage.getItem(key) || '[]'));
   } catch (e) {
     logger.error(e, { msg: 'Error parsing favorite services from local storage' });
   }

--- a/src/services/variableGetters.ts
+++ b/src/services/variableGetters.ts
@@ -176,36 +176,20 @@ export function getUrlParamNameForVariable(variableName: string) {
   return `var-${variableName}`;
 }
 
-// export function getValueFromFieldsFilter(filter: AdHocVariableFilter, variableName: string = VAR_FIELDS): FieldValue {
-//   try {
-//     return JSON.parse(filter.value);
-//   } catch (e) {
-//     logger.warn(`Failed to parse ${variableName}`, { value: filter.value });
-//
-//     // If the user has a URL from before 0.1.4 where detected_fields changed the format of the fields value to include the parser, fall back to mixed parser if we have a value
-//     if (filter.value) {
-//       return {
-//         value: filter.value,
-//         parser: 'mixed',
-//       };
-//     }
-//     throw e;
-//   }
-// }
-
 export function getValueFromFieldsFilter(filter: AdHocVariableFilter, variableName: string = VAR_FIELDS): FieldValue {
   try {
     const fieldValue = narrowFieldValue(JSON.parse(filter.value));
     if (fieldValue !== false) {
       return fieldValue;
     } else {
-      logger.error(new NarrowingError('getValueFromFieldsFilter: invalid filter value!'), {
-        msg: `getValueFromFieldsFilter: Failed to validate ${variableName}`,
-        value: filter.value,
-      });
+      throw new NarrowingError('getValueFromFieldsFilter: invalid filter value!');
     }
   } catch (e) {
-    logger.error(e, { msg: `getValueFromFieldsFilter: Failed to parse ${variableName}`, value: filter.value });
+    if (e instanceof NarrowingError) {
+      logger.error(e, { msg: `getValueFromFieldsFilter: Failed to validate ${variableName}`, value: filter.value });
+    } else {
+      logger.error(e, { msg: `getValueFromFieldsFilter: Failed to parse ${variableName}`, value: filter.value });
+    }
 
     // If the user has a URL from before 0.1.4 where detected_fields changed the format of the fields value to include the parser, fall back to mixed parser if we have a value
     if (filter.value) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2252,6 +2252,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@total-typescript/ts-reset@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@total-typescript/ts-reset/-/ts-reset-0.6.1.tgz#aebb29b6a79bb404e4cf618da6a392c94ed73a45"
+  integrity sha512-cka47fVSo6lfQDIATYqb/vO1nvFfbPw7uWLayIXIhGETj0wcOOlrlkobOMDNQOFr9QOafegUPq13V2+6vtD7yg==
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"


### PR DESCRIPTION
Adding https://www.totaltypescript.com/ts-reset to Explore Logs.

The primary use case is for improved type-safety when dealing with values coming from local storage and when parsing JSON encoded strings. There is also some QoL improvements as well, take a look at the link above for more information.

TL;DR localStorage and JSON.parse now return `unknown` instead of `any`.
This PR implements additional runtime narrowing of types to make sure we're not displaying the wrong data, and malicious actors will have a harder time injecting unexpected data through url parameters or local storage.