### PR TITLE
chore: upgrade scenes to prevent panels from not being hidden

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@grafana/data": "^11.3.0",
     "@grafana/lezer-logql": "^0.2.7",
     "@grafana/runtime": "^11.3.0",
-    "@grafana/scenes": "5.41.0",
+    "@grafana/scenes": "5.41.1",
     "@grafana/ui": "^11.3.0",
     "@hello-pangea/dnd": "^16.6.0",
     "@lezer/common": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,10 +1114,10 @@
     rxjs "7.8.1"
     tslib "2.7.0"
 
-"@grafana/scenes@5.41.0":
-  version "5.41.0"
-  resolved "https://registry.yarnpkg.com/@grafana/scenes/-/scenes-5.41.0.tgz#851592266314634c2f3daa13c5b984969993b5d5"
-  integrity sha512-UQp92fCdPhn280H5ZjKo7KQ0OWla9QIP7zfC/hmpBqzNtpD20BUCPEBDcmFEkJ1PUxv49hH2F9aQ0NfOmUJI4g==
+"@grafana/scenes@5.41.1":
+  version "5.41.1"
+  resolved "https://registry.yarnpkg.com/@grafana/scenes/-/scenes-5.41.1.tgz#83df1990afdb2aacdaf411685f887b73066caabf"
+  integrity sha512-wXVDYMAD4Eio8+Da84J0lYWmU5GciRPoZjJvRA5JqlPQFegbxy8VynZzepwrO3SSB56VAkQAstsJdqCwjuMzzw==
   dependencies:
     "@floating-ui/react" "^0.26.16"
     "@leeoniya/ufuzzy" "^1.0.16"


### PR DESCRIPTION
Upgrading scenes to get https://github.com/grafana/scenes/pull/1039 which fixes a bug that prevented panels from being hidden in Firefox.

This is the broken behavior where empty panels are shown, but they should be hidden:
![image](https://github.com/user-attachments/assets/aa38ebd1-bc07-4bda-8f87-28cef788d04d)
