### PR TITLE
Logs Tab: Show log line count

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -71,11 +71,12 @@ import { getDetectedFieldValuesTagValuesProvider, getLabelsTagValuesProvider } f
 import { lokiRegularEscape } from '../../services/fields';
 import { logger } from '../../services/logger';
 import { getLabelsTagKeysProvider } from '../../services/TagKeysProviders';
-import { AdHocFilterWithLabels } from '../../services/scenes';
+import { AdHocFilterWithLabels, getLokiDatasource } from '../../services/scenes';
 import { FilterOp } from '../../services/filterTypes';
 import { ShowLogsButtonScene } from './ShowLogsButtonScene';
 import { CustomVariableValueSelectors } from './CustomVariableValueSelectors';
 import { setupKeyboardShortcuts } from '../../services/keyboardShortcuts';
+import { LokiDatasource } from '../../services/lokiQuery';
 
 export const showLogsButtonSceneKey = 'showLogsButtonScene';
 export interface AppliedPattern {
@@ -91,6 +92,7 @@ export interface IndexSceneState extends SceneObjectState {
   initialFilters?: AdHocVariableFilter[];
   patterns?: AppliedPattern[];
   routeMatch?: OptionalRouteMatch;
+  ds?: LokiDatasource;
 }
 
 export class IndexScene extends SceneObjectBase<IndexSceneState> {
@@ -140,6 +142,10 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
 
     this._subs.add(unsub);
     this.addActivationHandler(this.onActivate.bind(this));
+
+    getLokiDatasource(this).then((ds) => {
+      this.setState({ ds });
+    });
   }
 
   static Component = ({ model }: SceneComponentProps<IndexScene>) => {

--- a/src/Components/ServiceScene/ActionBarScene.tsx
+++ b/src/Components/ServiceScene/ActionBarScene.tsx
@@ -109,8 +109,6 @@ const getCounter = (tab: BreakdownViewDefinition, state: ServiceSceneCustomState
       return state.patternsCount;
     case 'labels':
       return state.labelsCount;
-    // case 'logs':
-    //   return state.totalLogsCount
     default:
       return undefined;
   }

--- a/src/Components/ServiceScene/ActionBarScene.tsx
+++ b/src/Components/ServiceScene/ActionBarScene.tsx
@@ -52,7 +52,7 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
                 key={index}
                 label={tab.displayName}
                 active={currentBreakdownViewSlug === tab.value}
-                counter={loadingStates[tab.displayName] ? undefined : getCounter(tab, { ...state })}
+                counter={loadingStates[tab.displayName] ? undefined : getCounter(tab, state)}
                 suffix={
                   tab.displayName === TabNames.logs
                     ? ({ className }) => LogsCount(className, logsCount, totalLogsCount)
@@ -90,8 +90,6 @@ const getCounter = (tab: BreakdownViewDefinition, state: ServiceSceneCustomState
       return state.patternsCount;
     case 'labels':
       return state.labelsCount;
-    case 'logs':
-      return state.totalLogsCount;
     default:
       return undefined;
   }

--- a/src/Components/ServiceScene/ActionBarScene.tsx
+++ b/src/Components/ServiceScene/ActionBarScene.tsx
@@ -11,7 +11,6 @@ import { BreakdownViewDefinition, breakdownViewsDefinitions, TabNames } from './
 import { config, usePluginLinks } from '@grafana/runtime';
 import { getLabelsVariable } from '../../services/variableGetters';
 import { IndexScene } from '../IndexScene/IndexScene';
-import { LINE_LIMIT } from '../../services/query';
 
 export interface ActionBarSceneState extends SceneObjectState {
   maxLines?: number;
@@ -37,7 +36,6 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
     const styles = useStyles2(getStyles);
     let currentBreakdownViewSlug = getDrilldownSlug();
     let allowNavToParent = false;
-    const { maxLines } = model.useState();
 
     if (!Object.values(PageSlugs).includes(currentBreakdownViewSlug)) {
       const drilldownValueSlug = getDrilldownValueSlug();
@@ -74,7 +72,7 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
                 counter={loadingStates[tab.displayName] ? undefined : getCounter(tab, state)}
                 suffix={
                   tab.displayName === TabNames.logs
-                    ? ({ className }) => LogsCount(className, logsCount, totalLogsCount, maxLines)
+                    ? ({ className }) => LogsCount(className, totalLogsCount)
                     : undefined
                 }
                 icon={loadingStates[tab.displayName] ? 'spinner' : undefined}
@@ -109,6 +107,8 @@ const getCounter = (tab: BreakdownViewDefinition, state: ServiceSceneCustomState
       return state.patternsCount;
     case 'labels':
       return state.labelsCount;
+    // case 'logs':
+    //   return state.totalLogsCount
     default:
       return undefined;
   }
@@ -195,34 +195,15 @@ function ToolbarExtensionsRenderer(props: { serviceScene: SceneObject }) {
   );
 }
 
-function LogsCount(
-  className: string | undefined,
-  logsCount: number | undefined,
-  totalCount: number | undefined,
-  maxLines?: number
-) {
+function LogsCount(className: string | undefined, totalCount: number | undefined) {
   const styles = useStyles2(getLogsCountStyles);
 
-  if (logsCount !== undefined) {
-    const lineLimit = maxLines ?? LINE_LIMIT;
+  if (totalCount !== undefined) {
     const valueFormatter = getValueFormat('short');
-
-    const formattedLogsCount = valueFormatter(logsCount, 0);
-
-    if (logsCount < lineLimit || totalCount === undefined) {
-      return (
-        <span className={cx(className, styles.logsCountStyles)}>
-          {formattedLogsCount.text}
-          {formattedLogsCount.suffix?.trim()}
-        </span>
-      );
-    }
-
     const formattedTotalCount = valueFormatter(totalCount, 0);
     return (
       <span className={cx(className, styles.logsCountStyles)}>
-        {formattedLogsCount.text}
-        {formattedLogsCount.suffix?.trim()} of {formattedTotalCount.text}
+        {formattedTotalCount.text}
         {formattedTotalCount.suffix?.trim()}
       </span>
     );

--- a/src/Components/ServiceScene/Breakdowns/AddToExplorationButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToExplorationButton.tsx
@@ -1,28 +1,27 @@
-import { DataFrame, DataSourceJsonData, TimeRange } from '@grafana/data';
-import { DataSourceWithBackend, usePluginLinks } from '@grafana/runtime';
+import { DataFrame, TimeRange } from '@grafana/data';
+import { usePluginLinks } from '@grafana/runtime';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState, SceneQueryRunner } from '@grafana/scenes';
-import { DataQuery, DataSourceRef } from '@grafana/schema';
+import { DataSourceRef } from '@grafana/schema';
 import { IconButton } from '@grafana/ui';
 import React from 'react';
 import { ExtensionPoints } from 'services/extensions/links';
 import { findObjectOfType, getLokiDatasource } from 'services/scenes';
 
 import LokiLogo from '../../../img/logo.svg';
+import { LokiDatasource, LokiQuery } from '../../../services/lokiQuery';
 
 export interface AddToExplorationButtonState extends SceneObjectState {
   frame?: DataFrame;
   labelName?: string;
   fieldName?: string;
-
-  ds?: DataSourceWithBackend<DataQuery, DataSourceJsonData>;
+  ds?: LokiDatasource;
   context?: ExtensionContext;
-
-  queries: DataQuery[];
+  queries: LokiQuery[];
 }
 
 type ExtensionContext = {
   timeRange: TimeRange;
-  queries: DataQuery[];
+  queries: LokiQuery[];
   datasource: DataSourceRef;
   origin: string;
   url: string;
@@ -66,6 +65,7 @@ export class AddToExplorationButton extends SceneObjectBase<AddToExplorationButt
         ...q,
         expr: sceneGraph.interpolate(queryRunner, q.expr),
         legendFormat: filter?.name ? `{{ ${filter.name} }}` : sceneGraph.interpolate(queryRunner, q.legendFormat),
+        datasource: q.datasource ?? undefined,
       }));
       if (JSON.stringify(queries) !== JSON.stringify(this.state.queries)) {
         this.setState({ queries });

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.test.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.test.tsx
@@ -67,7 +67,7 @@ describe('PatternNameLabel', () => {
   });
 
   it('calls data source query correctly', async () => {
-    render(<PatternNameLabel exploration={explorationMock} pattern="test <_> pattern" />);
+    render(<PatternNameLabel exploration={explorationMock} pattern="test <_> pattern" maxLines={1000} />);
 
     const patternElement = screen.getByText('<_>');
     userEvent.click(patternElement);
@@ -86,7 +86,7 @@ describe('PatternNameLabel', () => {
   });
 
   it('calls datasource query', async () => {
-    render(<PatternNameLabel exploration={explorationMock} pattern="test <_> pattern" />);
+    render(<PatternNameLabel exploration={explorationMock} pattern="test <_> pattern" maxLines={1000} />);
 
     const patternElement = screen.getByText('<_>');
     userEvent.click(patternElement);
@@ -98,7 +98,7 @@ describe('PatternNameLabel', () => {
   });
 
   it('avoids duplicate queries for the same pattern and time range', async () => {
-    render(<PatternNameLabel exploration={explorationMock} pattern="test <_> pattern" />);
+    render(<PatternNameLabel exploration={explorationMock} pattern="test <_> pattern" maxLines={1000} />);
 
     const patternElement = screen.getByText('<_>');
     userEvent.click(patternElement);

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternNameLabel.tsx
@@ -15,7 +15,7 @@ interface PatternNameLabelProps {
   pattern: string;
 }
 
-const LINE_LIMIT = 1000;
+export const LINE_LIMIT = 1000;
 
 export const PatternNameLabel = ({ exploration, pattern }: PatternNameLabelProps) => {
   const patternIndices = extractPatternIndices(pattern);

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -7,7 +7,7 @@ import {
   SceneObjectState,
   VizPanel,
 } from '@grafana/scenes';
-import { DataFrame, LogRowModel } from '@grafana/data';
+import { DataFrame, getValueFormat, LogRowModel } from '@grafana/data';
 import { getLogOption, setDisplayedFields } from '../../services/store';
 import React, { MouseEvent } from 'react';
 import { LogsListScene } from './LogsListScene';
@@ -43,6 +43,23 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
         body: this.getLogsPanel(),
       });
     }
+
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
+    this._subs.add(
+      serviceScene.subscribeToState((newState, prevState) => {
+        if (newState.logsCount !== prevState.logsCount) {
+          if (!this.state.body) {
+            this.setState({
+              body: this.getLogsPanel(),
+            });
+          } else {
+            this.state.body.setState({
+              title: this.getTitle(newState.logsCount),
+            });
+          }
+        }
+      })
+    );
   }
 
   onClickShowField = (field: string) => {
@@ -104,12 +121,19 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
     return sceneGraph.getAncestor(this, LogsListScene);
   }
 
+  private getTitle(logsCount: number | undefined) {
+    const valueFormatter = getValueFormat('short');
+    const formattedCount = logsCount !== undefined ? valueFormatter(logsCount, 0) : undefined;
+    return formattedCount !== undefined ? `Logs (${formattedCount.text}${formattedCount.suffix?.trim()})` : 'Logs';
+  }
+
   private getLogsPanel() {
     const parentModel = this.getParentScene();
     const visualizationType = parentModel.state.visualizationType;
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
     return (
       PanelBuilders.logs()
-        .setTitle('Logs')
+        .setTitle(this.getTitle(serviceScene.state.logsCount))
         .setOption('showTime', true)
         .setOption('onClickFilterLabel', this.handleLabelFilterClick)
         .setOption('onClickFilterOutLabel', this.handleLabelFilterOutClick)

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -22,6 +22,7 @@ import { CopyLinkButton } from './CopyLinkButton';
 import { getLogsPanelSortOrder, LogOptionsScene } from './LogOptionsScene';
 import { LogsVolumePanel, logsVolumePanelKey } from './LogsVolumePanel';
 import { getPanelWrapperStyles, PanelMenu } from '../Panels/PanelMenu';
+import { ServiceScene } from './ServiceScene';
 
 interface LogsPanelSceneState extends SceneObjectState {
   body?: VizPanel;
@@ -136,6 +137,12 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
   }
 
   private updateVisibleRange = (newLogs: DataFrame[]) => {
+    // Update logs count
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
+    serviceScene.setState({
+      logsCount: newLogs[0].length,
+    });
+
     const logsVolumeScene = sceneGraph.findByKeyAndType(this, logsVolumePanelKey, LogsVolumePanel);
     if (logsVolumeScene instanceof LogsVolumePanel) {
       logsVolumeScene.updateVisibleRange(newLogs);

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -15,7 +15,7 @@ import { LEVEL_VARIABLE_VALUE } from 'services/variables';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { getTimeSeriesExpr } from '../../services/expressions';
 import { toggleLevelFromFilter } from 'services/levels';
-import { DataFrame, LoadingState } from '@grafana/data';
+import { DataFrame, getValueFormat, LoadingState } from '@grafana/data';
 import { getFieldsVariable, getLabelsVariable, getLevelsVariable } from '../../services/variableGetters';
 import { areArraysEqual } from '../../services/comparison';
 import { getPanelWrapperStyles, PanelMenu } from '../Panels/PanelMenu';
@@ -65,9 +65,19 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     });
   }
 
+  private getTitle(logsCount: number | undefined) {
+    const valueFormatter = getValueFormat('short');
+    const formattedTotalCount = logsCount !== undefined ? valueFormatter(logsCount, 0) : undefined;
+    return formattedTotalCount !== undefined
+      ? `Log volume (${formattedTotalCount.text}${formattedTotalCount.suffix?.trim()})`
+      : 'Log volume';
+  }
+
   private getVizPanel() {
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
+    const totalLogsCount = serviceScene.state.totalLogsCount;
     const viz = PanelBuilders.timeseries()
-      .setTitle('Log volume')
+      .setTitle(this.getTitle(totalLogsCount))
       .setOption('legend', { showLegend: true, calcs: ['sum'], displayMode: LegendDisplayMode.List })
       .setUnit('short')
       .setMenu(new PanelMenu({}))
@@ -88,7 +98,6 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       extendPanelContext: (_, context) => this.extendTimeSeriesLegendBus(context),
     });
 
-    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
     this._subs.add(
       panel.state.$data?.subscribeToState((newState) => {
         if (newState.data?.state !== LoadingState.Done) {
@@ -107,6 +116,22 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       serviceScene.state.$data?.subscribeToState((newState) => {
         if (newState.data?.state === LoadingState.Done) {
           this.updateVisibleRange(newState.data.series);
+        }
+      })
+    );
+
+    this._subs.add(
+      serviceScene.subscribeToState((newState, prevState) => {
+        if (newState.totalLogsCount !== prevState.totalLogsCount) {
+          if (!this.state.panel) {
+            this.setState({
+              panel: this.getVizPanel(),
+            });
+          } else {
+            this.state.panel.setState({
+              title: this.getTitle(newState.totalLogsCount),
+            });
+          }
         }
       })
     );

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -433,7 +433,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     return this.state.$data?.subscribeToState((newState, prevState) => {
       this.updateLoadingState(newState, TabNames.logs);
       if (newState.data?.state === LoadingState.Done || newState.data?.state === LoadingState.Streaming) {
-        const resultCount = newState.data.series[0].length;
+        const resultCount = newState.data.series[0]?.length ?? 0;
         if (resultCount !== this.state.logsCount) {
           this.setState({
             logsCount: resultCount,

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -447,11 +447,9 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     return this.state.$logsCount?.subscribeToState((newState) => {
       if (newState.data?.state === LoadingState.Done) {
         const value: number | undefined = newState.data.series[0]?.fields?.[1]?.values?.[0];
-        if (value !== undefined) {
-          this.setState({
-            totalLogsCount: value,
-          });
-        }
+        this.setState({
+          totalLogsCount: value,
+        });
       }
     });
   }

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -166,6 +166,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
         if (newState.filters.length === 0) {
           this.redirectToStart();
         }
+
         // If we remove the service name filter, we should redirect to the start
         let { labelName, labelValue, breakdownLabel } = getPrimaryLabelFromUrl();
 
@@ -177,7 +178,11 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
         const prevRouteMatch = indexScene.state.routeMatch;
 
         // The "primary" label used in the URL is no longer active, pick a new one
-        if (!newState.filters.some((f) => f.key === labelName && f.operator === '=' && f.value === labelValue)) {
+        if (
+          !newState.filters.some(
+            (f) => f.key === labelName && f.operator === '=' && replaceSlash(f.value) === labelValue
+          )
+        ) {
           const newPrimaryLabel = newState.filters.find((f) => f.operator === '=' && f.value !== EMPTY_VARIABLE_VALUE);
           if (newPrimaryLabel) {
             indexScene.setState({

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -56,7 +56,6 @@ import {
 } from '../../services/routing';
 import { replaceSlash } from '../../services/extensions/links';
 import { ShowLogsButtonScene } from '../IndexScene/ShowLogsButtonScene';
-import { LokiQueryType } from '../../services/lokiQuery';
 
 export const LOGS_PANEL_QUERY_REFID = 'logsPanelQuery';
 export const LOGS_COUNT_QUERY_REFID = 'logsCountQuery';
@@ -600,7 +599,7 @@ function getLogCountQueryRunner() {
     [
       buildDataQuery(`sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR}[$__auto]))`, {
         refId: LOGS_COUNT_QUERY_REFID,
-        queryType: LokiQueryType.Instant,
+        queryType: 'instant',
       }),
     ],
     { runQueriesMode: 'manual' } // for some reason when this query is set to auto, it doesn't run on time range update, looks like there is different behavior with data providers not in the special $data prop

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -225,6 +225,8 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
       patternsCount: undefined,
       labelsCount: undefined,
       fieldsCount: undefined,
+      logsCount: undefined,
+      totalLogsCount: undefined,
     });
     getMetadataService().setServiceSceneState(this.state);
     this._subs.unsubscribe();

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -41,6 +41,7 @@ import {
   getFieldsVariable,
   getLabelsVariable,
   getLevelsVariable,
+  getLineFilterVariable,
   getMetadataVariable,
   getPatternsVariable,
 } from '../../services/variableGetters';
@@ -295,6 +296,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     this._subs.add(this.subscribeToLevelsVariable());
     this._subs.add(this.subscribeToDataSourceVariable());
     this._subs.add(this.subscribeToPatternsVariable());
+    this._subs.add(this.subscribeToLineFilterVariable());
 
     // Update query runner on manual time range change
     this._subs.add(this.subscribeToTimeRange());
@@ -304,6 +306,14 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     return getPatternsVariable(this).subscribeToState((newState, prevState) => {
       if (newState.value !== prevState.value) {
         this.state.$detectedFieldsData?.runQueries();
+        this.state.$logsCount?.runQueries();
+      }
+    });
+  }
+
+  private subscribeToLineFilterVariable() {
+    return getLineFilterVariable(this).subscribeToState((newState, prevState) => {
+      if (newState.value !== prevState.value) {
         this.state.$logsCount?.runQueries();
       }
     });

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -417,7 +417,6 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
       this.updateLoadingState(newState, TabNames.logs);
       if (newState.data?.state === LoadingState.Done || newState.data?.state === LoadingState.Streaming) {
         const resultCount = newState.data.series[0].length;
-        console.log('logs count', resultCount);
         this.setState({
           logsCount: resultCount,
         });
@@ -429,7 +428,6 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     return this.state.$logsCount?.subscribeToState((newState) => {
       if (newState.data?.state === LoadingState.Done) {
         const value: number | undefined = newState.data.series[0]?.fields?.[1]?.values?.[0];
-        console.log('total logs count', value, newState);
         if (value !== undefined) {
           this.setState({
             totalLogsCount: value,

--- a/src/services/TagKeysProviders.ts
+++ b/src/services/TagKeysProviders.ts
@@ -1,5 +1,5 @@
 import { logger } from './logger';
-import { LokiQuery } from './lokiQuery';
+import { LokiDatasource, LokiQuery } from './lokiQuery';
 import { DataSourceGetTagKeysOptions, GetTagResponse, MetricFindValue } from '@grafana/data';
 import { AdHocFiltersVariable } from '@grafana/scenes';
 import { DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
@@ -16,7 +16,7 @@ export async function getLabelsTagKeysProvider(variable: AdHocFiltersVariable): 
     logger.error(new Error('getTagKeysProvider: Invalid datasource!'));
     throw new Error('Invalid datasource!');
   }
-  const datasource = datasource_ as DataSourceWithBackend<LokiQuery>;
+  const datasource = datasource_ as LokiDatasource;
 
   if (datasource && datasource.getTagKeys) {
     const filters = joinTagFilters(variable);

--- a/src/services/TagValuesProviders.ts
+++ b/src/services/TagValuesProviders.ts
@@ -3,7 +3,7 @@ import { DataSourceGetTagValuesOptions, GetTagResponse, MetricFindValue, ScopedV
 import { BackendSrvRequest, DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
 import { AdHocFilterWithLabels, getDataSource } from './scenes';
 import { logger } from './logger';
-import { LokiQuery } from './lokiQuery';
+import { LokiDatasource, LokiQuery } from './lokiQuery';
 import { getDataSourceVariable, getValueFromFieldsFilter } from './variableGetters';
 import { VAR_FIELDS, VAR_LEVELS, VAR_METADATA } from './variables';
 import { isArray } from 'lodash';
@@ -45,7 +45,7 @@ export const getDetectedFieldValuesTagValuesProvider = async (
   }
 
   // Assert datasource is Loki
-  const lokiDatasource = datasourceUnknownType as DataSourceWithBackend<LokiQuery>;
+  const lokiDatasource = datasourceUnknownType as LokiDatasource;
   // Assert language provider is LokiLanguageProvider
   const languageProvider = lokiDatasource.languageProvider as LokiLanguageProviderWithDetectedLabelValues;
 
@@ -114,7 +114,7 @@ export async function getLabelsTagValuesProvider(
     logger.error(new Error('getTagValuesProvider: Invalid datasource!'));
     throw new Error('Invalid datasource!');
   }
-  const datasource = datasource_ as DataSourceWithBackend<LokiQuery>;
+  const datasource = datasource_ as LokiDatasource;
 
   if (datasource && datasource.getTagValues) {
     // Filter out other values for this key so users can include other values for this label

--- a/src/services/datasource.test.ts
+++ b/src/services/datasource.test.ts
@@ -10,7 +10,7 @@ import {
 import { Observable } from 'rxjs';
 import { DataSourceWithBackend } from '@grafana/runtime';
 import { DetectedFieldsResponse } from './fields';
-import { LokiQuery } from './lokiQuery';
+import { LokiDatasource, LokiQuery } from './lokiQuery';
 import { SceneDataQueryResourceRequest } from './datasourceTypes';
 
 jest.mock('@grafana/runtime', () => ({
@@ -31,7 +31,7 @@ let datasource = new DataSourceWithBackend<LokiQuery>({
   meta: {} as DataSourcePluginMeta,
   readOnly: false,
   uid: '',
-}) as DataSourceWithBackend<LokiQuery>;
+}) as LokiDatasource;
 
 jest.mock('./scenes', () => ({
   ...jest.requireActual('./scenes'),

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -19,7 +19,7 @@ import { FIELDS_TO_REMOVE, LABELS_TO_REMOVE, sortLabelsByCardinality } from './f
 import { SERVICE_NAME } from './variables';
 import { runShardSplitQuery } from './shardQuerySplitting';
 import { requestSupportsSharding } from './logql';
-import { LokiQuery } from './lokiQuery';
+import { LokiDatasource, LokiQuery } from './lokiQuery';
 import { SceneDataQueryRequest, SceneDataQueryResourceRequest, VolumeRequestProps } from './datasourceTypes';
 import { logger } from './logger';
 import { PLUGIN_ID } from './plugin';
@@ -136,11 +136,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
     });
   }
 
-  private getData(
-    request: SceneDataQueryRequest,
-    ds: DataSourceWithBackend<LokiQuery>,
-    subscriber: Subscriber<DataQueryResponse>
-  ) {
+  private getData(request: SceneDataQueryRequest, ds: LokiDatasource, subscriber: Subscriber<DataQueryResponse>) {
     const shardingEnabled = config.featureToggles.exploreLogsShardSplitting;
 
     const updatedRequest = {
@@ -164,7 +160,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
 
   private async getPatterns(
     request: DataQueryRequest<LokiQuery & SceneDataQueryResourceRequest>,
-    ds: DataSourceWithBackend<LokiQuery>,
+    ds: LokiDatasource,
     subscriber: Subscriber<DataQueryResponse>
   ) {
     const targets = request.targets.filter((target) => {
@@ -256,7 +252,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
   }
 
   private interpolate(
-    ds: DataSourceWithBackend<LokiQuery>,
+    ds: LokiDatasource,
     targets: Array<LokiQuery & SceneDataQueryResourceRequest>,
     request: DataQueryRequest<LokiQuery & SceneDataQueryResourceRequest>
   ) {
@@ -271,7 +267,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
 
   private async getDetectedLabels(
     request: DataQueryRequest<LokiQuery & SceneDataQueryResourceRequest>,
-    ds: DataSourceWithBackend<LokiQuery>,
+    ds: LokiDatasource,
     subscriber: Subscriber<DataQueryResponse>
   ) {
     const targets = request.targets.filter((target) => {
@@ -335,7 +331,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
 
   private async getDetectedFields(
     request: DataQueryRequest<LokiQuery & SceneDataQueryResourceRequest>,
-    ds: DataSourceWithBackend<LokiQuery>,
+    ds: LokiDatasource,
     subscriber: Subscriber<DataQueryResponse>
   ) {
     const targets = request.targets.filter((target) => {
@@ -402,7 +398,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
   //@todo doesn't work with multiple queries
   private async getVolume(
     request: DataQueryRequest<LokiQuery & SceneDataQueryResourceRequest & VolumeRequestProps>,
-    ds: DataSourceWithBackend<LokiQuery>,
+    ds: LokiDatasource,
     subscriber: Subscriber<DataQueryResponse>
   ) {
     if (request.targets.length !== 1) {
@@ -469,7 +465,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
 
   private async getLabels(
     request: DataQueryRequest<LokiQuery & SceneDataQueryResourceRequest>,
-    ds: DataSourceWithBackend<LokiQuery>,
+    ds: LokiDatasource,
     subscriber: Subscriber<DataQueryResponse>
   ) {
     if (request.targets.length !== 1) {

--- a/src/services/datasourceTypes.ts
+++ b/src/services/datasourceTypes.ts
@@ -6,8 +6,15 @@ export type SceneDataQueryRequest = DataQueryRequest<LokiQuery & SceneDataQueryR
   scopedVars?: { __sceneObject?: { valueOf: () => SceneObject } };
 };
 export type SceneDataQueryResourceRequest = {
-  resource: 'volume' | 'patterns' | 'detected_labels' | 'detected_fields' | 'labels' | undefined;
+  resource?: SceneDataQueryResourceRequestOptions;
 };
+
+export type SceneDataQueryResourceRequestOptions =
+  | 'volume'
+  | 'patterns'
+  | 'detected_labels'
+  | 'detected_fields'
+  | 'labels';
 
 export type VolumeRequestProps = {
   primaryLabel?: string;

--- a/src/services/logql.ts
+++ b/src/services/logql.ts
@@ -1,5 +1,5 @@
 import { MetricExpr, parser, Selector } from '@grafana/lezer-logql';
-import { LokiQuery, LokiQueryType } from './lokiQuery';
+import { LokiQuery } from './lokiQuery';
 import { getNodesFromQuery } from './logqlMatchers';
 import { SceneDataQueryRequest } from './datasourceTypes';
 
@@ -27,7 +27,7 @@ export function isLogsRequest(request: SceneDataQueryRequest) {
 }
 
 export function isInstantQuery(request: SceneDataQueryRequest) {
-  return request.targets.find((query) => query.queryType === LokiQueryType.Instant);
+  return request.targets.find((query) => query.queryType === 'instant');
 }
 
 export function requestSupportsSharding(request: SceneDataQueryRequest) {

--- a/src/services/logql.ts
+++ b/src/services/logql.ts
@@ -1,5 +1,5 @@
 import { MetricExpr, parser, Selector } from '@grafana/lezer-logql';
-import { LokiQuery } from './lokiQuery';
+import { LokiQuery, LokiQueryType } from './lokiQuery';
 import { getNodesFromQuery } from './logqlMatchers';
 import { SceneDataQueryRequest } from './datasourceTypes';
 
@@ -26,8 +26,15 @@ export function isLogsRequest(request: SceneDataQueryRequest) {
   return request.targets.find((query) => isLogsQuery(query.expr)) !== undefined;
 }
 
+export function isInstantQuery(request: SceneDataQueryRequest) {
+  return request.targets.find((query) => query.queryType === LokiQueryType.Instant);
+}
+
 export function requestSupportsSharding(request: SceneDataQueryRequest) {
   if (isLogsRequest(request)) {
+    return false;
+  }
+  if (isInstantQuery(request)) {
     return false;
   }
   for (let i = 0; i < request.targets.length; i++) {

--- a/src/services/lokiQuery.ts
+++ b/src/services/lokiQuery.ts
@@ -3,7 +3,7 @@ import { DataSourceRef } from '@grafana/schema';
 
 export type LokiQuery = {
   refId: string;
-  queryType: string;
+  queryType: LokiQueryType;
   editorMode: string;
   supportingQueryType: string;
   expr: string;
@@ -12,3 +12,9 @@ export type LokiQuery = {
   datasource?: DataSourceRef;
   maxLines?: number;
 };
+
+export enum LokiQueryType {
+  Instant = 'instant',
+  Range = 'range',
+  Stream = 'stream',
+}

--- a/src/services/lokiQuery.ts
+++ b/src/services/lokiQuery.ts
@@ -3,9 +3,9 @@ import { DataSourceRef } from '@grafana/schema';
 
 export type LokiQuery = {
   refId: string;
-  queryType: LokiQueryType;
-  editorMode: string;
-  supportingQueryType: string;
+  queryType?: LokiQueryType;
+  editorMode?: string;
+  supportingQueryType?: string;
   expr: string;
   legendFormat?: string;
   splitDuration?: string;
@@ -13,8 +13,4 @@ export type LokiQuery = {
   maxLines?: number;
 };
 
-export enum LokiQueryType {
-  Instant = 'instant',
-  Range = 'range',
-  Stream = 'stream',
-}
+export type LokiQueryType = 'instant' | 'range' | 'stream' | string;

--- a/src/services/lokiQuery.ts
+++ b/src/services/lokiQuery.ts
@@ -1,5 +1,7 @@
 // Warning: This file (and any imports) are included in the main bundle with Grafana in order to provide link extension support in Grafana core, in an effort to keep Grafana loading quickly, please do not add any unnecessary imports to this file and run the bundle analyzer before committing any changes!
 import { DataSourceRef } from '@grafana/schema';
+import { DataSourceWithBackend } from '@grafana/runtime';
+import { DataSourceJsonData } from '@grafana/data';
 
 export type LokiQuery = {
   refId: string;
@@ -14,3 +16,5 @@ export type LokiQuery = {
 };
 
 export type LokiQueryType = 'instant' | 'range' | 'stream' | string;
+
+export type LokiDatasource = DataSourceWithBackend<LokiQuery, DataSourceJsonData> & { maxLines?: number };

--- a/src/services/metadata.ts
+++ b/src/services/metadata.ts
@@ -47,6 +47,7 @@ export class MetadataService {
       labelsCount: state.labelsCount,
       fieldsCount: state.fieldsCount,
       loading: state.loading,
+      totalLogsCount: undefined,
     };
   }
 }

--- a/src/services/metadata.ts
+++ b/src/services/metadata.ts
@@ -47,7 +47,8 @@ export class MetadataService {
       labelsCount: state.labelsCount,
       fieldsCount: state.fieldsCount,
       loading: state.loading,
-      totalLogsCount: undefined,
+      logsCount: state.logsCount,
+      totalLogsCount: state.totalLogsCount,
     };
   }
 }

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -25,7 +25,7 @@ import { LogsSceneQueryRunner } from './LogsSceneQueryRunner';
 import { DrawStyle, StackingMode } from '@grafana/ui';
 import { getLabelsFromSeries, getVisibleLevels } from './levels';
 import { LokiQuery } from './lokiQuery';
-import { LOGS_PANEL_QUERY_REFID } from '../Components/ServiceScene/ServiceScene';
+import { LOGS_COUNT_QUERY_REFID, LOGS_PANEL_QUERY_REFID } from '../Components/ServiceScene/ServiceScene';
 
 const UNKNOWN_LEVEL_LOGS = 'logs';
 export function setLevelColorOverrides(overrides: FieldConfigOverridesBuilder<FieldConfig>) {
@@ -175,7 +175,9 @@ export function getQueryRunner(queries: LokiQuery[], queryRunnerOptions?: Partia
   // `level` label.
 
   const hasLevel = queries.find((query) => query.legendFormat?.toLowerCase().includes('level'));
-  const isLogPanelQuery = queries.find((query) => query.refId === LOGS_PANEL_QUERY_REFID);
+  const isLogPanelQuery = queries.find(
+    (query) => query.refId === LOGS_PANEL_QUERY_REFID || query.refId === LOGS_COUNT_QUERY_REFID
+  );
 
   if (hasLevel) {
     return new SceneDataTransformer({

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -228,3 +228,5 @@ export function unwrapWildcardSearch(input: string) {
 export function sanitizeStreamSelector(expression: string) {
   return expression.replace(/\s*,\s*}/, '}');
 }
+
+export const LINE_LIMIT = 1000;

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -229,4 +229,5 @@ export function sanitizeStreamSelector(expression: string) {
   return expression.replace(/\s*,\s*}/, '}');
 }
 
+// default line limit; each data source can define it's own line limit too
 export const LINE_LIMIT = 1000;

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -28,7 +28,7 @@ export const buildResourceQuery = (
     ...queryParamsOverrides,
     datasource: { uid: VAR_DATASOURCE_EXPR },
     expr,
-  };
+  } as LokiQuery & SceneDataQueryResourceRequest;
 };
 /**
  * Builds a loki data query
@@ -36,12 +36,12 @@ export const buildResourceQuery = (
  * @param queryParamsOverrides
  * @returns LokiQuery
  */
-export const buildDataQuery = (expr: string, queryParamsOverrides?: Record<string, unknown>): LokiQuery => {
+export const buildDataQuery = (expr: string, queryParamsOverrides?: Partial<LokiQuery>): LokiQuery => {
   return {
     ...defaultQueryParams,
     ...queryParamsOverrides,
     expr,
-  };
+  } as LokiQuery;
 };
 
 const defaultQueryParams = {

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -4,7 +4,7 @@ import { EMPTY_VARIABLE_VALUE, VAR_DATASOURCE_EXPR } from './variables';
 import { groupBy, trim } from 'lodash';
 import { getValueFromFieldsFilter } from './variableGetters';
 import { LokiQuery } from './lokiQuery';
-import { SceneDataQueryResourceRequest } from './datasourceTypes';
+import { SceneDataQueryResourceRequest, SceneDataQueryResourceRequestOptions } from './datasourceTypes';
 import { AdHocFilterWithLabels } from './scenes';
 import { PLUGIN_ID } from './plugin';
 import { AdHocFiltersVariable } from '@grafana/scenes';
@@ -15,12 +15,14 @@ import { FilterOp } from './filterTypes';
  * @param expr string to be interpolated and executed in the resource request
  * @param resource
  * @param queryParamsOverrides
+ * @param primaryLabel
  */
 export const buildResourceQuery = (
   expr: string,
-  resource: 'volume' | 'patterns' | 'detected_labels' | 'detected_fields' | 'labels',
-  queryParamsOverrides?: Record<string, unknown>
-): LokiQuery & SceneDataQueryResourceRequest => {
+  resource: SceneDataQueryResourceRequestOptions,
+  queryParamsOverrides?: Partial<LokiQuery>,
+  primaryLabel?: string
+): LokiQuery & SceneDataQueryResourceRequest & { primaryLabel?: string } => {
   return {
     ...defaultQueryParams,
     resource,
@@ -28,7 +30,8 @@ export const buildResourceQuery = (
     ...queryParamsOverrides,
     datasource: { uid: VAR_DATASOURCE_EXPR },
     expr,
-  } as LokiQuery & SceneDataQueryResourceRequest;
+    primaryLabel,
+  };
 };
 /**
  * Builds a loki data query
@@ -41,7 +44,7 @@ export const buildDataQuery = (expr: string, queryParamsOverrides?: Partial<Loki
     ...defaultQueryParams,
     ...queryParamsOverrides,
     expr,
-  } as LokiQuery;
+  };
 };
 
 const defaultQueryParams = {
@@ -57,7 +60,7 @@ export const buildVolumeQuery = (
   primaryLabel: string,
   queryParamsOverrides?: Record<string, unknown>
 ): LokiQuery & SceneDataQueryResourceRequest => {
-  return buildResourceQuery(expr, resource, { ...queryParamsOverrides, primaryLabel });
+  return buildResourceQuery(expr, resource, { ...queryParamsOverrides }, primaryLabel);
 };
 
 export function getLogQLLabelGroups(filters: AdHocVariableFilter[]) {

--- a/src/services/scenes.ts
+++ b/src/services/scenes.ts
@@ -1,10 +1,11 @@
 import { AdHocVariableFilter, urlUtil } from '@grafana/data';
-import { config, DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
+import { config, getDataSourceSrv } from '@grafana/runtime';
 import { sceneGraph, SceneObject, SceneObjectUrlValues, SceneQueryRunner, SceneTimePicker } from '@grafana/scenes';
 import { LOG_STREAM_SELECTOR_EXPR, VAR_DATASOURCE_EXPR, VAR_LABELS_EXPR } from './variables';
 import { EXPLORATIONS_ROUTE } from './routing';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
 import { logger } from './logger';
+import { LokiDatasource } from './lokiQuery';
 
 export function getExplorationFor(model: SceneObject): IndexScene {
   return sceneGraph.getAncestor(model, IndexScene);
@@ -33,7 +34,7 @@ export function getColorByIndex(index: number) {
 
 export async function getLokiDatasource(sceneObject: SceneObject) {
   const ds = (await getDataSourceSrv().get(VAR_DATASOURCE_EXPR, { __sceneObject: { value: sceneObject } })) as
-    | DataSourceWithBackend
+    | LokiDatasource
     | undefined;
   return ds;
 }

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -3,9 +3,8 @@ import { of } from 'rxjs';
 import { DataQueryRequest, DataQueryResponse, dateTime, LoadingState } from '@grafana/data';
 
 import { runShardSplitQuery } from './shardQuerySplitting';
-import { DataSourceWithBackend } from '@grafana/runtime';
 
-import { LokiQuery } from './lokiQuery';
+import { LokiDatasource, LokiQuery } from './lokiQuery';
 import { getMockFrames } from './combineResponses.test';
 
 jest.mock('uuid', () => ({
@@ -25,7 +24,7 @@ afterAll(() => {
 });
 
 describe('runShardSplitQuery()', () => {
-  let datasource: DataSourceWithBackend<LokiQuery>;
+  let datasource: LokiDatasource;
   const range = {
     from: dateTime('2023-02-08T04:00:00.000Z'),
     to: dateTime('2023-02-08T11:00:00.000Z'),
@@ -440,5 +439,5 @@ function createLokiDatasource() {
     languageProvider: {
       fetchLabelValues: jest.fn(),
     },
-  } as unknown as DataSourceWithBackend<LokiQuery>;
+  } as unknown as LokiDatasource;
 }

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -5,8 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { DataQueryRequest, DataQueryResponse, LoadingState, QueryResultMetaStat } from '@grafana/data';
 import { addShardingPlaceholderSelector, getSelectorForShardValues, interpolateShardingSelector } from './logql';
 import { combineResponses } from './combineResponses';
-import { DataSourceWithBackend } from '@grafana/runtime';
-import { LokiQuery } from './lokiQuery';
+import { LokiDatasource, LokiQuery } from './lokiQuery';
 import { logger } from './logger';
 import { isValidQuery } from './logqlMatchers';
 
@@ -44,7 +43,7 @@ import { isValidQuery } from './logqlMatchers';
  * - Once all request groups have been executed, it will be done().
  */
 
-export function runShardSplitQuery(datasource: DataSourceWithBackend<LokiQuery>, request: DataQueryRequest<LokiQuery>) {
+export function runShardSplitQuery(datasource: LokiDatasource, request: DataQueryRequest<LokiQuery>) {
   const queries = datasource
     .interpolateVariablesInQueries(request.targets, request.scopedVars)
     .filter((query) => query.expr)
@@ -57,7 +56,7 @@ export function runShardSplitQuery(datasource: DataSourceWithBackend<LokiQuery>,
 }
 
 function splitQueriesByStreamShard(
-  datasource: DataSourceWithBackend<LokiQuery>,
+  datasource: LokiDatasource,
   request: DataQueryRequest<LokiQuery>,
   splittingTargets: LokiQuery[]
 ) {

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -2,7 +2,7 @@ import pluginJson from '../plugin.json';
 import { Observable, Subscriber, Subscription } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
-import { DataQueryRequest, LoadingState, DataQueryResponse, QueryResultMetaStat } from '@grafana/data';
+import { DataQueryRequest, DataQueryResponse, LoadingState, QueryResultMetaStat } from '@grafana/data';
 import { addShardingPlaceholderSelector, getSelectorForShardValues, interpolateShardingSelector } from './logql';
 import { combineResponses } from './combineResponses';
 import { DataSourceWithBackend } from '@grafana/runtime';

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -97,7 +97,7 @@ test.describe('explore services breakdown page', () => {
   test('logs panel should have panel-content class suffix', async ({ page }) => {
     await explorePage.serviceBreakdownSearch.click();
     await explorePage.serviceBreakdownSearch.fill('broadcast');
-    await expect(page.getByTestId('data-testid Panel header Logs').locator('[class$="panel-content"]')).toBeVisible();
+    await expect(explorePage.getLogsPanelLocator().locator('[class$="panel-content"]')).toBeVisible();
   });
 
   test(`should add ${levelName} filter on table click`, async ({ page }) => {
@@ -136,7 +136,7 @@ test.describe('explore services breakdown page', () => {
 
     await expect(page.getByTestId(`data-testid Dashboard template variables submenu Label ${levelName}`)).toBeVisible();
     await explorePage.goToLogsTab();
-    await page.getByTestId('data-testid Panel menu Logs').click();
+    await explorePage.getLogsVolumePanelLocator().click();
     await page.getByTestId('data-testid Panel menu item Explore').click();
     await expect(page.getByText(`{service_name=\`tempo-distributor\`} | ${levelName}=\`${valueName}\``)).toBeVisible();
   });
@@ -155,7 +155,7 @@ test.describe('explore services breakdown page', () => {
 
     // Navigate to logs query
     await explorePage.goToLogsTab();
-    await page.getByTestId('data-testid Panel menu Logs').click();
+    await explorePage.getLogsVolumePanelLocator().click();
     await page.getByTestId('data-testid Panel menu item Explore').click();
 
     await expect(
@@ -637,9 +637,7 @@ test.describe('explore services breakdown page', () => {
     await page.getByTitle('See log details').nth(1).click();
 
     await explorePage.scrollToBottom();
-    const adHocLocator = page
-      .getByTestId('data-testid Panel header Logs')
-      .getByText('mimir-distributor', { exact: true });
+    const adHocLocator = explorePage.getLogsPanelLocator().getByText('mimir-distributor', { exact: true });
     await expect(adHocLocator).toHaveCount(1);
     // find text corresponding text to match adhoc filter
     await expect(adHocLocator).toBeVisible();

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -370,7 +370,7 @@ test.describe('explore services breakdown page', () => {
     await expect(page.getByText('=').nth(1)).toBeVisible();
   });
 
-  test.only('should only load fields that are in the viewport', async ({ page }) => {
+  test('should only load fields that are in the viewport', async ({ page }) => {
     await explorePage.setDefaultViewportSize();
     let requestCount = 0,
       logsCountQueryCount = 0;

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -32,7 +32,7 @@ export class ExplorePage {
   }
 
   getLogsToggleLocator() {
-    return this.page.getByTestId('data-testid Panel header Logs').getByLabel('Logs', { exact: true });
+    return this.page.getByTestId(/data-testid Panel header Logs/).getByLabel('Logs', { exact: true });
   }
 
   getPanelContentLocator() {
@@ -40,7 +40,11 @@ export class ExplorePage {
   }
 
   getLogsPanelLocator() {
-    return this.page.getByTestId('data-testid Panel header Logs');
+    return this.page.getByTestId(/data-testid Panel header Logs/);
+  }
+
+  getLogsVolumePanelLocator() {
+    return this.page.getByTestId(/data-testid Panel menu Logs/);
   }
 
   getLogsPanelContentLocator() {


### PR DESCRIPTION
Fixes: https://github.com/grafana/explore-logs/issues/425

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d9623be2-d510-4952-aba0-7f0645a9c27d">

<img width="594" alt="image" src="https://github.com/user-attachments/assets/5a67936b-15a4-43a7-8185-93eefce792a7">

<img width="1721" alt="image" src="https://github.com/user-attachments/assets/fb5dd56b-05bf-4c68-8724-d7e2fa426bb5">

<img width="1719" alt="image" src="https://github.com/user-attachments/assets/2f78ef34-a152-45e4-933a-6ff67646d3ea">

\@TODO:
* ✅  we're running this query on every activation of the ServiceScene, can we only run it when the query/timerange changes or if the current count is undefined?
* ✅  fix e2e assertions now that there's another query in the mix
* ✅  LogsCount needs to sum all infinite scroll pages
* ✅ Custom maxLines support