### PR TITLE
Logs panel: update service data when receiving new logs

### DIFF
--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -167,6 +167,11 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
       logsCount: newLogs[0].length,
     });
 
+    if (serviceScene.state.$data?.state.data?.series) {
+      // We need to update the state with the new data without triggering state-dependent changes.
+      serviceScene.state.$data.state.data.series = newLogs;
+    }
+
     const logsVolumeScene = sceneGraph.findByKeyAndType(this, logsVolumePanelKey, LogsVolumePanel);
     if (logsVolumeScene instanceof LogsVolumePanel) {
       logsVolumeScene.updateVisibleRange(newLogs);

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -169,7 +169,13 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
 
     if (serviceScene.state.$data?.state.data?.series) {
       // We need to update the state with the new data without triggering state-dependent changes.
-      serviceScene.state.$data.state.data.series = newLogs;
+      serviceScene.state.$data.setState({
+        ...serviceScene.state.$data.state,
+        data: {
+          ...serviceScene.state.$data.state.data,
+          series: newLogs,
+        },
+      });
     }
 
     const logsVolumeScene = sceneGraph.findByKeyAndType(this, logsVolumePanelKey, LogsVolumePanel);


### PR DESCRIPTION
Before these changes, the ServiceScene was keeping the original data frame but with mutated fields after merging, so it would have an original length of 1000 but potentially many more field values.

With these changes, the table will have access to the updated data frame.

![imagen](https://github.com/user-attachments/assets/99306ae4-fef7-4ae3-b0cd-57cbe8b520b4)

Without this, paginated results will be lost or not available when switching back and forth from table to logs.

Fixes #966