### PR TITLE
fix: add default `level` label name for volume panel in investigations

### DIFF
--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -94,7 +94,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       .setTitle(this.getTitle(serviceScene.state.totalLogsCount, serviceScene.state.logsCount))
       .setOption('legend', { showLegend: true, calcs: ['sum'], displayMode: LegendDisplayMode.List })
       .setUnit('short')
-      .setMenu(new PanelMenu({}))
+      .setMenu(new PanelMenu({ labelName: 'level' }))
       .setCollapsible(true)
       .setCollapsed(Boolean(getLogsVolumeOption('collapsed')))
       .setHeaderActions(new LogsVolumeActions({}))


### PR DESCRIPTION
Adding a collectable from the volume panel would add it with an `undefined` name. This changes the name to default to `level`.