### PR TITLE
fix(sorting): prevent sorting timeFields in place

### DIFF
--- a/src/services/logsFrame.test.ts
+++ b/src/services/logsFrame.test.ts
@@ -1,0 +1,43 @@
+import { FieldType } from '@grafana/data';
+import { getSeriesVisibleRange } from './logsFrame';
+
+describe('logsFrame', () => {
+  describe('getSeriesVisibleRange', () => {
+    it('should not sort the timeField in place', () => {
+      const timeField = {
+        values: [2, 1],
+        type: FieldType.time,
+        length: 2,
+        name: 'time',
+        config: {},
+      };
+      const series = [{ fields: [timeField], length: 2 }];
+      getSeriesVisibleRange(series);
+      expect(timeField.values).toEqual([2, 1]);
+    });
+
+    it('should return the correct range when the values are sorted', () => {
+      const timeField = {
+        values: [1, 2],
+        type: FieldType.time,
+        length: 2,
+        name: 'time',
+        config: {},
+      };
+      const series = [{ fields: [timeField], length: 2 }];
+      expect(getSeriesVisibleRange(series)).toEqual({ start: 1, end: 2 });
+    });
+
+    it('should return the correct range when the values are not sorted', () => {
+      const timeField = {
+        values: [2, 1],
+        type: FieldType.time,
+        length: 2,
+        name: 'time',
+        config: {},
+      };
+      const series = [{ fields: [timeField], length: 2 }];
+      expect(getSeriesVisibleRange(series)).toEqual({ start: 1, end: 2 });
+    });
+  });
+});

--- a/src/services/logsFrame.ts
+++ b/src/services/logsFrame.ts
@@ -197,7 +197,7 @@ export function getSeriesVisibleRange(series: DataFrame[]) {
 
   const timeField = series[0]?.fields.find((field) => field.type === FieldType.time);
   if (timeField) {
-    const values = timeField.values.sort();
+    const values = [...timeField.values].sort();
     const oldestFirst = values[0] < values[values.length - 1];
     start = oldestFirst ? values[0] : values[values.length - 1];
     end = oldestFirst ? values[values.length - 1] : values[0];


### PR DESCRIPTION
Just sorting the timeField and not the other fields in a frame will lead to mismatching loglines and timestamps. This PR fixes the behavior by not sorting the timeField values in place.