### PR TITLE
Breakdown panels: Add shared crosshairs

### DIFF
--- a/src/Components/ServiceScene/BreakdownViews.ts
+++ b/src/Components/ServiceScene/BreakdownViews.ts
@@ -4,9 +4,10 @@ import { testIds } from '../../services/testIds';
 import { LabelBreakdownScene } from './Breakdowns/LabelBreakdownScene';
 import { FieldsBreakdownScene } from './Breakdowns/FieldsBreakdownScene';
 import { PatternsBreakdownScene } from './Breakdowns/Patterns/PatternsBreakdownScene';
-import { SceneFlexItem, SceneFlexLayout, SceneObject } from '@grafana/scenes';
+import { behaviors, SceneFlexItem, SceneFlexLayout, SceneObject } from '@grafana/scenes';
 import { LogsVolumePanel } from './LogsVolumePanel';
 import { buildLabelValuesBreakdownActionScene } from '../../services/labels';
+import { DashboardCursorSync } from '@grafana/schema';
 
 interface ValueBreakdownViewDefinition {
   displayName: string;
@@ -81,6 +82,7 @@ function buildPatternsScene() {
 
 function buildFieldsBreakdownActionScene(changeFieldNumber: (n: number) => void) {
   return new SceneFlexLayout({
+    $behaviors: [new behaviors.CursorSync({ key: 'sync', sync: DashboardCursorSync.Crosshair })],
     children: [
       new SceneFlexItem({
         body: new FieldsBreakdownScene({ changeFieldCount: changeFieldNumber }),
@@ -102,6 +104,7 @@ function buildFieldValuesBreakdownActionScene(value: string) {
 function buildLogsListScene() {
   return new SceneFlexLayout({
     direction: 'column',
+    $behaviors: [new behaviors.CursorSync({ key: 'sync', sync: DashboardCursorSync.Crosshair })],
     children: [
       new SceneFlexItem({
         minHeight: 200,
@@ -118,6 +121,7 @@ function buildLogsListScene() {
 
 function buildLabelBreakdownActionScene() {
   return new SceneFlexLayout({
+    $behaviors: [new behaviors.CursorSync({ key: 'sync', sync: DashboardCursorSync.Crosshair })],
     children: [
       new SceneFlexItem({
         body: new LabelBreakdownScene({}),

--- a/src/Components/ServiceScene/BreakdownViews.ts
+++ b/src/Components/ServiceScene/BreakdownViews.ts
@@ -6,7 +6,6 @@ import { FieldsBreakdownScene } from './Breakdowns/FieldsBreakdownScene';
 import { PatternsBreakdownScene } from './Breakdowns/Patterns/PatternsBreakdownScene';
 import { behaviors, SceneFlexItem, SceneFlexLayout, SceneObject } from '@grafana/scenes';
 import { LogsVolumePanel } from './LogsVolumePanel';
-import { buildLabelValuesBreakdownActionScene } from '../../services/labels';
 import { DashboardCursorSync } from '@grafana/schema';
 
 interface ValueBreakdownViewDefinition {
@@ -93,9 +92,21 @@ function buildFieldsBreakdownActionScene(changeFieldNumber: (n: number) => void)
 
 function buildFieldValuesBreakdownActionScene(value: string) {
   return new SceneFlexLayout({
+    $behaviors: [new behaviors.CursorSync({ key: 'sync', sync: DashboardCursorSync.Crosshair })],
     children: [
       new SceneFlexItem({
         body: new FieldsBreakdownScene({ value }),
+      }),
+    ],
+  });
+}
+
+function buildLabelValuesBreakdownActionScene(value: string) {
+  return new SceneFlexLayout({
+    $behaviors: [new behaviors.CursorSync({ key: 'sync', sync: DashboardCursorSync.Crosshair })],
+    children: [
+      new SceneFlexItem({
+        body: new LabelBreakdownScene({ value }),
       }),
     ],
   });

--- a/src/Components/ServiceScene/BreakdownViews.ts
+++ b/src/Components/ServiceScene/BreakdownViews.ts
@@ -104,7 +104,6 @@ function buildFieldValuesBreakdownActionScene(value: string) {
 function buildLogsListScene() {
   return new SceneFlexLayout({
     direction: 'column',
-    $behaviors: [new behaviors.CursorSync({ key: 'sync', sync: DashboardCursorSync.Crosshair })],
     children: [
       new SceneFlexItem({
         minHeight: 200,

--- a/src/services/labels.ts
+++ b/src/services/labels.ts
@@ -1,21 +1,10 @@
-import { SceneFlexItem, SceneFlexLayout, SceneObject } from '@grafana/scenes';
+import { SceneObject } from '@grafana/scenes';
 import { LEVEL_VARIABLE_VALUE } from './variables';
 import { getParserFromFieldsFilters } from './fields';
 import { buildDataQuery } from './query';
-import { LabelBreakdownScene } from '../Components/ServiceScene/Breakdowns/LabelBreakdownScene';
 import { getFieldsVariable, getLogsStreamSelector } from './variableGetters';
 
 export const LABEL_BREAKDOWN_GRID_TEMPLATE_COLUMNS = 'repeat(auto-fit, minmax(400px, 1fr))';
-
-export function buildLabelValuesBreakdownActionScene(value: string) {
-  return new SceneFlexLayout({
-    children: [
-      new SceneFlexItem({
-        body: new LabelBreakdownScene({ value }),
-      }),
-    ],
-  });
-}
 
 export function buildLabelsQuery(sceneRef: SceneObject, optionValue: string, optionName: string) {
   let labelExpressionToAdd = '';


### PR DESCRIPTION
Fixes: https://github.com/grafana/explore-logs/issues/934

<img width="1703" alt="image" src="https://github.com/user-attachments/assets/9548b635-3147-4d26-9a80-b7d1b742ed0a">

Notes:
There is a bug with the logs panel and the time series panel, where the tooltip will show in the time series panel when hovering on logs, if the time series graph emitted any hover events before hovering over the logs panel.

I reported it here: https://github.com/grafana/grafana/issues/97600

<img width="1724" alt="image" src="https://github.com/user-attachments/assets/633c893b-69b2-4faf-a933-a7b216f4aa25">

Table isn't working: 
Looks like there is a bug with sorted tables and the shared crosshair: https://github.com/grafana/grafana/pull/97599
But there is something else going on as well, the tooltips don't show up at all, even though the event is being emitted. 

I'm going to suggest we don't add shared crosshairs for the logs panels and volume panel for now, until those issues above are resolved upstream.

Created https://github.com/grafana/explore-logs/issues/941 to follow up with that functionality when those bugs are resolved.

