### PR TITLE
Regex labels: support queries from explore

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -89,6 +89,7 @@ import { getCopiedTimeRange, PasteTimeEvent, setupKeyboardShortcuts } from '../.
 import { LokiDatasource } from '../../services/lokiQuery';
 import {
   includeOperators,
+  isOperatorInclusive,
   lineFilterOperators,
   numericOperatorArray,
   numericOperators,
@@ -246,7 +247,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
       const wip = labelsVar.state._wip;
       if (
         wip &&
-        labelsVar.state.filters.some((filter) => filter.key === wip.key && filter.operator === FilterOp.Equal)
+        labelsVar.state.filters.some((filter) => filter.key === wip.key && isOperatorInclusive(filter.operator))
       ) {
         return includeOperators;
       }
@@ -451,7 +452,6 @@ function getVariableSet(initialDatasourceUid: string, initialFilters?: AdHocVari
     datasource: EXPLORATION_DS,
     layout: 'combobox',
     label: 'Labels',
-    supportsMultiValueOperators: true,
     allowCustomValue: true,
     filters: initialFilters ?? [],
     expressionBuilder: renderLogQLLabelFilters,

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { AdHocVariableFilter, AppEvents, AppPluginMeta, rangeUtil, SelectableValue } from '@grafana/data';
+import { AdHocVariableFilter, AppEvents, AppPluginMeta, rangeUtil } from '@grafana/data';
 import {
   AdHocFiltersVariable,
   CustomVariable,
@@ -82,11 +82,18 @@ import { lokiRegularEscape } from '../../services/fields';
 import { logger } from '../../services/logger';
 import { getLabelsTagKeysProvider } from '../../services/TagKeysProviders';
 import { AdHocFilterWithLabels, getLokiDatasource } from '../../services/scenes';
-import { FilterOp, LineFilterOp } from '../../services/filterTypes';
+import { FilterOp } from '../../services/filterTypes';
 import { ShowLogsButtonScene } from './ShowLogsButtonScene';
 import { CustomVariableValueSelectors } from './CustomVariableValueSelectors';
 import { getCopiedTimeRange, PasteTimeEvent, setupKeyboardShortcuts } from '../../services/keyboardShortcuts';
 import { LokiDatasource } from '../../services/lokiQuery';
+import {
+  includeOperators,
+  lineFilterOperators,
+  numericOperatorArray,
+  numericOperators,
+  operators,
+} from '../../services/operators';
 
 export const showLogsButtonSceneKey = 'showLogsButtonScene';
 export interface AppliedPattern {
@@ -437,29 +444,6 @@ function getContentScene(drillDownLabel?: string) {
     drillDownLabel,
   });
 }
-const operators = [FilterOp.Equal, FilterOp.NotEqual].map<SelectableValue<string>>((value) => ({
-  label: value,
-  value,
-}));
-
-const includeOperators = [FilterOp.Equal].map<SelectableValue<string>>((value) => ({
-  label: value,
-  value,
-}));
-
-export const numericOperatorArray = [FilterOp.gt, FilterOp.gte, FilterOp.lt, FilterOp.lte];
-
-const numericOperators = numericOperatorArray.map<SelectableValue<string>>((value) => ({
-  label: value,
-  value,
-}));
-
-const lineFilterOperators: SelectableValue[] = [
-  { label: 'match', value: LineFilterOp.match },
-  { label: 'negativeMatch', value: LineFilterOp.negativeMatch },
-  { label: 'regex', value: LineFilterOp.regex },
-  { label: 'negativeRegex', value: LineFilterOp.negativeRegex },
-];
 
 function getVariableSet(initialDatasourceUid: string, initialFilters?: AdHocVariableFilter[]) {
   const labelVariable = new AdHocFiltersVariable({
@@ -467,6 +451,8 @@ function getVariableSet(initialDatasourceUid: string, initialFilters?: AdHocVari
     datasource: EXPLORATION_DS,
     layout: 'combobox',
     label: 'Labels',
+    supportsMultiValueOperators: true,
+    allowCustomValue: true,
     filters: initialFilters ?? [],
     expressionBuilder: renderLogQLLabelFilters,
     hide: VariableHide.dontHide,

--- a/src/Components/IndexScene/ShowLogsButtonScene.tsx
+++ b/src/Components/IndexScene/ShowLogsButtonScene.tsx
@@ -5,8 +5,8 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 import { navigateToInitialPageAfterServiceSelection } from '../../services/navigate';
 import { getLabelsVariable } from '../../services/variableGetters';
-import { FilterOp } from '../../services/filterTypes';
 import { testIds } from '../../services/testIds';
+import { isOperatorInclusive } from '../../services/operators';
 
 export interface ShowLogsButtonSceneState extends SceneObjectState {
   disabled?: boolean;
@@ -23,13 +23,13 @@ export class ShowLogsButtonScene extends SceneObjectBase<ShowLogsButtonSceneStat
 
   onActivate() {
     const labelsVar = getLabelsVariable(this);
-    const hasPositiveFilter = labelsVar.state.filters.some((f) => f.operator === FilterOp.Equal);
+    const hasPositiveFilter = labelsVar.state.filters.some((f) => isOperatorInclusive(f.operator));
     this.setState({
       disabled: !hasPositiveFilter,
     });
 
     labelsVar.subscribeToState((newState) => {
-      const hasPositiveFilter = newState.filters.some((f) => f.operator === FilterOp.Equal);
+      const hasPositiveFilter = newState.filters.some((f) => isOperatorInclusive(f.operator));
       this.setState({
         disabled: !hasPositiveFilter,
       });
@@ -38,7 +38,7 @@ export class ShowLogsButtonScene extends SceneObjectBase<ShowLogsButtonSceneStat
 
   onClick = () => {
     const labelsVar = getLabelsVariable(this);
-    const positiveFilter = labelsVar.state.filters.find((f) => f.operator === FilterOp.Equal);
+    const positiveFilter = labelsVar.state.filters.find((f) => isOperatorInclusive(f.operator));
 
     if (positiveFilter) {
       navigateToInitialPageAfterServiceSelection(positiveFilter.key, positiveFilter.value);

--- a/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
@@ -298,6 +298,7 @@ export class AddToFiltersButton extends SceneObjectBase<AddToFiltersButtonState>
       return { isIncluded: false, isExcluded: false };
     }
 
+    // @todo support regex operators?
     return {
       isIncluded: filterInSelectedFilters.operator === FilterOp.Equal,
       isExcluded: filterInSelectedFilters.operator === FilterOp.NotEqual,

--- a/src/Components/ServiceScene/Breakdowns/SelectLabelActionScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SelectLabelActionScene.tsx
@@ -94,6 +94,7 @@ export class SelectLabelActionScene extends SceneObjectBase<SelectLabelActionSce
     const popoverRef = useRef<HTMLButtonElement>(null);
     const filterButtonDisabled =
       fieldType === ValueSlugs.label &&
+      // @todo support regex operators?
       variable.state.filters.filter((f) => f.key !== labelName && f.operator === FilterOp.Equal).length === 0;
 
     const isIncluded = existingFilter?.operator === FilterOp.NotEqual && fieldValue.value === EMPTY_VARIABLE_VALUE;

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -58,6 +58,8 @@ import {
 import { replaceSlash } from '../../services/extensions/links';
 import { ShowLogsButtonScene } from '../IndexScene/ShowLogsButtonScene';
 import { migrateLineFilterV1 } from '../../services/migrations';
+import { FilterOp } from '../../services/filterTypes';
+import { isOperatorInclusive } from '../../services/operators';
 
 export const LOGS_PANEL_QUERY_REFID = 'logsPanelQuery';
 export const LOGS_COUNT_QUERY_REFID = 'logsCountQuery';
@@ -182,10 +184,12 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
         // The "primary" label used in the URL is no longer active, pick a new one
         if (
           !newState.filters.some(
-            (f) => f.key === labelName && f.operator === '=' && replaceSlash(f.value) === labelValue
+            (f) => f.key === labelName && isOperatorInclusive(f.operator) && replaceSlash(f.value) === labelValue
           )
         ) {
-          const newPrimaryLabel = newState.filters.find((f) => f.operator === '=' && f.value !== EMPTY_VARIABLE_VALUE);
+          const newPrimaryLabel = newState.filters.find(
+            (f) => isOperatorInclusive(f.operator) && f.value !== EMPTY_VARIABLE_VALUE
+          );
           if (newPrimaryLabel) {
             indexScene.setState({
               routeMatch: {

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -58,7 +58,6 @@ import {
 import { replaceSlash } from '../../services/extensions/links';
 import { ShowLogsButtonScene } from '../IndexScene/ShowLogsButtonScene';
 import { migrateLineFilterV1 } from '../../services/migrations';
-import { FilterOp } from '../../services/filterTypes';
 import { isOperatorInclusive } from '../../services/operators';
 
 export const LOGS_PANEL_QUERY_REFID = 'logsPanelQuery';

--- a/src/Components/ServiceSelectionScene/AddLabelToFiltersHeaderActionScene.tsx
+++ b/src/Components/ServiceSelectionScene/AddLabelToFiltersHeaderActionScene.tsx
@@ -51,6 +51,7 @@ export class AddLabelToFiltersHeaderActionScene extends SceneObjectBase<AddLabel
       return { included: false };
     }
 
+    // @todo support regex operator
     return {
       included: filterInSelectedFilters.operator === FilterOp.Equal,
     };

--- a/src/services/TagKeysProviders.ts
+++ b/src/services/TagKeysProviders.ts
@@ -25,6 +25,8 @@ export async function getLabelsTagKeysProvider(variable: AdHocFiltersVariable): 
       filters,
     };
 
+    // @todo currently having a regex-include will not allow regular include.
+    // Do we want to only have regex operations?
     const tagKeys = await datasource.getTagKeys(options);
     const result: MetricFindValue[] = Array.isArray(tagKeys) ? tagKeys : [];
     const filteredResult = result.filter((key) => !LABELS_TO_REMOVE.includes(key.text));

--- a/src/services/TagKeysProviders.ts
+++ b/src/services/TagKeysProviders.ts
@@ -25,9 +25,7 @@ export async function getLabelsTagKeysProvider(variable: AdHocFiltersVariable): 
       filters,
     };
 
-    // @todo currently having a regex-include will not allow regular include.
     // Do we want to only have regex operations?
-    console.log('tagKeys options', options);
     const tagKeys = await datasource.getTagKeys(options);
     const result: MetricFindValue[] = Array.isArray(tagKeys) ? tagKeys : [];
     const filteredResult = result.filter((key) => !LABELS_TO_REMOVE.includes(key.text));

--- a/src/services/TagKeysProviders.ts
+++ b/src/services/TagKeysProviders.ts
@@ -27,6 +27,7 @@ export async function getLabelsTagKeysProvider(variable: AdHocFiltersVariable): 
 
     // @todo currently having a regex-include will not allow regular include.
     // Do we want to only have regex operations?
+    console.log('tagKeys options', options);
     const tagKeys = await datasource.getTagKeys(options);
     const result: MetricFindValue[] = Array.isArray(tagKeys) ? tagKeys : [];
     const filteredResult = result.filter((key) => !LABELS_TO_REMOVE.includes(key.text));

--- a/src/services/TagValuesProviders.ts
+++ b/src/services/TagValuesProviders.ts
@@ -122,10 +122,6 @@ export async function getLabelsTagValuesProvider(
     let filters = joinTagFilters(variable).filter(
       (f) => !(isOperatorInclusive(filter.operator) && f.key === filter.key)
     );
-    console.log('filters', {
-      filters,
-      varState: variable.state.filters,
-    });
 
     // If there aren't any inclusive filters, we need to ignore the exclusive ones as well, or Loki will throw an error
     if (!filters.some((filter) => isOperatorInclusive(filter.operator))) {

--- a/src/services/extensions/links.test.ts
+++ b/src/services/extensions/links.test.ts
@@ -179,8 +179,8 @@ describe('contextToLink', () => {
         '&var-fields=level%7C%3D%7C%7B%22value%22%3A%22error%22__gfc__%22parser%22%3A%22logfmt%22%7D%2Cerror' +
         // statusSource|!=|{"value":"downstream"__gfc__"parser":"logfmt"},downstream
         '&var-fields=statusSource%7C%21%3D%7C%7B%22value%22%3A%22downstream%22__gfc__%22parser%22%3A%22logfmt%22%7D%2Cdownstream' +
-        // error|!=|{"value":""__gfc__"parser":"logfmt"},
-        '&var-fields=error%7C%21%3D%7C%7B%22value%22%3A%22%22__gfc__%22parser%22%3A%22logfmt%22%7D%2C' +
+        // error|!=|{"value":""__gfc__"parser":"logfmt"},""
+        '&var-fields=error%7C%21%3D%7C%7B%22value%22%3A%22%22__gfc__%22parser%22%3A%22logfmt%22%7D%2C%22%22' +
         // endpoint|=|{"value":"queryData"__gfc__"parser":"logfmt"},queryData
         '&var-fields=endpoint%7C%3D%7C%7B%22value%22%3A%22queryData%22__gfc__%22parser%22%3A%22logfmt%22%7D%2CqueryData';
 
@@ -206,12 +206,12 @@ describe('contextToLink', () => {
 
       // level|=|{"value":"error"__gfc__"parser":"logfmt"},error
       // statusSource|!=|{"value":"downstream"__gfc__"parser":"logfmt"},downstream
-      // error|!=|{"value":""__gfc__"parser":"logfmt"},
+      // error|!=|{"value":""__gfc__"parser":"logfmt"},""
       // endpoint|=|{"value":"queryData"__gfc__"parser":"logfmt"},queryData
       const expectedFieldsUrlString =
         '&var-fields=level%7C%3D%7C%7B%22value%22%3A%22error%22__gfc__%22parser%22%3A%22logfmt%22%7D%2Cerror' +
         '&var-fields=statusSource%7C%21%3D%7C%7B%22value%22%3A%22downstream%22__gfc__%22parser%22%3A%22logfmt%22%7D%2Cdownstream' +
-        '&var-fields=error%7C%21%3D%7C%7B%22value%22%3A%22%22__gfc__%22parser%22%3A%22logfmt%22%7D%2C' +
+        '&var-fields=error%7C%21%3D%7C%7B%22value%22%3A%22%22__gfc__%22parser%22%3A%22logfmt%22%7D%2C%22%22' +
         '&var-fields=endpoint%7C%3D%7C%7B%22value%22%3A%22queryData%22__gfc__%22parser%22%3A%22logfmt%22%7D%2CqueryData';
 
       expect(config).toEqual({

--- a/src/services/extensions/links.ts
+++ b/src/services/extensions/links.ts
@@ -15,9 +15,8 @@ import {
 import pluginJson from '../../plugin.json';
 import { getMatcherFromQuery } from '../logqlMatchers';
 import { LokiQuery } from '../lokiQuery';
-import { FilterOp } from '../filterTypes';
 import { LabelType } from '../fieldsTypes';
-import { isOperatorExclusive, isOperatorInclusive } from '../operators';
+import { isOperatorInclusive } from '../operators';
 
 const title = 'Open in Explore Logs';
 const description = 'Open current query in the Explore Logs view';

--- a/src/services/extensions/links.ts
+++ b/src/services/extensions/links.ts
@@ -7,6 +7,7 @@ import { LabelType } from '../fieldsTypes';
 import { getMatcherFromQuery } from '../logqlMatchers';
 import { LokiQuery } from '../lokiQuery';
 import { FilterOp } from '../filterTypes';
+import { isOperatorExclusive, isOperatorInclusive } from '../operators';
 
 const title = 'Open in Explore Logs';
 const description = 'Open current query in the Explore Logs view';
@@ -54,7 +55,7 @@ function contextToLink<T extends PluginExtensionPanelContext>(context?: T) {
   const expr = lokiQuery.expr;
   const labelFilters = getMatcherFromQuery(expr);
 
-  const labelSelector = labelFilters.find((selector) => selector.operator === FilterOp.Equal);
+  const labelSelector = labelFilters.find((selector) => isOperatorInclusive(selector.operator));
 
   if (!labelSelector) {
     return undefined;
@@ -81,6 +82,7 @@ function contextToLink<T extends PluginExtensionPanelContext>(context?: T) {
       params
     );
   }
+
   return {
     path: createAppUrl(`/explore/${labelName}/${labelValue}/logs`, params),
   };

--- a/src/services/extensions/links.ts
+++ b/src/services/extensions/links.ts
@@ -64,10 +64,10 @@ function contextToLink<T extends PluginExtensionPanelContext>(context?: T) {
   }
 
   const expr = lokiQuery.expr;
-  const { labelFilters: labelFilters, lineFilters, fields } = getMatcherFromQuery(expr, context, lokiQuery);
-
+  const { labelFilters, lineFilters, fields } = getMatcherFromQuery(expr, context, lokiQuery);
   const labelSelector = labelFilters.find((selector) => isOperatorInclusive(selector.operator));
 
+  // Require at least one inclusive operator to run a valid Loki query
   if (!labelSelector) {
     return undefined;
   }
@@ -89,7 +89,7 @@ function contextToLink<T extends PluginExtensionPanelContext>(context?: T) {
 
     params = appendUrlParameter(
       UrlParameters.Labels,
-      `${labelFilter.key}|${labelFilter.operator}|${labelFilter.value}`,
+      `${labelFilter.key}|${labelFilter.operator}|${escapeURLDelimiters(labelFilter.value)}`,
       params
     );
   }
@@ -134,6 +134,8 @@ function contextToLink<T extends PluginExtensionPanelContext>(context?: T) {
       }
     }
   }
+
+  console.log('output url', createAppUrl(`/explore/${labelName}/${labelValue}/logs`, params));
 
   return {
     path: createAppUrl(`/explore/${labelName}/${labelValue}/logs`, params),

--- a/src/services/extensions/links.ts
+++ b/src/services/extensions/links.ts
@@ -54,6 +54,13 @@ export const linkConfigs: LinkConfigs = [
   },
 ];
 
+function stringifyValues(value?: string): string {
+  if (!value) {
+    return '""';
+  }
+  return value;
+}
+
 function contextToLink<T extends PluginExtensionPanelContext>(context?: T) {
   if (!context) {
     return undefined;
@@ -89,7 +96,7 @@ function contextToLink<T extends PluginExtensionPanelContext>(context?: T) {
 
     params = appendUrlParameter(
       UrlParameters.Labels,
-      `${labelFilter.key}|${labelFilter.operator}|${escapeURLDelimiters(labelFilter.value)}`,
+      `${labelFilter.key}|${labelFilter.operator}|${escapeURLDelimiters(stringifyValues(labelFilter.value))}`,
       params
     );
   }
@@ -98,7 +105,9 @@ function contextToLink<T extends PluginExtensionPanelContext>(context?: T) {
     for (const lineFilter of lineFilters) {
       params = appendUrlParameter(
         UrlParameters.LineFilters,
-        `${lineFilter.key}|${escapeURLDelimiters(lineFilter.operator)}|${escapeURLDelimiters(lineFilter.value)}`,
+        `${lineFilter.key}|${escapeURLDelimiters(lineFilter.operator)}|${escapeURLDelimiters(
+          stringifyValues(lineFilter.value)
+        )}`,
         params
       );
     }
@@ -109,13 +118,13 @@ function contextToLink<T extends PluginExtensionPanelContext>(context?: T) {
         if (field.key === LEVEL_VARIABLE_VALUE) {
           params = appendUrlParameter(
             UrlParameters.Levels,
-            `${field.key}|${field.operator}|${escapeURLDelimiters(field.value)}`,
+            `${field.key}|${field.operator}|${escapeURLDelimiters(stringifyValues(field.value))}`,
             params
           );
         } else {
           params = appendUrlParameter(
             UrlParameters.Metadata,
-            `${field.key}|${field.operator}|${escapeURLDelimiters(field.value)}`,
+            `${field.key}|${field.operator}|${escapeURLDelimiters(stringifyValues(field.value))}`,
             params
           );
         }
@@ -127,15 +136,13 @@ function contextToLink<T extends PluginExtensionPanelContext>(context?: T) {
         params = appendUrlParameter(
           UrlParameters.Fields,
           `${field.key}|${field.operator}|${escapeURLDelimiters(JSON.stringify(fieldValue))},${escapeURLDelimiters(
-            fieldValue.value
+            stringifyValues(fieldValue.value)
           )}`,
           params
         );
       }
     }
   }
-
-  console.log('output url', createAppUrl(`/explore/${labelName}/${labelValue}/logs`, params));
 
   return {
     path: createAppUrl(`/explore/${labelName}/${labelValue}/logs`, params),

--- a/src/services/filterTypes.ts
+++ b/src/services/filterTypes.ts
@@ -8,6 +8,9 @@ export enum FilterOp {
   lt = '<',
   gte = '>=',
   lte = '<=',
+
+  RegexEqual = '=~',
+  RegexNotEqual = '!~',
 }
 
 export type Filter = {

--- a/src/services/levels.test.ts
+++ b/src/services/levels.test.ts
@@ -197,6 +197,50 @@ describe('getVisibleLevels', () => {
     ]);
     expect(getVisibleLevels(['error', 'logs'], scene)).toEqual(['error']);
   });
+
+  it('Handles exclusion regex negative log level filter', () => {
+    setup([
+      {
+        key: 'detected_level',
+        operator: FilterOp.RegexNotEqual,
+        value: '""',
+      },
+    ]);
+    expect(getVisibleLevels(['error', 'logs'], scene)).toEqual(['error']);
+  });
+
+  it('Handles matching regex positive log level filter', () => {
+    setup([
+      {
+        key: 'detected_level',
+        operator: FilterOp.RegexEqual,
+        value: '""',
+      },
+    ]);
+    expect(getVisibleLevels(['error', 'logs'], scene)).toEqual(['logs']);
+  });
+
+  it('Handles matching regex positive log levels filter', () => {
+    setup([
+      {
+        key: 'detected_level',
+        operator: FilterOp.RegexEqual,
+        value: 'error|info',
+      },
+    ]);
+    expect(getVisibleLevels(ALL_LEVELS, scene)).toEqual(['info', 'error']);
+  });
+
+  it('Handles matching regex negative log levels filter', () => {
+    setup([
+      {
+        key: 'detected_level',
+        operator: FilterOp.RegexNotEqual,
+        value: 'error|info',
+      },
+    ]);
+    expect(getVisibleLevels(ALL_LEVELS, scene)).toEqual(['logs', 'debug', 'warn', 'crit']);
+  });
 });
 
 describe('toggleLevelFromFilter', () => {
@@ -230,6 +274,20 @@ describe('toggleLevelFromFilter', () => {
 
   it('Toggles it off if the filter with the same value exists', () => {
     setup([{ key: 'detected_level', operator: FilterOp.Equal, value: 'info' }]);
+
+    expect(toggleLevelFromFilter('info', scene)).toBe('remove');
+    expect(addToFilters).toHaveBeenCalledTimes(1);
+  });
+
+  it('Toggles it off if a regex filter with the exact value exists', () => {
+    setup([{ key: 'detected_level', operator: FilterOp.RegexEqual, value: 'info' }]);
+
+    expect(toggleLevelFromFilter('info', scene)).toBe('remove');
+    expect(addToFilters).toHaveBeenCalledTimes(1);
+  });
+
+  it('Toggles it off if a regex filter containing the value exists', () => {
+    setup([{ key: 'detected_level', operator: FilterOp.RegexEqual, value: 'info|warn' }]);
 
     expect(toggleLevelFromFilter('info', scene)).toBe('remove');
     expect(addToFilters).toHaveBeenCalledTimes(1);

--- a/src/services/logqlMatchers.ts
+++ b/src/services/logqlMatchers.ts
@@ -73,8 +73,8 @@ export function getMatcherFromQuery(query: string): Filter[] {
     const matcherPosition = NodePosition.fromNode(matcher);
     const identifierPosition = getAllPositionsInNodeByType(matcher, Identifier);
     const valuePosition = getAllPositionsInNodeByType(matcher, String);
-    const operation = query.substring(identifierPosition[0].to, valuePosition[0].from);
-    const op = operation === '=' ? FilterOp.Equal : FilterOp.NotEqual;
+    // @todo narrow the type to enum
+    const operator = query.substring(identifierPosition[0].to, valuePosition[0].from) as FilterOp;
     const key = identifierPosition[0].getExpression(query);
     const value = valuePosition.map((position) => query.substring(position.from + 1, position.to - 1))[0];
 
@@ -84,7 +84,7 @@ export function getMatcherFromQuery(query: string): Filter[] {
 
     filter.push({
       key,
-      operator: op,
+      operator,
       value,
       type: selectorPosition.contains(matcherPosition) ? LabelType.Indexed : undefined,
     });

--- a/src/services/logqlMatchers.ts
+++ b/src/services/logqlMatchers.ts
@@ -131,7 +131,14 @@ function parseLabelFilters(query: string, filter: IndexedLabelFilter[]) {
     const key = identifierPosition[0].getExpression(query);
     const value = valuePosition.map((position) => query.substring(position.from + 1, position.to - 1))[0];
 
-    if (!key || !value || (operator !== FilterOperator.NotEqual && operator !== FilterOperator.Equal)) {
+    if (
+      !key ||
+      !value ||
+      (operator !== FilterOperator.NotEqual &&
+        operator !== FilterOperator.Equal &&
+        operator !== FilterOperator.RegexEqual &&
+        operator !== FilterOperator.RegexNotEqual)
+    ) {
       continue;
     }
 

--- a/src/services/operators.ts
+++ b/src/services/operators.ts
@@ -49,3 +49,6 @@ export const isOperatorInclusive = (op: string | FilterOp): boolean => {
 export const isOperatorExclusive = (op: string | FilterOp): boolean => {
   return op === FilterOp.NotEqual || op === FilterOp.RegexNotEqual;
 };
+export const isOperatorRegex = (op: string | FilterOp): boolean => {
+  return op === FilterOp.RegexEqual || op === FilterOp.RegexNotEqual;
+};

--- a/src/services/operators.ts
+++ b/src/services/operators.ts
@@ -1,31 +1,15 @@
 import { FilterOp, LineFilterOp } from './filterTypes';
 import { SelectableValue } from '@grafana/data';
 
-const getLabelForOperator = (op: FilterOp): string => {
-  switch (op) {
-    case FilterOp.Equal:
-      return 'Equal';
-    case FilterOp.NotEqual:
-      return 'Not equal';
-    case FilterOp.RegexEqual:
-      return 'Regex equal';
-    case FilterOp.RegexNotEqual:
-      return 'Regex not equal';
-    default:
-      console.error('invalid operator');
-      throw new Error('invalid operator!');
-  }
-};
-
 export const operators = [FilterOp.Equal, FilterOp.NotEqual].map<SelectableValue<string>>((value, index, array) => {
   return {
-    label: getLabelForOperator(value),
+    label: value,
     value,
   };
 });
 
 export const includeOperators = [FilterOp.Equal].map<SelectableValue<string>>((value) => ({
-  label: getLabelForOperator(value),
+  label: value,
   value,
 }));
 

--- a/src/services/operators.ts
+++ b/src/services/operators.ts
@@ -1,0 +1,53 @@
+import { FilterOp, LineFilterOp } from './filterTypes';
+import { SelectableValue } from '@grafana/data';
+
+const getLabelForOperator = (op: FilterOp): string => {
+  switch (op) {
+    case FilterOp.Equal:
+      return 'Equal';
+    case FilterOp.NotEqual:
+      return 'Not equal';
+    case FilterOp.RegexEqual:
+      return 'Regex equal';
+    case FilterOp.RegexNotEqual:
+      return 'Regex not equal';
+    default:
+      console.error('invalid operator');
+      throw new Error('invalid operator!');
+  }
+};
+
+export const operators = [FilterOp.Equal, FilterOp.NotEqual, FilterOp.RegexEqual, FilterOp.RegexNotEqual].map<
+  SelectableValue<string>
+>((value, index, array) => {
+  return {
+    label: getLabelForOperator(value),
+    value,
+  };
+});
+
+export const includeOperators = [FilterOp.Equal, FilterOp.RegexEqual].map<SelectableValue<string>>((value) => ({
+  label: getLabelForOperator(value),
+  value,
+}));
+
+export const numericOperatorArray = [FilterOp.gt, FilterOp.gte, FilterOp.lt, FilterOp.lte];
+
+export const numericOperators = numericOperatorArray.map<SelectableValue<string>>((value) => ({
+  label: value,
+  value,
+}));
+
+export const lineFilterOperators: SelectableValue[] = [
+  { label: 'match', value: LineFilterOp.match },
+  { label: 'negativeMatch', value: LineFilterOp.negativeMatch },
+  { label: 'regex', value: LineFilterOp.regex },
+  { label: 'negativeRegex', value: LineFilterOp.negativeRegex },
+];
+
+export const isOperatorInclusive = (op: string | FilterOp): boolean => {
+  return op === FilterOp.Equal || op === FilterOp.RegexEqual;
+};
+export const isOperatorExclusive = (op: string | FilterOp): boolean => {
+  return op === FilterOp.NotEqual || op === FilterOp.RegexNotEqual;
+};

--- a/src/services/operators.ts
+++ b/src/services/operators.ts
@@ -17,16 +17,14 @@ const getLabelForOperator = (op: FilterOp): string => {
   }
 };
 
-export const operators = [FilterOp.Equal, FilterOp.NotEqual, FilterOp.RegexEqual, FilterOp.RegexNotEqual].map<
-  SelectableValue<string>
->((value, index, array) => {
+export const operators = [FilterOp.Equal, FilterOp.NotEqual].map<SelectableValue<string>>((value, index, array) => {
   return {
     label: getLabelForOperator(value),
     value,
   };
 });
 
-export const includeOperators = [FilterOp.Equal, FilterOp.RegexEqual].map<SelectableValue<string>>((value) => ({
+export const includeOperators = [FilterOp.Equal].map<SelectableValue<string>>((value) => ({
   label: getLabelForOperator(value),
   value,
 }));

--- a/src/services/query.test.ts
+++ b/src/services/query.test.ts
@@ -8,6 +8,7 @@ import {
   unwrapWildcardSearch,
   wrapWildcardSearch,
   renderPatternFilters,
+  renderLogQLMetadataFilters,
 } from './query';
 
 import { FieldValue } from './variables';
@@ -153,6 +154,54 @@ describe('renderLogQLFieldFilters', () => {
     expect(renderLogQLFieldFilters(filters)).toEqual(
       '| level=`info` or level=`error` | cluster=`lil-cluster` | component!=`comp1` | pod!=`pod1`'
     );
+  });
+
+  test('Renders positive regex filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.RegexEqual,
+        value: JSON.stringify({
+          value: 'info',
+          parser: 'logfmt',
+        } as FieldValue),
+      },
+      {
+        key: 'cluster',
+        operator: FilterOp.RegexEqual,
+        value: JSON.stringify({
+          value: 'lil-cluster',
+          parser: 'logfmt',
+        } as FieldValue),
+      },
+    ];
+
+    // Filters do not yet support regex operators
+    expect(renderLogQLFieldFilters(filters)).toEqual('');
+  });
+
+  test('Renders negative regex filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.RegexNotEqual,
+        value: JSON.stringify({
+          value: 'info',
+          parser: 'logfmt',
+        } as FieldValue),
+      },
+      {
+        key: 'cluster',
+        operator: FilterOp.RegexNotEqual,
+        value: JSON.stringify({
+          value: 'lil-cluster',
+          parser: 'logfmt',
+        } as FieldValue),
+      },
+    ];
+
+    // Filters do not yet support regex operators
+    expect(renderLogQLFieldFilters(filters)).toEqual('');
   });
 });
 describe('renderLogQLLineFilter not containing backticks', () => {
@@ -332,7 +381,6 @@ describe('renderLogQLLabelFilters', () => {
 
     expect(renderLogQLLabelFilters(filters)).toEqual('level=`info`, cluster=`lil-cluster`');
   });
-
   test('Renders negative filters', () => {
     const filters: AdHocVariableFilter[] = [
       {
@@ -349,7 +397,6 @@ describe('renderLogQLLabelFilters', () => {
 
     expect(renderLogQLLabelFilters(filters)).toEqual('level!=`info`, cluster!=`lil-cluster`');
   });
-
   test('Groups positive filters', () => {
     const filters: AdHocVariableFilter[] = [
       {
@@ -366,7 +413,54 @@ describe('renderLogQLLabelFilters', () => {
 
     expect(renderLogQLLabelFilters(filters)).toEqual('level=~"info|error"');
   });
+  test('Groups positive regex filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.RegexEqual,
+        value: 'info',
+      },
+      {
+        key: 'level',
+        operator: FilterOp.RegexEqual,
+        value: 'error',
+      },
+    ];
 
+    expect(renderLogQLLabelFilters(filters)).toEqual('level=~"info|error"');
+  });
+  test('Groups negative regex filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.RegexNotEqual,
+        value: 'info',
+      },
+      {
+        key: 'level',
+        operator: FilterOp.RegexNotEqual,
+        value: 'error',
+      },
+    ];
+
+    expect(renderLogQLLabelFilters(filters)).toEqual('level!~"info|error"');
+  });
+  test('Doesnt mix negative and positive regex filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.RegexEqual,
+        value: 'info',
+      },
+      {
+        key: 'level',
+        operator: FilterOp.RegexNotEqual,
+        value: 'error',
+      },
+    ];
+
+    expect(renderLogQLLabelFilters(filters)).toEqual('level=~`info`, level!~`error`');
+  });
   test('Renders grouped and ungrouped positive and negative filters', () => {
     const filters: AdHocVariableFilter[] = [
       {
@@ -475,7 +569,80 @@ describe('joinTagFilters', () => {
       },
     ]);
   });
+  it('joins multiple include with regex', () => {
+    const adHoc = new AdHocFiltersVariable({
+      filters: [
+        {
+          key: 'service_name',
+          value: 'service_value.+',
+          operator: '=~',
+        },
+        {
+          key: 'service_name',
+          value: 'service_value_2$',
+          operator: '=',
+        },
+        {
+          key: 'not_service_name',
+          value: 'not_service_name_value',
+          operator: '=',
+        },
+      ],
+    });
+
+    const result = joinTagFilters(adHoc);
+    expect(result).toEqual([
+      {
+        key: 'service_name',
+        value: 'service_value.+|service_value_2$',
+        operator: '=~',
+      },
+      {
+        key: 'not_service_name',
+        value: 'not_service_name_value',
+        operator: '=',
+      },
+    ]);
+  });
+  it('joins multiple exclude with regex', () => {
+    const filters = [
+      {
+        key: 'not_service_name',
+        value: 'not_service_name_value',
+        operator: '!~',
+      },
+      {
+        key: 'service_name',
+        value: 'service_value',
+        operator: '!~',
+      },
+      {
+        key: 'service_name',
+        value: 'service_value_2',
+        operator: '!~',
+      },
+    ];
+
+    const adHoc = new AdHocFiltersVariable({
+      filters,
+    });
+
+    const result = joinTagFilters(adHoc);
+    expect(result).toEqual([
+      {
+        key: 'not_service_name',
+        value: 'not_service_name_value',
+        operator: '!~',
+      },
+      {
+        key: 'service_name',
+        value: 'service_value|service_value_2',
+        operator: '!~',
+      },
+    ]);
+  });
 });
+
 describe('wrapWildcardSearch', () => {
   it('should wrap string with case-insensitive query params', () => {
     expect(wrapWildcardSearch('.+')).toEqual('.+');
@@ -507,26 +674,6 @@ describe('renderPatternFilters', () => {
       ])
     ).toEqual(`|> "level=info ts=<_> msg=\\"completing block\\""`);
   });
-  it('wraps in double quotes', () => {
-    expect(
-      renderPatternFilters([
-        {
-          pattern: 'level=info ts=<_> msg="completing block"',
-          type: 'include',
-        },
-      ])
-    ).toEqual(`|> "level=info ts=<_> msg=\\"completing block\\""`);
-  });
-  it('wraps in double quotes', () => {
-    expect(
-      renderPatternFilters([
-        {
-          pattern: 'level=info ts=<_> msg="completing block"',
-          type: 'include',
-        },
-      ])
-    ).toEqual(`|> "level=info ts=<_> msg=\\"completing block\\""`);
-  });
   it('ignores backticks', () => {
     expect(
       renderPatternFilters([
@@ -538,6 +685,204 @@ describe('renderPatternFilters', () => {
       ])
     ).toEqual(
       `|> "logger=sqlstore.metrics traceID=<_> msg=\\"query finished\\" sql=\\"INSERT INTO instance (\`org_id\`, \`result\`) VALUES (?, ?) ON DUPLICATE KEY UPDATE \`org_id\`=VALUES(\`org_id\`)\\" error=null"`
+    );
+  });
+});
+
+describe('renderLogQLMetadataFilters', () => {
+  test('Renders positive filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.Equal,
+        value: 'info',
+      },
+      {
+        key: 'cluster',
+        operator: FilterOp.Equal,
+        value: 'lil-cluster',
+      },
+    ];
+
+    expect(renderLogQLMetadataFilters(filters)).toEqual('| level=`info` | cluster=`lil-cluster`');
+  });
+  test('Renders negative filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.NotEqual,
+        value: 'info',
+      },
+      {
+        key: 'cluster',
+        operator: FilterOp.NotEqual,
+        value: 'lil-cluster',
+      },
+    ];
+
+    expect(renderLogQLMetadataFilters(filters)).toEqual('| level!=`info` | cluster!=`lil-cluster`');
+  });
+  test('Groups positive filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.Equal,
+        value: 'info',
+      },
+      {
+        key: 'level',
+        operator: FilterOp.Equal,
+        value: 'error',
+      },
+    ];
+
+    expect(renderLogQLMetadataFilters(filters)).toEqual('| level=`info` or level=`error`');
+  });
+  test('Renders grouped and ungrouped positive and negative filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.Equal,
+        value: 'info',
+      },
+      {
+        key: 'component',
+        operator: FilterOp.NotEqual,
+        value: 'comp1',
+      },
+      {
+        key: 'level',
+        operator: FilterOp.Equal,
+        value: 'error',
+      },
+      {
+        key: 'cluster',
+        operator: FilterOp.Equal,
+        value: 'lil-cluster',
+      },
+      {
+        key: 'pod',
+        operator: FilterOp.NotEqual,
+        value: 'pod1',
+      },
+    ];
+
+    expect(renderLogQLMetadataFilters(filters)).toEqual(
+      '| level=`info` or level=`error` | cluster=`lil-cluster` | component!=`comp1` | pod!=`pod1`'
+    );
+  });
+  test('Renders positive regex filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.RegexEqual,
+        value: 'info',
+      },
+      {
+        key: 'cluster',
+        operator: FilterOp.RegexEqual,
+        value: 'lil-cluster',
+      },
+    ];
+
+    expect(renderLogQLMetadataFilters(filters)).toEqual('| level=~`info` | cluster=~`lil-cluster`');
+  });
+  test('Renders negative regex filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.RegexNotEqual,
+        value: 'info',
+      },
+      {
+        key: 'cluster',
+        operator: FilterOp.RegexNotEqual,
+        value: 'lil-cluster',
+      },
+    ];
+
+    expect(renderLogQLMetadataFilters(filters)).toEqual('| level!~`info` | cluster!~`lil-cluster`');
+  });
+  test('Groups positive regex filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.RegexEqual,
+        value: 'info',
+      },
+      {
+        key: 'level',
+        operator: FilterOp.RegexEqual,
+        value: 'error',
+      },
+    ];
+
+    expect(renderLogQLMetadataFilters(filters)).toEqual('| level=~`info` or level=~`error`');
+  });
+  test('Renders grouped and ungrouped positive and negative regex filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.RegexEqual,
+        value: 'info',
+      },
+      {
+        key: 'component',
+        operator: FilterOp.RegexNotEqual,
+        value: 'comp1',
+      },
+      {
+        key: 'level',
+        operator: FilterOp.RegexEqual,
+        value: 'error',
+      },
+      {
+        key: 'cluster',
+        operator: FilterOp.RegexEqual,
+        value: 'lil-cluster',
+      },
+      {
+        key: 'pod',
+        operator: FilterOp.RegexNotEqual,
+        value: 'pod1',
+      },
+    ];
+
+    expect(renderLogQLMetadataFilters(filters)).toEqual(
+      '| level=~`info` or level=~`error` | cluster=~`lil-cluster` | component!~`comp1` | pod!~`pod1`'
+    );
+  });
+  test('Renders grouped and ungrouped positive and negative regex and non-regex filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'level',
+        operator: FilterOp.RegexEqual,
+        value: 'info',
+      },
+      {
+        key: 'component',
+        operator: FilterOp.RegexNotEqual,
+        value: 'comp1',
+      },
+      {
+        key: 'level',
+        operator: FilterOp.RegexEqual,
+        value: 'error',
+      },
+      {
+        key: 'cluster',
+        operator: FilterOp.Equal,
+        value: 'lil-cluster',
+      },
+      {
+        key: 'pod',
+        operator: FilterOp.NotEqual,
+        value: 'pod1',
+      },
+    ];
+
+    expect(renderLogQLMetadataFilters(filters)).toEqual(
+      '| level=~`info` or level=~`error` | cluster=`lil-cluster` | component!~`comp1` | pod!=`pod1`'
     );
   });
 });

--- a/src/services/query.test.ts
+++ b/src/services/query.test.ts
@@ -435,7 +435,7 @@ describe('joinTagFilters', () => {
       },
     ]);
   });
-  it('does not join multiple exclude', () => {
+  it('joins multiple exclude', () => {
     const filters = [
       {
         key: 'not_service_name',
@@ -459,6 +459,17 @@ describe('joinTagFilters', () => {
     });
 
     const result = joinTagFilters(adHoc);
-    expect(result).toEqual(filters);
+    expect(result).toEqual([
+      {
+        key: 'not_service_name',
+        value: 'not_service_name_value',
+        operator: '=',
+      },
+      {
+        key: 'service_name',
+        value: 'service_value|service_value_2',
+        operator: '!~',
+      },
+    ]);
   });
 });

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -1,5 +1,5 @@
 import { AdHocVariableFilter } from '@grafana/data';
-import { AppliedPattern, numericOperatorArray } from 'Components/IndexScene/IndexScene';
+import { AppliedPattern } from 'Components/IndexScene/IndexScene';
 import { EMPTY_VARIABLE_VALUE, VAR_DATASOURCE_EXPR } from './variables';
 import { groupBy, trim } from 'lodash';
 import { getValueFromFieldsFilter } from './variableGetters';
@@ -10,7 +10,7 @@ import { PLUGIN_ID } from './plugin';
 import { AdHocFiltersVariable, sceneUtils } from '@grafana/scenes';
 import { FilterOp, LineFilterCaseSensitive, LineFilterOp } from './filterTypes';
 import { sortLineFilters } from '../Components/IndexScene/LineFilterVariablesScene';
-import { isOperatorExclusive, isOperatorInclusive } from './operators';
+import { isOperatorExclusive, isOperatorInclusive, numericOperatorArray } from './operators';
 
 /**
  * Builds the resource query

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -244,14 +244,24 @@ export function renderPatternFilters(patterns: AppliedPattern[]) {
 export function joinTagFilters(variable: AdHocFiltersVariable) {
   const { positiveGroups, negativeGroups } = getLogQLLabelGroups(variable.state.filters);
 
+  console.log('joinTagFilters', {
+    filters: variable.state.filters,
+    positiveGroups,
+    negativeGroups,
+  });
+
   const filters: AdHocFilterWithLabels[] = [];
   for (const key in positiveGroups) {
     const values = positiveGroups[key].map((filter) => filter.value);
+    console.log('values', {
+      key,
+      values,
+    });
     if (values.length === 1) {
       filters.push({
         key,
         value: positiveGroups[key][0].value,
-        operator: '=',
+        operator: positiveGroups[key][0].operator,
       });
     } else {
       filters.push({
@@ -268,7 +278,7 @@ export function joinTagFilters(variable: AdHocFiltersVariable) {
       filters.push({
         key,
         value: negativeGroups[key][0].value,
-        operator: '!=',
+        operator: negativeGroups[key][0].operator,
       });
     } else {
       filters.push({

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -253,7 +253,6 @@ export function joinTagFilters(variable: AdHocFiltersVariable) {
   }
 
   if (negative.length) {
-    console.log('filters', { filters, negative, positiveGroups });
     negative.forEach((filter) => {
       filters.push(filter);
     });

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -109,6 +109,7 @@ export function renderLogQLLabelFilters(filters: AdHocFilterWithLabels[]) {
 
 export function renderLogQLFieldFilters(filters: AdHocVariableFilter[]) {
   // @todo partition instead of looping through again and again
+  // @todo support regex operators
   const positive = filters.filter((filter) => filter.operator === FilterOp.Equal);
   const negative = filters.filter((filter) => filter.operator === FilterOp.NotEqual);
 
@@ -177,8 +178,8 @@ export function renderLogQLLineFilter(filters: AdHocFilterWithLabels[]) {
     .join(' ');
 }
 export function renderLogQLMetadataFilters(filters: AdHocVariableFilter[]) {
-  const positive = filters.filter((filter) => filter.operator === FilterOp.Equal);
-  const negative = filters.filter((filter) => filter.operator === FilterOp.NotEqual);
+  const positive = filters.filter((filter) => isOperatorInclusive(filter.operator));
+  const negative = filters.filter((filter) => isOperatorExclusive(filter.operator));
 
   const positiveGroups = groupBy(positive, (filter) => filter.key);
 

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -244,19 +244,9 @@ export function renderPatternFilters(patterns: AppliedPattern[]) {
 export function joinTagFilters(variable: AdHocFiltersVariable) {
   const { positiveGroups, negativeGroups } = getLogQLLabelGroups(variable.state.filters);
 
-  console.log('joinTagFilters', {
-    filters: variable.state.filters,
-    positiveGroups,
-    negativeGroups,
-  });
-
   const filters: AdHocFilterWithLabels[] = [];
   for (const key in positiveGroups) {
     const values = positiveGroups[key].map((filter) => filter.value);
-    console.log('values', {
-      key,
-      values,
-    });
     if (values.length === 1) {
       filters.push({
         key,

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -240,23 +240,20 @@ export function joinTagFilters(variable: AdHocFiltersVariable) {
       filters.push({
         key,
         value: positiveGroups[key][0].value,
-        operator: positiveGroups[key][0].operator,
+        operator: '=',
       });
     } else {
       filters.push({
         key,
         value: values.join('|'),
-        operator: positiveGroups[key][0].operator,
+        operator: '=~',
       });
     }
   }
 
-  if (negative.length) {
-    negative.forEach((filter) => {
-      filters.push(filter);
-    });
-  }
-
+  negative.forEach((filter) => {
+    filters.push(filter);
+  });
   return filters;
 }
 

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -70,28 +70,39 @@ export function getLogQLLabelGroups(filters: AdHocVariableFilter[]) {
   const negative = filters.filter((filter) => isOperatorExclusive(filter.operator));
 
   const positiveGroups = groupBy(positive, (filter) => filter.key);
-  return { negative, positiveGroups };
+  const negativeGroups = groupBy(negative, (filter) => filter.key);
+  return { positiveGroups, negativeGroups };
 }
 
 export function getLogQLLabelFilters(filters: AdHocVariableFilter[]) {
-  const { negative, positiveGroups } = getLogQLLabelGroups(filters);
+  const { positiveGroups, negativeGroups } = getLogQLLabelGroups(filters);
 
   let positiveFilters: string[] = [];
   for (const key in positiveGroups) {
     const values = positiveGroups[key].map((filter) => filter.value);
     positiveFilters.push(
-      values.length === 1 ? renderMetadata(positiveGroups[key][0]) : renderRegexLabelFilter(key, values)
+      values.length === 1
+        ? renderMetadata(positiveGroups[key][0])
+        : renderRegexLabelFilter(key, values, FilterOp.RegexEqual)
     );
   }
 
-  return { positiveFilters, negative };
+  let negativeFilters: string[] = [];
+  for (const key in negativeGroups) {
+    const values = negativeGroups[key].map((filter) => filter.value);
+    negativeFilters.push(
+      values.length === 1
+        ? renderMetadata(negativeGroups[key][0])
+        : renderRegexLabelFilter(key, values, FilterOp.RegexNotEqual)
+    );
+  }
+
+  return { positiveFilters, negativeFilters };
 }
 
 export function renderLogQLLabelFilters(filters: AdHocFilterWithLabels[]) {
-  let { positiveFilters, negative } = getLogQLLabelFilters(filters);
-  const negativeFilters = negative.map((filter) => renderMetadata(filter)).join(', ');
-
-  const result = trim(`${positiveFilters.join(', ')}, ${negativeFilters}`, ' ,');
+  let { positiveFilters, negativeFilters } = getLogQLLabelFilters(filters);
+  const result = trim(`${positiveFilters.join(', ')}, ${negativeFilters.join(', ')}`, ' ,');
 
   return result;
 }
@@ -207,8 +218,8 @@ function fieldNumericFilterToQueryString(filter: AdHocVariableFilter) {
   return `${filter.key}${filter.operator}${value}`;
 }
 
-export function renderRegexLabelFilter(key: string, values: string[]) {
-  return `${key}=~"${values.join('|')}"`;
+export function renderRegexLabelFilter(key: string, values: string[], operator: FilterOp) {
+  return `${key}${operator}"${values.join('|')}"`;
 }
 
 export function renderPatternFilters(patterns: AppliedPattern[]) {
@@ -231,7 +242,7 @@ export function renderPatternFilters(patterns: AppliedPattern[]) {
 }
 
 export function joinTagFilters(variable: AdHocFiltersVariable) {
-  const { positiveGroups, negative } = getLogQLLabelGroups(variable.state.filters);
+  const { positiveGroups, negativeGroups } = getLogQLLabelGroups(variable.state.filters);
 
   const filters: AdHocFilterWithLabels[] = [];
   for (const key in positiveGroups) {
@@ -251,9 +262,23 @@ export function joinTagFilters(variable: AdHocFiltersVariable) {
     }
   }
 
-  negative.forEach((filter) => {
-    filters.push(filter);
-  });
+  for (const key in negativeGroups) {
+    const values = negativeGroups[key].map((filter) => filter.value);
+    if (values.length === 1) {
+      filters.push({
+        key,
+        value: negativeGroups[key][0].value,
+        operator: '!=',
+      });
+    } else {
+      filters.push({
+        key,
+        value: values.join('|'),
+        operator: '!~',
+      });
+    }
+  }
+
   return filters;
 }
 


### PR DESCRIPTION
This PR adds support for all labels in Explore Logs coming from an Explore query.

The ability to write arbitrary regex queries within Explore Logs is not supported yet, but this PR is the first step towards providing support in the UI for adding regex label queries.
Field regex operators are not supported yet, but should be a fast follow.

Fixes: https://github.com/grafana/explore-logs/issues/1008