### PR TITLE
feat(LogsPanelScene): issue queries in forward or backward direction …

### DIFF
--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -10,7 +10,7 @@ import {
 } from '@grafana/data';
 import { config, DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
 import { RuntimeDataSource, sceneUtils } from '@grafana/scenes';
-import { DataQuery } from '@grafana/schema';
+import { DataQuery, LogsSortOrder } from '@grafana/schema';
 import { Observable, Subscriber } from 'rxjs';
 import { getDataSource } from './scenes';
 import { getPrimaryLabelFromUrl } from './routing';
@@ -19,11 +19,13 @@ import { FIELDS_TO_REMOVE, LABELS_TO_REMOVE, sortLabelsByCardinality } from './f
 import { SERVICE_NAME } from './variables';
 import { runShardSplitQuery } from './shardQuerySplitting';
 import { requestSupportsSharding } from './logql';
-import { LokiDatasource, LokiQuery } from './lokiQuery';
+import { LokiDatasource, LokiQuery, LokiQueryDirection } from './lokiQuery';
 import { SceneDataQueryRequest, SceneDataQueryResourceRequest, VolumeRequestProps } from './datasourceTypes';
 import { logger } from './logger';
 import { PLUGIN_ID } from './plugin';
 import { sanitizeStreamSelector } from './query';
+import { LOGS_PANEL_QUERY_REFID } from 'Components/ServiceScene/ServiceScene';
+import { getLogsPanelSortOrder } from 'Components/ServiceScene/LogOptionsScene';
 
 export const WRAPPED_LOKI_DS_UID = 'wrapped-loki-ds-uid';
 
@@ -141,11 +143,13 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
 
     const updatedRequest = {
       ...request,
-      targets: ds.interpolateVariablesInQueries(request.targets, request.scopedVars).map((target) => ({
-        ...target,
-        resource: undefined,
-        expr: sanitizeStreamSelector(target.expr),
-      })),
+      targets: this.applyQueryDirection(
+        ds.interpolateVariablesInQueries(request.targets, request.scopedVars).map((target) => ({
+          ...target,
+          resource: undefined,
+          expr: sanitizeStreamSelector(target.expr),
+        }))
+      ),
     };
 
     // Query the datasource and return either observable or promise
@@ -263,6 +267,18 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
     const interpolatedTarget = targetsInterpolated[0];
     const expression = sanitizeStreamSelector(interpolatedTarget.expr);
     return { interpolatedTarget, expression };
+  }
+
+  private applyQueryDirection(targets: LokiQuery[]) {
+    const sortOrder = getLogsPanelSortOrder();
+    return targets.map((target) => {
+      if (target.refId !== LOGS_PANEL_QUERY_REFID) {
+        return target;
+      }
+      target.direction =
+        sortOrder === LogsSortOrder.Descending ? LokiQueryDirection.Backward : LokiQueryDirection.Forward;
+      return target;
+    });
   }
 
   private async getDetectedLabels(

--- a/src/services/lokiQuery.ts
+++ b/src/services/lokiQuery.ts
@@ -3,6 +3,12 @@ import { DataSourceRef } from '@grafana/schema';
 import { DataSourceWithBackend } from '@grafana/runtime';
 import { DataSourceJsonData } from '@grafana/data';
 
+export enum LokiQueryDirection {
+  Backward = 'backward',
+  Forward = 'forward',
+  Scan = 'scan',
+}
+
 export type LokiQuery = {
   refId: string;
   queryType?: LokiQueryType;
@@ -13,6 +19,7 @@ export type LokiQuery = {
   splitDuration?: string;
   datasource?: DataSourceRef;
   maxLines?: number;
+  direction?: LokiQueryDirection;
 };
 
 export type LokiQueryType = 'instant' | 'range' | 'stream' | string;


### PR DESCRIPTION
Sibling of https://github.com/grafana/grafana/pull/98203

This adds direction to our logs queries, so they are issued in the backward direction when the sorting is "newest first", or forward direction when looking for "oldest first".