### PR TITLE
Patterns: Not configured state not working

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
@@ -100,24 +100,23 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
     this.setBody();
 
-    const dataFrames = serviceScene.state.$patternsData?.state.data?.series;
-
     // If the patterns exist already, update the dataframe
-    if (dataFrames) {
-      this.updatePatternFrames(dataFrames);
+    if (serviceScene.state.$patternsData?.state) {
+      this.onDataChange(serviceScene.state.$patternsData?.state);
     }
 
     // Subscribe to changes from pattern API call
     this._subs.add(serviceScene.state.$patternsData?.subscribeToState(this.onDataChange));
   }
 
-  private onDataChange = (newState: SceneDataState, prevState: SceneDataState) => {
+  private onDataChange = (newState: SceneDataState, prevState?: SceneDataState) => {
     const newFrames = newState.data?.series;
-    const prevFrames = prevState.data?.series;
+    const prevFrames = prevState?.data?.series;
 
     if (newState.data?.state === LoadingState.Done) {
       this.setState({
         loading: false,
+        error: false,
       });
 
       if (!areArraysEqual(newFrames, prevFrames)) {
@@ -126,6 +125,7 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
     } else if (newState.data?.state === LoadingState.Loading) {
       this.setState({
         loading: true,
+        error: false,
       });
     } else if (newState.data?.state === LoadingState.Error) {
       this.setState({

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
@@ -27,7 +27,7 @@ export interface PatternsBreakdownSceneState extends SceneObjectState {
   body?: SceneFlexLayout;
   value?: string;
   loading?: boolean;
-  error?: string;
+  error?: boolean;
   blockingMessage?: string;
   // The dataframe built from the patterns that we get back from the loki Patterns API
   patternFrames?: PatternFrame[];
@@ -64,7 +64,7 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
 
   // parent render
   public static Component = ({ model }: SceneComponentProps<PatternsBreakdownScene>) => {
-    const { body, loading, blockingMessage, patternFrames } = model.useState();
+    const { body, loading, blockingMessage, patternFrames, error } = model.useState();
     const { value: timeRange } = sceneGraph.getTimeRange(model).useState();
     const styles = useStyles2(getStyles);
     const timeRangeTooOld = dateTime().diff(timeRange.to, 'hours') >= PATTERNS_MAX_AGE_HOURS;
@@ -72,13 +72,13 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
     return (
       <div className={styles.container}>
         <StatusWrapper {...{ isLoading: loading, blockingMessage }}>
-          {!loading && !patternFrames && (
+          {!loading && error && (
             <div className={styles.patternMissingText}>
               <Text textAlignment="center" color="primary">
                 <p>There are no pattern matches.</p>
                 <p>Pattern matching has not been configured.</p>
                 <p>Patterns let you detect similar log lines and add or exclude them from your search.</p>
-                <p>To see them in action, add the following to your configuration</p>
+                <p>To see them in action, add the following to your Loki configuration</p>
                 <p>
                   <code>--pattern-ingester.enabled=true</code>
                 </p>
@@ -86,9 +86,9 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
             </div>
           )}
 
-          {!loading && patternFrames?.length === 0 && timeRangeTooOld && <PatternsTooOld />}
-          {!loading && patternFrames?.length === 0 && !timeRangeTooOld && <PatternsNotDetected />}
-          {!loading && patternFrames && patternFrames.length > 0 && (
+          {!error && !loading && patternFrames?.length === 0 && timeRangeTooOld && <PatternsTooOld />}
+          {!error && !loading && patternFrames?.length === 0 && !timeRangeTooOld && <PatternsNotDetected />}
+          {!error && !loading && patternFrames && patternFrames.length > 0 && (
             <div className={styles.content}>{body && <body.Component model={body} />}</div>
           )}
         </StatusWrapper>
@@ -126,6 +126,11 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
     } else if (newState.data?.state === LoadingState.Loading) {
       this.setState({
         loading: true,
+      });
+    } else if (newState.data?.state === LoadingState.Error) {
+      this.setState({
+        loading: false,
+        error: true,
       });
     }
   };

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -483,6 +483,23 @@ test.describe('explore services breakdown page', () => {
     expect(logsCountQueryCount).toEqual(2);
   });
 
+  test.only('Patterns should show error state when API call returns error', async ({ page }) => {
+    // Block everything to speed up the test
+    explorePage.blockAllQueriesExcept({
+      refIds: ['C'],
+    });
+
+    await page.route('**/resources/patterns**', async (route) => {
+      await route.fulfill({
+        status: 404,
+        contentType: 'text/plain',
+        body: '{"message":"","traceID":"abc123"}',
+      });
+    });
+    await page.getByTestId(testIds.exploreServiceDetails.tabPatterns).click();
+    await expect(page.getByText('Pattern matching has not been configured.')).toBeVisible();
+  });
+
   test(`should select field ${fieldName}, update filters, open log panel`, async ({ page }) => {
     await explorePage.goToFieldsTab();
     await page.getByTestId(`data-testid Panel header ${fieldName}`).getByRole('button', { name: 'Select' }).click();

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -492,7 +492,7 @@ test.describe('explore services breakdown page', () => {
     expect(logsCountQueryCount).toEqual(2);
   });
 
-  test.only('Patterns should show error state when API call returns error', async ({ page }) => {
+  test('Patterns should show error state when API call returns error', async ({ page }) => {
     // Block everything to speed up the test
     explorePage.blockAllQueriesExcept({
       refIds: ['C'],


### PR DESCRIPTION
Fixes: https://github.com/grafana/explore-logs/issues/1005

We've had a few users complain as well in the feedback form that patterns are broken, it's likely that this is because the patterns not configured state is no longer showing.

This PR simply shows the error state if we get an error response from the API, and adds an e2e test to ensure we don't break it again in the future.