### PR TITLE
Logs Panel: Combine wrapLogMessage with prettifyLogMessage

### DIFF
--- a/src/Components/ServiceScene/LogOptionsScene.tsx
+++ b/src/Components/ServiceScene/LogOptionsScene.tsx
@@ -33,6 +33,7 @@ export class LogOptionsScene extends SceneObjectBase<LogOptionsState> {
     this.setState({ wrapLogMessage: type });
     setLogOption('wrapLogMessage', type);
     this.getParentScene().setLogsVizOption({ wrapLogMessage: type });
+    this.getParentScene().setLogsVizOption({ prettifyLogMessage: type });
   };
 
   onChangeLogsSortOrder = (sortOrder: LogsSortOrder) => {

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -118,6 +118,7 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
         .setOption('displayedFields', parentModel.state.displayedFields)
         .setOption('sortOrder', getLogsPanelSortOrder())
         .setOption('wrapLogMessage', Boolean(getLogOption<boolean>('wrapLogMessage', false)))
+        .setOption('prettifyLogMessage', Boolean(getLogOption<boolean>('wrapLogMessage', false)))
         .setOption('showLogContextToggle', true)
         // @ts-expect-error Requires Grafana 11.4
         .setOption('enableInfiniteScrolling', true)


### PR DESCRIPTION
This PR adds `prettifyLogMessage` to work in combination with `wrapLogMessage`. When `wrapLogMessage` is enabled, so will be `prettifyLogMessage`, expanding json log lines if there are.


https://github.com/user-attachments/assets/4915d8b2-5745-4319-8937-5f181acafab9
