### PR TITLE
feat(patterns): use grafana's calculated `interval` as `step`

### DIFF
--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -180,6 +180,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
           query: expression,
           start: request.range.from.utc().toISOString(),
           end: request.range.to.utc().toISOString(),
+          step: request.interval,
         },
         {
           requestId: request.requestId ?? 'patterns',


### PR DESCRIPTION
Optimizes the patterns graph. 

Due to defaulting to no step, graphs can sometimes look very spikey:
<img width="904" alt="image" src="https://github.com/user-attachments/assets/8ab7538c-dc10-4672-a58d-b47bcee5e332" />

while they actually shouldn't be when used with a correct `step`:

<img width="1107" alt="image" src="https://github.com/user-attachments/assets/292c0aaa-6653-44d6-ab0f-6dc28e351790" />
