### PR TITLE
Keybindings: support time range copy/paste 

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -225,7 +225,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
   private subscribeToPasteTimeEvent = async () => {
     const copiedRange = await getCopiedTimeRange();
 
-    if (!copiedRange.isError) {
+    if (copiedRange.isError) {
       return;
     }
 

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -226,26 +226,27 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     const copiedRange = await getCopiedTimeRange();
 
     if (!copiedRange.isError) {
-      const timeRange = sceneGraph.getTimeRange(this);
-      const to = typeof copiedRange.range.to === 'string' ? copiedRange.range.to : undefined;
-      const from = typeof copiedRange.range.from === 'string' ? copiedRange.range.from : undefined;
+      return;
+    }
 
-      const newRange = rangeUtil.convertRawToRange(copiedRange.range);
+    const timeRange = sceneGraph.getTimeRange(this);
+    const to = typeof copiedRange.range.to === 'string' ? copiedRange.range.to : undefined;
+    const from = typeof copiedRange.range.from === 'string' ? copiedRange.range.from : undefined;
+    const newRange = rangeUtil.convertRawToRange(copiedRange.range);
 
-      if (timeRange && newRange) {
-        timeRange.setState({
-          value: newRange,
-          to,
-          from,
-        });
-      } else {
-        logger.error(new Error('Invalid time range from clipboard'), {
-          msg: 'Invalid time range from clipboard',
-          sceneTimeRange: typeof timeRange,
-          to: to ?? '',
-          from: from ?? '',
-        });
-      }
+    if (timeRange && newRange) {
+      timeRange.setState({
+        value: newRange,
+        to,
+        from,
+      });
+    } else {
+      logger.error(new Error('Invalid time range from clipboard'), {
+        msg: 'Invalid time range from clipboard',
+        sceneTimeRange: typeof timeRange,
+        to: to ?? '',
+        from: from ?? '',
+      });
     }
   };
 

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -75,7 +75,7 @@ import { AdHocFilterWithLabels } from '../../services/scenes';
 import { FilterOp } from '../../services/filterTypes';
 import { ShowLogsButtonScene } from './ShowLogsButtonScene';
 import { CustomVariableValueSelectors } from './CustomVariableValueSelectors';
-import { setupKeyboardShortcuts } from '../../services/keyboardShortcuts';
+import { getCopiedTimeRange, PasteTimeEvent, setupKeyboardShortcuts } from '../../services/keyboardShortcuts';
 
 export const showLogsButtonSceneKey = 'showLogsButtonScene';
 export interface AppliedPattern {
@@ -180,6 +180,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     const timeRange = sceneGraph.getTimeRange(this);
 
     this._subs.add(timeRange.subscribeToState(this.limitMaxInterval(timeRange)));
+    this._subs.add(this.subscribeToEvent(PasteTimeEvent, this.subscribeToPasteTimeEvent));
 
     const clearKeyBindings = setupKeyboardShortcuts(this);
 
@@ -220,6 +221,33 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
       getTagValuesProvider: getLabelsTagValuesProvider,
     });
   }
+
+  private subscribeToPasteTimeEvent = async () => {
+    const copiedRange = await getCopiedTimeRange();
+
+    if (!copiedRange.isError) {
+      const timeRange = sceneGraph.getTimeRange(this);
+      const to = typeof copiedRange.range.to === 'string' ? copiedRange.range.to : undefined;
+      const from = typeof copiedRange.range.from === 'string' ? copiedRange.range.from : undefined;
+
+      const newRange = rangeUtil.convertRawToRange(copiedRange.range);
+
+      if (timeRange && newRange) {
+        timeRange.setState({
+          value: newRange,
+          to,
+          from,
+        });
+      } else {
+        logger.error(new Error('Invalid time range from clipboard'), {
+          msg: 'Invalid time range from clipboard',
+          sceneTimeRange: typeof timeRange,
+          to: to ?? '',
+          from: from ?? '',
+        });
+      }
+    }
+  };
 
   /**
    * If user selects a time range longer then the max configured interval, show toast and set the previous time range.

--- a/src/services/keyboardShortcuts.test.ts
+++ b/src/services/keyboardShortcuts.test.ts
@@ -1,0 +1,49 @@
+import { getCopiedTimeRange } from './keyboardShortcuts';
+
+function mockReadText(value: any) {
+  Object.defineProperty(navigator, 'clipboard', {
+    // Allow overwriting
+    configurable: true,
+    value: {
+      // Provide mock implementation
+      readText: jest.fn().mockReturnValueOnce(Promise.resolve(value)),
+    },
+  });
+}
+describe('getCopiedTimeRange', () => {
+  it('should return valid absolute time range', async () => {
+    const inputString = `{"from":"2024-12-13T15:13:39.680Z","to":"2024-12-13T15:14:04.904Z"}`;
+    mockReadText(inputString);
+
+    const expected = {
+      isError: false,
+      range: JSON.parse(inputString),
+    };
+
+    expect(await getCopiedTimeRange()).toEqual(expected);
+  });
+
+  it('should return valid relative time range', async () => {
+    const inputString = `{"from":"now-30m","to":"now"}`;
+    mockReadText(inputString);
+
+    const expected = {
+      isError: false,
+      range: JSON.parse(inputString),
+    };
+
+    expect(await getCopiedTimeRange()).toEqual(expected);
+  });
+
+  it('should return error for non-timerange', async () => {
+    const inputString = `{"never":"gonna","give":"you", "up": true}`;
+    mockReadText(inputString);
+
+    const expected = {
+      isError: true,
+      range: inputString,
+    };
+
+    expect(await getCopiedTimeRange()).toEqual(expected);
+  });
+});

--- a/src/services/keyboardShortcuts.ts
+++ b/src/services/keyboardShortcuts.ts
@@ -68,7 +68,6 @@ export function setupKeyboardShortcuts(scene: IndexScene) {
     key: 't c',
     onTrigger: () => {
       const timeRange = sceneGraph.getTimeRange(scene);
-      //
       setWindowGrafanaSceneContext(timeRange);
       appEvents.publish(new CopyTimeEvent());
     },

--- a/src/services/keyboardShortcuts.ts
+++ b/src/services/keyboardShortcuts.ts
@@ -188,8 +188,12 @@ export class PasteTimeEvent extends BusEventWithPayload<PasteTimeEventPayload> {
 }
 
 /**
+ * Adds the scene object to the global window state so that templateSrv in core can interpolate strings using the scene interpolation engine with the scene as scope.
+ * This is needed for old datasources that call templateSrv.replace without passing scopedVars. For example in DataSourceAPI.metricFindQuery.
+ *
+ * This is also used from TimeSrv to access scene time range.
+ *
  * @todo delete after https://github.com/grafana/scenes/pull/999 is available
- * @param activeScene
  */
 export function setWindowGrafanaSceneContext(activeScene: SceneObject) {
   const prevScene = (window as any).__grafanaSceneContext;

--- a/src/services/keyboardShortcuts.ts
+++ b/src/services/keyboardShortcuts.ts
@@ -165,14 +165,21 @@ export function toggleVizPanelLegend(vizPanel: VizPanel): void {
 function hasLegendOptions(optionsWithLegend: unknown): optionsWithLegend is OptionsWithLegend {
   return optionsWithLegend != null && typeof optionsWithLegend === 'object' && 'legend' in optionsWithLegend;
 }
+
+// Copied from https://github.com/grafana/grafana/blob/main/public/app/types/events.ts
+// @todo export from core grafana
 export class CopyTimeEvent extends BusEventBase {
   static type = 'copy-time';
 }
 
+// Copied from https://github.com/grafana/grafana/blob/main/public/app/types/events.ts
+// @todo export from core grafana
 interface PasteTimeEventPayload {
   updateUrl?: boolean;
 }
 
+// Copied from https://github.com/grafana/grafana/blob/main/public/app/types/events.ts
+// @todo export from core grafana
 export class PasteTimeEvent extends BusEventWithPayload<PasteTimeEventPayload> {
   static type = 'paste-time';
 }

--- a/src/services/narrowing.ts
+++ b/src/services/narrowing.ts
@@ -1,13 +1,14 @@
 import { SelectedTableRow } from '../Components/Table/LogLineCellComponent';
 import { LogsVisualizationType } from './store';
 import { FieldValue, ParserType } from './variables';
-export const isObj = (o: unknown): o is object => typeof o === 'object' && o !== null;
+import { RawTimeRange } from '@grafana/data';
+const isObj = (o: unknown): o is object => typeof o === 'object' && o !== null;
 
-export function hasProp<K extends PropertyKey>(data: object, prop: K): data is Record<K, unknown> {
+function hasProp<K extends PropertyKey>(data: object, prop: K): data is Record<K, unknown> {
   return prop in data;
 }
 
-export const isString = (s: unknown) => (typeof s === 'string' && s) || '';
+const isString = (s: unknown) => (typeof s === 'string' && s) || '';
 
 export const isRecord = (obj: unknown): obj is Record<string, unknown> => typeof obj === 'object';
 
@@ -78,6 +79,19 @@ export function narrowRecordStringNumber(o: unknown): Record<string, number> | f
   }
 
   return false;
+}
+
+export function narrowTimeRange(unknownRange: unknown): RawTimeRange | undefined {
+  const range = isObj(unknownRange) && hasProp(unknownRange, 'to') && hasProp(unknownRange, 'from') && unknownRange;
+  if (range) {
+    const to = isString(range.to);
+    const from = isString(range.from);
+    if (to && from) {
+      return { to, from };
+    }
+  }
+
+  return undefined;
 }
 
 export class NarrowingError extends Error {}

--- a/src/services/narrowing.ts
+++ b/src/services/narrowing.ts
@@ -1,13 +1,13 @@
 import { SelectedTableRow } from '../Components/Table/LogLineCellComponent';
 import { LogsVisualizationType } from './store';
 import { FieldValue, ParserType } from './variables';
-const isObj = (o: unknown): o is object => typeof o === 'object' && o !== null;
+export const isObj = (o: unknown): o is object => typeof o === 'object' && o !== null;
 
-function hasProp<K extends PropertyKey>(data: object, prop: K): data is Record<K, unknown> {
+export function hasProp<K extends PropertyKey>(data: object, prop: K): data is Record<K, unknown> {
   return prop in data;
 }
 
-const isString = (s: unknown) => (typeof s === 'string' && s) || '';
+export const isString = (s: unknown) => (typeof s === 'string' && s) || '';
 
 export const isRecord = (obj: unknown): obj is Record<string, unknown> => typeof obj === 'object';
 


### PR DESCRIPTION
Add support for `t c` and `t v` in Explore Logs.

Related: https://github.com/grafana/scenes/pull/999
Also ran into this bug while testing: https://github.com/grafana/grafana/issues/97892