### PR TITLE
Remove go to explore button, add PanelMenu to logs & table panels

### DIFF
--- a/src/Components/Panels/PanelMenu.tsx
+++ b/src/Components/Panels/PanelMenu.tsx
@@ -58,7 +58,7 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
   constructor(state: Partial<PanelMenuState>) {
     super(state);
     this.addActivationHandler(() => {
-      const viz = sceneGraph.getAncestor(this, VizPanel);
+      const viz = findObjectOfType(this, (o) => o instanceof VizPanel, VizPanel);
 
       this.setState({
         addToExplorations: new AddToExplorationButton({
@@ -87,11 +87,11 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
       ];
 
       // Visualization options
-      if (this.state.panelType || viz.state.collapsible) {
+      if (this.state.panelType || viz?.state.collapsible) {
         addVisualizationHeader(items, this);
       }
 
-      if (viz.state.collapsible) {
+      if (viz?.state.collapsible) {
         addCollapsableItem(items, this);
       }
 

--- a/src/Components/ServiceScene/ActionBarScene.tsx
+++ b/src/Components/ServiceScene/ActionBarScene.tsx
@@ -42,7 +42,6 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
         <div className={styles.actions}>
           <Stack gap={1}>
             {config.featureToggles.appSidecar && <ToolbarExtensionsRenderer serviceScene={serviceScene} />}
-            <GoToExploreButton exploration={exploration} />
           </Stack>
         </div>
 

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -11,7 +11,7 @@ import { DataFrame, LogRowModel } from '@grafana/data';
 import { getLogOption, setDisplayedFields } from '../../services/store';
 import React, { MouseEvent } from 'react';
 import { LogsListScene } from './LogsListScene';
-import { LoadingPlaceholder } from '@grafana/ui';
+import { LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 import { addToFilters, FilterType } from './Breakdowns/AddToFiltersButton';
 import { getVariableForLabel } from '../../services/fields';
 import { VAR_FIELDS, VAR_LABELS, VAR_LEVELS, VAR_METADATA } from '../../services/variables';
@@ -21,6 +21,7 @@ import { copyText, generateLogShortlink, resolveRowTimeRangeForSharing } from 's
 import { CopyLinkButton } from './CopyLinkButton';
 import { getLogsPanelSortOrder, LogOptionsScene } from './LogOptionsScene';
 import { LogsVolumePanel, logsVolumePanelKey } from './LogsVolumePanel';
+import { getPanelWrapperStyles, PanelMenu } from '../Panels/PanelMenu';
 
 interface LogsPanelSceneState extends SceneObjectState {
   body?: VizPanel;
@@ -118,6 +119,7 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
         .setOption('displayedFields', parentModel.state.displayedFields)
         .setOption('sortOrder', getLogsPanelSortOrder())
         .setOption('wrapLogMessage', Boolean(getLogOption<boolean>('wrapLogMessage', false)))
+        .setMenu(new PanelMenu({}))
         .setOption('showLogContextToggle', true)
         // @ts-expect-error Requires Grafana 11.5
         .setOption('enableInfiniteScrolling', true)
@@ -234,8 +236,13 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
 
   public static Component = ({ model }: SceneComponentProps<LogsPanelScene>) => {
     const { body } = model.useState();
+    const styles = useStyles2(getPanelWrapperStyles);
     if (body) {
-      return <body.Component model={body} />;
+      return (
+        <span className={styles.panelWrapper}>
+          <body.Component model={body} />
+        </span>
+      );
     }
     return <LoadingPlaceholder text={'Loading...'} />;
   };


### PR DESCRIPTION
Remove this button:
<img width="583" alt="image" src="https://github.com/user-attachments/assets/8818ae96-10da-4de1-87eb-31ef17604f68">

Add PanelMenu instead:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/e3926a26-af03-45eb-997c-e24551ed6169">

\@todo:
* Disable investigations links for these panels
* * Looks like investigations doesn't support non timeseries data yet (logs/table data)
* * Table has a weird bug with the useResizeObserver when investigations drawer is opened