### PR TITLE
fix(panel-menu): menu throwing error in logs table

### DIFF
--- a/src/Components/Panels/PanelMenu.tsx
+++ b/src/Components/Panels/PanelMenu.tsx
@@ -59,22 +59,6 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
   constructor(state: Partial<PanelMenuState>) {
     super({ ...state, addExplorationsLink: state.addExplorationsLink ?? true });
     this.addActivationHandler(() => {
-      const viz = findObjectOfType(this, (o) => o instanceof VizPanel, VizPanel);
-
-      this.setState({
-        explorationsButton: new AddToExplorationButton({
-          labelName: this.state.labelName,
-          fieldName: this.state.fieldName,
-          frame: this.state.frame,
-        }),
-      });
-
-      if (this.state.addExplorationsLink) {
-        // @todo rewrite the AddToExplorationButton
-        // Manually activate scene
-        this.state.explorationsButton?.activate();
-      }
-
       // Navigation options (all panels)
       const items: PanelMenuItem[] = [
         {
@@ -89,6 +73,33 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
           shortcut: 'p x',
         },
       ];
+
+      let viz;
+      try {
+        viz = sceneGraph.getAncestor(this, VizPanel);
+      } catch (e) {
+        // If we can't find the viz panel, we can't add the Explore item. Currently the case for logs table.
+        this.setState({
+          body: new VizPanelMenu({
+            items,
+          }),
+        });
+        return;
+      }
+
+      this.setState({
+        explorationsButton: new AddToExplorationButton({
+          labelName: this.state.labelName,
+          fieldName: this.state.fieldName,
+          frame: this.state.frame,
+        }),
+      });
+
+      if (this.state.addExplorationsLink) {
+        // @todo rewrite the AddToExplorationButton
+        // Manually activate scene
+        this.state.explorationsButton?.activate();
+      }
 
       // Visualization options
       if (this.state.panelType || viz?.state.collapsible) {

--- a/src/Components/ServiceScene/LogsTableScene.tsx
+++ b/src/Components/ServiceScene/LogsTableScene.tsx
@@ -33,7 +33,7 @@ export class LogsTableScene extends SceneObjectBase<LogsTableSceneState> {
     const parentModel = sceneGraph.getAncestor(model, LogsListScene);
     const { data } = sceneGraph.getData(model).useState();
     const { selectedLine, urlColumns, visualizationType } = parentModel.useState();
-    const { menu: Menu } = model.useState();
+    const { menu } = model.useState();
 
     // Get time range
     const timeRange = sceneGraph.getTimeRange(model);
@@ -68,7 +68,7 @@ export class LogsTableScene extends SceneObjectBase<LogsTableSceneState> {
         <PanelChrome
           loadingState={data?.state}
           title={'Logs'}
-          menu={Menu ? <Menu.Component model={Menu} /> : undefined}
+          menu={menu ? <menu.Component model={menu} /> : undefined}
           actions={<LogsPanelHeaderActions vizType={visualizationType} onChange={parentModel.setVisualizationType} />}
         >
           {dataFrame && (

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -100,6 +100,18 @@ test.describe('explore services breakdown page', () => {
     await expect(explorePage.getLogsPanelLocator().locator('[class$="panel-content"]')).toBeVisible();
   });
 
+  test(`should show "Explore" on table panel menu`, async ({ page }) => {
+    await explorePage.goToLogsTab();
+    // Switch to table view
+    await explorePage.getTableToggleLocator().click();
+
+    const table = page.getByTestId(testIds.table.wrapper);
+    await page.getByTestId('data-testid Panel menu Logs').click();
+    await page.getByTestId('data-testid Panel menu item Explore').click();
+
+    await expect(page.getByText(`drop __error__, __error_details__`)).toBeVisible();
+  });
+
   test(`should add ${levelName} filter on table click`, async ({ page }) => {
     // Switch to table view
     await explorePage.getTableToggleLocator().click();


### PR DESCRIPTION
Opening panel menu was throwing an error in Logs Table because no `VizPanel` ancestor could be found. Interestingly `findObjectOfType` returned a `VizPanel` instance, but `sceneGraph.getAncestor` threw an error.

Change the behavior to always use `sceneGraph.getAncestor` and catch the error in case there's not `VizPanel`.