### PR TITLE
SortLevelTransformation: account for possibly empty fields

### DIFF
--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -100,12 +100,18 @@ export function sortLevelTransformation() {
       map((data: DataFrame[]) => {
         return data
           .map((d) => {
+            if (!d.fields.length) {
+              return d;
+            }
             if (!d.fields[1].config.displayNameFromDS) {
               d.fields[1].config.displayNameFromDS = UNKNOWN_LEVEL_LOGS;
             }
             return d;
           })
           .sort((a, b) => {
+            if (!a.fields.length || !b.fields.length) {
+              return 0;
+            }
             const aName: string | undefined = a.fields[1].config.displayNameFromDS;
             const aVal = aName?.includes('error') ? 4 : aName?.includes('warn') ? 3 : aName?.includes('info') ? 2 : 1;
             const bName: string | undefined = b.fields[1].config.displayNameFromDS;

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -100,7 +100,7 @@ export function sortLevelTransformation() {
       map((data: DataFrame[]) => {
         return data
           .map((d) => {
-            if (!d.fields.length) {
+            if (d.fields.length < 2) {
               return d;
             }
             if (!d.fields[1].config.displayNameFromDS) {

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -109,7 +109,7 @@ export function sortLevelTransformation() {
             return d;
           })
           .sort((a, b) => {
-            if (!a.fields.length || !b.fields.length) {
+            if (a.fields.length < 2 || b.fields.length < 2) {
               return 0;
             }
             const aName: string | undefined = a.fields[1].config.displayNameFromDS;


### PR DESCRIPTION
Found while testing visible range, it can happen that data frame fields are empty

![empty fields](https://github.com/user-attachments/assets/0ea09a83-6c03-4a64-bc6d-fb719fdcbf91)

and we were accessing them by index

![errors](https://github.com/user-attachments/assets/6d8fa71a-07ff-43c3-b9cc-2865bb3472aa)

, causing errors

![source](https://github.com/user-attachments/assets/dc5a57a5-f539-4540-92b0-674750a1e664)

Can be reproduced with OPS logs and the following URL state: `/a/grafana-lokiexplore-app/explore/service/loki-distributor/logs?from=2024-11-29T09:26:52.467Z&to=2024-11-29T09:27:43.073Z&var-ds=adygcacqmfabkc&var-filters=service_name%7C%3D%7Cloki%2Fdistributor&var-fields=&var-levels=&patterns=%5B%5D&var-metadata=&var-patterns=&var-lineFilter=&urlColumns=%5B%5D&visualizationType="logs"&displayedFields=%5B%5D`
