### PR TITLE
fix(firefox-panel-hidden): add position absolute

### DIFF
--- a/src/Components/Panels/PanelMenu.tsx
+++ b/src/Components/Panels/PanelMenu.tsx
@@ -175,6 +175,7 @@ export const getPanelWrapperStyles = (theme: GrafanaTheme2) => {
       width: '100%',
       height: '100%',
       label: 'panel-wrapper',
+      position: 'absolute',
       display: 'flex',
 
       // @todo remove this wrapper and styles when core changes are introduced in ???


### PR DESCRIPTION
Log volume panel is hidden in Firefox. Since it's a single `div`, we can position absolutely, which will fix the bug for now.

Fixes #927