### PR TITLE
Logs Volume: Set relative height and allow to collapse

### DIFF
--- a/src/Components/ServiceScene/BreakdownViews.ts
+++ b/src/Components/ServiceScene/BreakdownViews.ts
@@ -117,8 +117,8 @@ function buildLogsListScene() {
     direction: 'column',
     children: [
       new SceneFlexItem({
-        minHeight: 200,
         body: new LogsVolumePanel({}),
+        height: 100,
       }),
       new SceneFlexItem({
         minHeight: '470px',

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -217,6 +217,21 @@ export function setLogOption(option: keyof Options, value: string | number | boo
   localStorage.setItem(`${LOG_OPTIONS_LOCALSTORAGE_KEY}.${option}`, storedValue);
 }
 
+// Logs volume options
+const LOGS_VOLUME_LOCALSTORAGE_KEY = 'grafana.explore.logs.logsVolume';
+export function setLogsVolumeOption(option: 'collapsed', value: string | undefined) {
+  const key = `${LOGS_VOLUME_LOCALSTORAGE_KEY}.${option}`;
+  if (value === undefined) {
+    localStorage.removeItem(key);
+    return;
+  }
+  localStorage.setItem(key, value);
+}
+
+export function getLogsVolumeOption(option: 'collapsed') {
+  return localStorage.getItem(`${LOGS_VOLUME_LOCALSTORAGE_KEY}.${option}`);
+}
+
 // Log visualization options
 export type LogsVisualizationType = 'logs' | 'table';
 


### PR DESCRIPTION
The Logs Volume panel has been updated to support being collapsed. In addition, its height has been set to be 20% of the viewport height or 100px.


https://github.com/user-attachments/assets/6b8b3450-6494-4be1-9302-ab88575c0d10

