### PR TITLE
chore: fix e2e tests

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -9,7 +9,7 @@ services:
       context: ./.config
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana}
-        grafana_version: ${GRAFANA_VERSION:-11.3.3}
+        grafana_version: ${GRAFANA_VERSION:-latest}
     ports:
       - 3001:3000/tcp
     volumes:

--- a/tests/appNavigation.spec.ts
+++ b/tests/appNavigation.spec.ts
@@ -17,7 +17,7 @@ test.describe('navigating app', () => {
 
   test('mega menu click should reset url params (deprecated url)', async ({ page }) => {
     await explorePage.gotoServicesBreakdownOldUrl();
-    await page.getByTestId('data-testid Toggle menu').click();
+    await page.getByLabel('Open menu').click();
     await page.getByTestId('data-testid navigation mega-menu').getByRole('link', { name: 'Logs' }).click();
     await expect(page).toHaveURL(/a\/grafana\-lokiexplore\-app\/explore\?patterns\=%5B%5D/);
     await expect(page).toHaveURL(/var-primary_label=service_name/);
@@ -46,7 +46,7 @@ test.describe('navigating app', () => {
     await expect(page.getByRole('heading', { name: 'tempo-distributor' })).not.toBeVisible();
 
     await explorePage.addServiceName();
-    await page.getByTestId('data-testid Toggle menu').click();
+    await page.getByLabel('Open menu').click();
     await page.getByTestId('data-testid navigation mega-menu').getByRole('link', { name: 'Logs' }).click();
     await expect(page).toHaveURL(/a\/grafana\-lokiexplore\-app\/explore\?patterns\=%5B%5D/);
 

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -468,7 +468,8 @@ test.describe('explore services breakdown page', () => {
 
     await explorePage.assertTabsNotLoading();
     // Fields on top should be loaded
-    // expect(requestCount).toEqual(6); -- assertion failed due to change in grafana latest
+    const REQUEST_COUNT_ADJUSTMENT = 3; // Due to a change in "latest" Grafana, the request count is 3 higher than expected
+    expect(requestCount).toEqual(6 + REQUEST_COUNT_ADJUSTMENT);
     expect(logsCountQueryCount).toEqual(2);
 
     await explorePage.scrollToBottom();
@@ -479,7 +480,7 @@ test.describe('explore services breakdown page', () => {
     // Wait for a bit for the requests to be made
     await page.waitForTimeout(250);
     // if this flakes we could just assert that it's greater then 3
-    expect(requestCount).toEqual(17);
+    expect(requestCount).toEqual(17 + REQUEST_COUNT_ADJUSTMENT);
     expect(logsCountQueryCount).toEqual(2);
   });
 

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -467,9 +467,17 @@ test.describe('explore services breakdown page', () => {
     await expect(page.getByTestId(/data-testid Panel header/).first()).toBeInViewport();
 
     await explorePage.assertTabsNotLoading();
+
+    // Assert the container size of the plugin hasn't changed, or that will mess with the assumptions below
+    const pageContainerSize = await page.locator('#pageContent').boundingBox();
+    expect(pageContainerSize.width).toEqual(1280);
+    expect(pageContainerSize.height).toEqual(640);
+
+    const INITIAL_ROWS = 3;
+    const COUNT_PER_ROW = 3;
+    const TOTAL_ROWS = 7;
     // Fields on top should be loaded
-    const REQUEST_COUNT_ADJUSTMENT = 3; // Due to a change in "latest" Grafana, the request count is 3 higher than expected
-    expect(requestCount).toEqual(6 + REQUEST_COUNT_ADJUSTMENT);
+    expect(requestCount).toEqual(INITIAL_ROWS * COUNT_PER_ROW);
     expect(logsCountQueryCount).toEqual(2);
 
     await explorePage.scrollToBottom();
@@ -479,8 +487,8 @@ test.describe('explore services breakdown page', () => {
     await expect(page.getByTestId(/data-testid Panel header/).first()).not.toBeInViewport();
     // Wait for a bit for the requests to be made
     await page.waitForTimeout(250);
-    // if this flakes we could just assert that it's greater then 3
-    expect(requestCount).toEqual(17 + REQUEST_COUNT_ADJUSTMENT);
+    // 7 rows, last row only has 2
+    expect(requestCount).toEqual(TOTAL_ROWS * COUNT_PER_ROW - 1);
     expect(logsCountQueryCount).toEqual(2);
   });
 

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -1502,7 +1502,7 @@ test.describe('explore services breakdown page', () => {
       const queryFieldText = await page.getByTestId('data-testid Query field').textContent();
 
       // Open "Go queryless" menu
-      const extensionsButton = page.getByLabel('Go queryless');
+      const extensionsButton = page.getByText('Go queryless');
       await expect(extensionsButton).toHaveCount(1);
       await extensionsButton.click();
 

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -227,7 +227,7 @@ test.describe('explore services breakdown page', () => {
     const toolBar = page.getByLabel('Explore toolbar');
     // Assert toolbar is visible before proceeding
     await expect(toolBar).toBeVisible();
-    const extensionsButton = page.getByLabel('Go queryless');
+    const extensionsButton = page.getByRole('button', { name: 'Go queryless' });
     await expect(extensionsButton).toHaveCount(1);
     // Click on extensions button
     await extensionsButton.click();

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -1505,7 +1505,7 @@ test.describe('explore services breakdown page', () => {
       await page.getByLabel('Add', { exact: true }).click();
 
       // Go to explore logs
-      await page.getByLabel('Open in Explore Logs').click();
+      await page.getByLabel('Open in Explore Logs').first().click();
       await page.getByRole('button', { name: 'Open', exact: true }).click();
 
       // Assert query returned results after nav

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -227,11 +227,11 @@ test.describe('explore services breakdown page', () => {
     const toolBar = page.getByLabel('Explore toolbar');
     // Assert toolbar is visible before proceeding
     await expect(toolBar).toBeVisible();
-    const extensionsButton = page.getByLabel('Add', { exact: true });
+    const extensionsButton = page.getByLabel('Go queryless');
     await expect(extensionsButton).toHaveCount(1);
     // Click on extensions button
     await extensionsButton.click();
-    const openInExploreLocator = page.getByLabel('Open in Explore Logs');
+    const openInExploreLocator = page.getByLabel('Open in Explore Logs').first();
     await expect(openInExploreLocator).toBeVisible();
     // Click on open in logs explore
     await openInExploreLocator.click();

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -468,7 +468,7 @@ test.describe('explore services breakdown page', () => {
 
     await explorePage.assertTabsNotLoading();
     // Fields on top should be loaded
-    expect(requestCount).toEqual(6);
+    // expect(requestCount).toEqual(6); -- assertion failed due to change in grafana latest
     expect(logsCountQueryCount).toEqual(2);
 
     await explorePage.scrollToBottom();

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -1501,11 +1501,15 @@ test.describe('explore services breakdown page', () => {
       await expect(firstExplorePanelRow).toBeVisible();
       const queryFieldText = await page.getByTestId('data-testid Query field').textContent();
 
-      // Open add menu (note will need to be changed after "queryless" button is released)
-      await page.getByLabel('Add', { exact: true }).click();
+      // Open "Go queryless" menu
+      const extensionsButton = page.getByLabel('Go queryless');
+      await expect(extensionsButton).toHaveCount(1);
+      await extensionsButton.click();
 
       // Go to explore logs
-      await page.getByLabel('Open in Explore Logs').first().click();
+      const openInExploreLocator = page.getByLabel('Open in Explore Logs').first();
+      await expect(openInExploreLocator).toBeVisible();
+      await openInExploreLocator.click();
       await page.getByRole('button', { name: 'Open', exact: true }).click();
 
       // Assert query returned results after nav


### PR DESCRIPTION
The e2e tests started failing on https://github.com/grafana/explore-logs/pull/1013.
This PR includes some cherry-picked commits to fix the tests and aims to restore the tests to working order.