### PR TITLE
Fields: Regex - Operator UI updates and double-quotes

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -350,7 +350,12 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
       const uninterpolatedExpression = this.getFieldsTagValuesExpression(variableType);
       const expr = uninterpolatedExpression.replace(PENDING_FIELDS_EXPR, otherFiltersString);
       const interpolated = sceneGraph.interpolate(this, expr);
-      return getFieldsKeysProvider(interpolated, this, sceneGraph.getTimeRange(this).state.value, variableType);
+      return getFieldsKeysProvider({
+        expr: interpolated,
+        sceneRef: this,
+        timeRange: sceneGraph.getTimeRange(this).state.value,
+        variableType,
+      });
     };
   }
 

--- a/src/Components/IndexScene/LayoutScene.tsx
+++ b/src/Components/IndexScene/LayoutScene.tsx
@@ -1,21 +1,22 @@
 import { GrafanaTheme2 } from '@grafana/data';
-import { SceneComponentProps, SceneFlexLayout, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import { SceneComponentProps, sceneGraph, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 import React from 'react';
-import { PatternControls } from './PatternControls';
-import { AppliedPattern, IndexScene, IndexSceneState } from './IndexScene';
-import { css, cx } from '@emotion/css';
-import { GiveFeedbackButton } from './GiveFeedbackButton';
+import { IndexScene } from './IndexScene';
+import { css } from '@emotion/css';
 import { InterceptBanner } from './InterceptBanner';
 
 import { PLUGIN_ID } from '../../services/plugin';
-import { CustomVariableValueSelectors } from './CustomVariableValueSelectors';
 import { logger } from '../../services/logger';
 import { LineFilterVariablesScene } from './LineFilterVariablesScene';
+import { VariableLayoutScene } from './VariableLayoutScene';
+import { LevelsVariableScene } from './LevelsVariableScene';
 
 interface LayoutSceneState extends SceneObjectState {
   interceptDismissed: boolean;
   lineFilterRenderer?: LineFilterVariablesScene;
+  levelsRenderer?: LevelsVariableScene;
+  variableLayout?: SceneObject;
 }
 
 const interceptBannerStorageKey = `${PLUGIN_ID}.interceptBannerStorageKey`;
@@ -23,10 +24,13 @@ const interceptBannerStorageKey = `${PLUGIN_ID}.interceptBannerStorageKey`;
 export const CONTROLS_VARS_FIRST_ROW_KEY = 'vars-row__datasource-labels-timepicker-button';
 export const CONTROLS_VARS_METADATA_ROW_KEY = 'vars-metadata';
 export const CONTROLS_VARS_LEVELS_ROW_KEY = 'vars-levels';
-export const CONTROLS_VARS_FIELDS_ELSE_KEY = 'vars-all-else';
+export const CONTROLS_VARS_FIELDS = 'vars-fields';
+export const CONTROLS_VARS_FIELDS_COMBINED = 'vars-fields-metadata';
 export const CONTROLS_VARS_TIMEPICKER = 'vars-timepicker';
 export const CONTROLS_VARS_REFRESH = 'vars-refresh';
 export const CONTROLS_VARS_TOOLBAR = 'vars-toolbar';
+export const CONTROLS_VARS_DATASOURCE = 'vars-ds';
+export const CONTROLS_VARS_LABELS = 'vars-labels';
 
 export class LayoutScene extends SceneObjectBase<LayoutSceneState> {
   constructor(state: Partial<LayoutSceneState>) {
@@ -40,8 +44,8 @@ export class LayoutScene extends SceneObjectBase<LayoutSceneState> {
 
   static Component = ({ model }: SceneComponentProps<LayoutScene>) => {
     const indexScene = sceneGraph.getAncestor(model, IndexScene);
-    const { controls, contentScene, patterns } = indexScene.useState();
-    const { interceptDismissed, lineFilterRenderer } = model.useState();
+    const { contentScene } = indexScene.useState();
+    const { interceptDismissed, variableLayout } = model.useState();
 
     if (!contentScene) {
       logger.warn('content scene not defined');
@@ -59,91 +63,8 @@ export class LayoutScene extends SceneObjectBase<LayoutSceneState> {
               }}
             />
           )}
-          <div className={styles.controlsContainer}>
-            <>
-              {/* First row - datasource, timepicker, refresh, labels, button */}
-              {controls && (
-                <div className={styles.controlsFirstRowContainer}>
-                  <div className={styles.filtersWrap}>
-                    <div className={cx(styles.filters, styles.firstRowWrapper)}>
-                      {controls.map((control) => {
-                        return control instanceof SceneFlexLayout ? (
-                          <control.Component key={control.state.key} model={control} />
-                        ) : null;
-                      })}
-                    </div>
-                  </div>
-                  <div className={styles.controlsWrapper}>
-                    <GiveFeedbackButton />
-                    <div className={styles.controls}>
-                      {controls.map((control) => {
-                        return !(control instanceof CustomVariableValueSelectors) &&
-                          !(control instanceof SceneFlexLayout) ? (
-                          <control.Component key={control.state.key} model={control} />
-                        ) : null;
-                      })}
-                    </div>
-                  </div>
-                </div>
-              )}
 
-              {/* Second row - Levels  */}
-              <div className={styles.controlsRowContainer}>
-                {controls &&
-                  controls.map((control) => {
-                    return control.state.key === CONTROLS_VARS_LEVELS_ROW_KEY ? (
-                      <div key={control.state.key} className={styles.filtersWrap}>
-                        <div className={styles.filters}>
-                          <control.Component model={control} />
-                        </div>
-                      </div>
-                    ) : null;
-                  })}
-              </div>
-
-              {/* 3rd row - Metadata  */}
-              <div className={styles.controlsRowContainer}>
-                {controls &&
-                  controls.map((control) => {
-                    return control.state.key === CONTROLS_VARS_METADATA_ROW_KEY ? (
-                      <div key={control.state.key} className={styles.filtersWrap}>
-                        <div className={styles.filters}>
-                          <control.Component model={control} />
-                        </div>
-                      </div>
-                    ) : null;
-                  })}
-              </div>
-
-              {/* 4th row - Patterns */}
-              <div className={styles.controlsRowContainer}>
-                <PatternControls
-                  patterns={patterns}
-                  onRemove={(patterns: AppliedPattern[]) => model.parent?.setState({ patterns } as IndexSceneState)}
-                />
-              </div>
-
-              {/* 5th row - line filters */}
-              <div className={styles.controlsRowContainer}>
-                {lineFilterRenderer && <lineFilterRenderer.Component model={lineFilterRenderer} />}
-              </div>
-
-              {/* 6th row - Fields  */}
-              <div className={styles.controlsRowContainer}>
-                {controls && (
-                  <div className={styles.filtersWrap}>
-                    <div className={styles.filters}>
-                      {controls.map((control) => {
-                        return control.state.key === CONTROLS_VARS_FIELDS_ELSE_KEY ? (
-                          <control.Component key={control.state.key} model={control} />
-                        ) : null;
-                      })}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </>
-          </div>
+          {variableLayout && <variableLayout.Component model={variableLayout} />}
 
           {/* Final "row" - body */}
           <div className={styles.body}>{contentScene && <contentScene.Component model={contentScene} />}</div>
@@ -155,6 +76,8 @@ export class LayoutScene extends SceneObjectBase<LayoutSceneState> {
   public onActivate() {
     this.setState({
       lineFilterRenderer: new LineFilterVariablesScene({}),
+      levelsRenderer: new LevelsVariableScene({}),
+      variableLayout: new VariableLayoutScene({}),
     });
   }
 
@@ -168,22 +91,6 @@ export class LayoutScene extends SceneObjectBase<LayoutSceneState> {
 
 function getStyles(theme: GrafanaTheme2) {
   return {
-    firstRowWrapper: css({
-      '& > div > div': {
-        gap: '16px',
-        label: 'first-row-wrapper',
-
-        [theme.breakpoints.down('lg')]: {
-          flexDirection: 'column',
-        },
-
-        // The datasource variable width should be auto, not fill the section
-        '& > div:first-child': {
-          flex: '1 0 auto',
-          display: 'inline-block',
-        },
-      },
-    }),
     bodyContainer: css({
       flexGrow: 1,
       display: 'flex',
@@ -199,110 +106,17 @@ function getStyles(theme: GrafanaTheme2) {
       maxWidth: '100vw',
     }),
     body: css({
+      label: 'body-wrapper',
       flexGrow: 1,
       display: 'flex',
       flexDirection: 'column',
       gap: theme.spacing(1),
-    }),
-    controlsFirstRowContainer: css({
-      label: 'controls-first-row',
-      display: 'flex',
-      gap: theme.spacing(2),
-      justifyContent: 'space-between',
-      alignItems: 'flex-start',
-    }),
-    controlsRowContainer: css({
-      '&:empty': {
-        display: 'none',
-      },
-      label: 'controls-row',
-      display: 'flex',
-      // @todo add custom renderers for all variables, this currently results in 2 "empty" rows that always take up space
-      gap: theme.spacing(1),
-      justifyContent: 'space-between',
-      alignItems: 'flex-start',
-      paddingLeft: theme.spacing(2),
     }),
     controlsContainer: css({
       label: 'controlsContainer',
       display: 'flex',
       flexDirection: 'column',
       gap: theme.spacing(1),
-    }),
-    filters: css({
-      label: 'filters',
-      display: 'flex',
-    }),
-    filtersWrap: css({
-      label: 'filtersWrap',
-      display: 'flex',
-      gap: theme.spacing(2),
-      width: 'calc(100% - 450)',
-      flexWrap: 'wrap',
-      alignItems: 'flex-end',
-      '& + div[data-testid="data-testid Dashboard template variables submenu Label Filters"]:empty': {
-        visibility: 'hidden',
-      },
-
-      //@todo not like this
-      // The filter variables container: i.e. services, filters
-      // '& > div &:first-child': {
-      //   // The wrapper of each filter
-      //   '& > div': {
-      //     // The actual inputs container
-      //     '& > div': {
-      //       flexWrap: 'wrap',
-      //       // wrapper around all inputs
-      //       '& > div': {
-      //         maxWidth: '380px',
-      //
-      //         // Wrapper around each input: i.e. label name, binary operator, value
-      //         '& > div': {
-      //           // These inputs need to flex, otherwise the value takes all of available space and they look broken
-      //           flex: '1 0 auto',
-      //
-      //           // The value input needs to shrink when the parent component is at max width
-      //           '&:nth-child(3)': {
-      //             flex: '0 1 auto',
-      //           },
-      //         },
-      //       },
-      //     },
-      //   },
-      // },
-      // the `service_name` filter is a special case where we want to hide the operator
-      // '[data-testid="AdHocFilter-service_name"]': {
-      //   'div[class*="input-wrapper"]:first-child': {
-      //     display: 'none',
-      //   },
-      //   'div[class*="input-wrapper"]:nth-child(2)': {
-      //     marginLeft: 0,
-      //   },
-      // },
-
-      // ['div >[title="Add filter"]']: {
-      //   border: 0,
-      //   display: 'none',
-      //   width: 0,
-      //   padding: 0,
-      //   margin: 0,
-      // },
-    }),
-    controlsWrapper: css({
-      label: 'controlsWrapper',
-      display: 'flex',
-      flexDirection: 'column',
-      marginTop: theme.spacing(0.375),
-    }),
-    controls: css({
-      display: 'flex',
-      gap: theme.spacing(1),
-    }),
-    feedback: css({
-      textAlign: 'end',
-    }),
-    rotateIcon: css({
-      svg: { transform: 'rotate(180deg)' },
     }),
   };
 }

--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -1,0 +1,204 @@
+import {
+  ControlsLabel,
+  SceneComponentProps,
+  SceneObjectBase,
+  SceneObjectState,
+  SceneVariableValueChangedEvent,
+} from '@grafana/scenes';
+import React from 'react';
+import { getLevelsVariable } from '../../services/variableGetters';
+import { GrafanaTheme2, MetricFindValue, SelectableValue } from '@grafana/data';
+import { css } from '@emotion/css';
+import { Icon, MultiSelect, useStyles2 } from '@grafana/ui';
+import { LEVEL_VARIABLE_VALUE } from '../../services/variables';
+import { FilterOp } from '../../services/filterTypes';
+import { testIds } from '../../services/testIds';
+
+type ChipOption = MetricFindValue & { selected?: boolean };
+export interface LevelsVariableSceneState extends SceneObjectState {
+  options?: ChipOption[];
+  isLoading: boolean;
+  visible: boolean;
+  isOpen: boolean;
+}
+export const LEVELS_VARIABLE_SCENE_KEY = 'levels-var-custom-renderer';
+export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneState> {
+  constructor(state: Partial<LevelsVariableSceneState>) {
+    super({ ...state, isLoading: false, visible: false, key: LEVELS_VARIABLE_SCENE_KEY, isOpen: false });
+
+    this.addActivationHandler(this.onActivate.bind(this));
+  }
+
+  onActivate() {
+    this.onFilterChange();
+    const levelsVar = getLevelsVariable(this);
+    levelsVar.subscribeToEvent(SceneVariableValueChangedEvent, () => this.onFilterChange());
+  }
+
+  private onFilterChange() {
+    const levelsVar = getLevelsVariable(this);
+    if (levelsVar.state.filters.length) {
+      this.setState({
+        options: levelsVar.state.filters.map((filter) => ({
+          text: filter.valueLabels?.[0] ?? filter.value,
+          selected: true,
+          value: filter.value,
+        })),
+      });
+    }
+  }
+
+  getTagValues = () => {
+    this.setState({ isLoading: true });
+    const levelsVar = getLevelsVariable(this);
+    const levelsKeys = levelsVar?.state?.getTagValuesProvider?.(
+      levelsVar,
+      levelsVar.state.filters[0] ?? { key: LEVEL_VARIABLE_VALUE }
+    );
+    levelsKeys?.then((response) => {
+      if (Array.isArray(response.values)) {
+        this.setState({
+          isLoading: false,
+          options: response.values.map((value) => {
+            return {
+              text: value.text,
+              value: value.value ?? value.text,
+              selected: levelsVar.state.filters.some((filter) => filter.value === value.text),
+            };
+          }),
+        });
+      }
+    });
+  };
+
+  updateFilters = (skipPublish: boolean, forcePublish?: boolean) => {
+    const levelsVar = getLevelsVariable(this);
+    const filterOptions = this.state.options?.filter((opt) => opt.selected);
+
+    levelsVar.updateFilters(
+      filterOptions?.map((filterOpt) => ({
+        key: LEVEL_VARIABLE_VALUE,
+        operator: FilterOp.Equal,
+        value: filterOpt.text,
+      })) ?? [],
+      { skipPublish, forcePublish }
+    );
+  };
+
+  onChangeOptions = (options: SelectableValue[]) => {
+    this.setState({
+      options: this.state.options?.map((value) => {
+        if (options.some((opt) => opt.value === value.value)) {
+          return { ...value, selected: true };
+        }
+        return { ...value, selected: false };
+      }),
+    });
+
+    if (!this.state.isOpen) {
+      this.updateFilters(false);
+    } else {
+      this.updateFilters(true);
+    }
+  };
+
+  openSelect = (isOpen: boolean) => {
+    this.setState({ isOpen });
+  };
+
+  onCloseMenu = () => {
+    this.openSelect(false);
+    // Update filters and run queries on close
+    this.updateFilters(false, true);
+  };
+
+  static Component = ({ model }: SceneComponentProps<LevelsVariableScene>) => {
+    const { options, isLoading, visible, isOpen } = model.useState();
+    const styles = useStyles2(getStyles);
+
+    if (!visible) {
+      return null;
+    }
+
+    return (
+      <div data-testid={testIds.variables.levels.inputWrap}>
+        <ControlsLabel layout="vertical" label={'Log levels'} />
+        <MultiSelect
+          aria-label={'Log level filters'}
+          prefix={<Icon size={'lg'} name={'filter'} />}
+          placeholder={'All levels'}
+          className={styles.flex}
+          onChange={model.onChangeOptions}
+          onCloseMenu={() => model.onCloseMenu()}
+          onOpenMenu={model.getTagValues}
+          onFocus={() => model.openSelect(true)}
+          menuShouldPortal={true}
+          isOpen={isOpen}
+          isLoading={isLoading}
+          isClearable={true}
+          blurInputOnSelect={false}
+          closeMenuOnSelect={false}
+          openMenuOnFocus={true}
+          showAllSelectedWhenOpen={true}
+          hideSelectedOptions={false}
+          value={options?.filter((v) => v.selected)}
+          options={options?.map((val) => ({
+            value: val.text,
+            label: val.text,
+          }))}
+        />
+      </div>
+    );
+  };
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  flex: css({
+    flex: '1',
+  }),
+  removeButton: css({
+    marginInline: theme.spacing(0.5),
+    cursor: 'pointer',
+    '&:hover': {
+      color: theme.colors.text.primary,
+    },
+  }),
+  pillText: css({
+    maxWidth: '200px',
+    width: '100%',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+  }),
+  tooltipText: css({
+    textAlign: 'center',
+  }),
+  comboboxWrapper: css({
+    display: 'flex',
+    flexWrap: 'nowrap',
+    alignItems: 'center',
+    columnGap: theme.spacing(1),
+    rowGap: theme.spacing(0.5),
+    minHeight: theme.spacing(4),
+    backgroundColor: theme.components.input.background,
+    border: `1px solid ${theme.colors.border.strong}`,
+    borderRadius: theme.shape.radius.default,
+    paddingInline: theme.spacing(1),
+    paddingBlock: theme.spacing(0.5),
+    flexGrow: 1,
+  }),
+  comboboxFocusOutline: css({
+    '&:focus-within': {
+      outline: '2px dotted transparent',
+      outlineOffset: '2px',
+      boxShadow: `0 0 0 2px ${theme.colors.background.canvas}, 0 0 0px 4px ${theme.colors.primary.main}`,
+      transitionTimingFunction: `cubic-bezier(0.19, 1, 0.22, 1)`,
+      transitionDuration: '0.2s',
+      transitionProperty: 'outline, outline-offset, box-shadow',
+      zIndex: 2,
+    },
+  }),
+  filterIcon: css({
+    color: theme.colors.text.secondary,
+    alignSelf: 'center',
+  }),
+});

--- a/src/Components/IndexScene/VariableLayoutScene.tsx
+++ b/src/Components/IndexScene/VariableLayoutScene.tsx
@@ -1,0 +1,197 @@
+import { SceneComponentProps, SceneFlexLayout, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import React from 'react';
+import { css, cx } from '@emotion/css';
+import { GiveFeedbackButton } from './GiveFeedbackButton';
+import { CustomVariableValueSelectors } from './CustomVariableValueSelectors';
+import { PatternControls } from './PatternControls';
+import { AppliedPattern, IndexScene } from './IndexScene';
+import { CONTROLS_VARS_DATASOURCE, CONTROLS_VARS_FIELDS_COMBINED, LayoutScene } from './LayoutScene';
+import { useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+
+interface VariableLayoutSceneState extends SceneObjectState {}
+export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneState> {
+  static Component = ({ model }: SceneComponentProps<VariableLayoutScene>) => {
+    const indexScene = sceneGraph.getAncestor(model, IndexScene);
+    const { controls, patterns } = indexScene.useState();
+
+    const layoutScene = sceneGraph.getAncestor(model, LayoutScene);
+    const { lineFilterRenderer, levelsRenderer } = layoutScene.useState();
+
+    const styles = useStyles2(getStyles);
+
+    return (
+      <div className={styles.controlsContainer}>
+        <>
+          {/* First row - datasource, timepicker, refresh, labels, button */}
+          {controls && (
+            <div className={styles.controlsFirstRowContainer}>
+              <div className={styles.filtersWrap}>
+                <div className={cx(styles.filters, styles.firstRowWrapper)}>
+                  {controls.map((control) => {
+                    return control instanceof SceneFlexLayout ? (
+                      <control.Component key={control.state.key} model={control} />
+                    ) : null;
+                  })}
+                </div>
+              </div>
+              <div className={styles.controlsWrapper}>
+                <GiveFeedbackButton />
+                <div className={styles.timeRangeDatasource}>
+                  {controls.map((control) => {
+                    return control.state.key === CONTROLS_VARS_DATASOURCE ? (
+                      <control.Component key={control.state.key} model={control} />
+                    ) : null;
+                  })}
+
+                  <div className={styles.timeRange}>
+                    {controls.map((control) => {
+                      return !(control instanceof CustomVariableValueSelectors) &&
+                        !(control instanceof SceneFlexLayout) ? (
+                        <control.Component key={control.state.key} model={control} />
+                      ) : null;
+                    })}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Second row - Levels - custom renderer */}
+          <div className={styles.controlsRowContainer}>
+            {levelsRenderer && <levelsRenderer.Component model={levelsRenderer} />}
+          </div>
+
+          {/* 3rd row - Combined fields (fields + metadata)  */}
+          <div className={styles.controlsRowContainer}>
+            {controls && (
+              <div className={styles.filtersWrap}>
+                <div className={styles.filters}>
+                  {controls.map((control) => {
+                    return control instanceof CustomVariableValueSelectors &&
+                      control.state.key === CONTROLS_VARS_FIELDS_COMBINED ? (
+                      <control.Component key={control.state.key} model={control} />
+                    ) : null;
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* 4th row - Patterns */}
+          <div className={styles.controlsRowContainer}>
+            <PatternControls
+              patterns={patterns}
+              onRemove={(patterns: AppliedPattern[]) => indexScene.setState({ patterns })}
+            />
+          </div>
+
+          {/* 5th row - Line filters - custom renderer */}
+          <div className={styles.controlsRowContainer}>
+            {lineFilterRenderer && <lineFilterRenderer.Component model={lineFilterRenderer} />}
+          </div>
+        </>
+      </div>
+    );
+  };
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    firstRowWrapper: css({
+      '& > div > div': {
+        gap: '16px',
+        label: 'first-row-wrapper',
+
+        [theme.breakpoints.down('lg')]: {
+          flexDirection: 'column',
+        },
+      },
+    }),
+    bodyContainer: css({
+      flexGrow: 1,
+      display: 'flex',
+      minHeight: '100%',
+      flexDirection: 'column',
+    }),
+    container: css({
+      flexGrow: 1,
+      display: 'flex',
+      minHeight: '100%',
+      flexDirection: 'column',
+      padding: theme.spacing(2),
+      maxWidth: '100vw',
+    }),
+    body: css({
+      flexGrow: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+    }),
+    controlsFirstRowContainer: css({
+      label: 'controls-first-row',
+      display: 'flex',
+      gap: theme.spacing(2),
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+    }),
+    controlsRowContainer: css({
+      '&:empty': {
+        display: 'none',
+      },
+      label: 'controls-row',
+      display: 'flex',
+      // @todo add custom renderers for all variables, this currently results in 2 "empty" rows that always take up space
+      gap: theme.spacing(1),
+      alignItems: 'flex-start',
+      paddingLeft: theme.spacing(2),
+    }),
+    controlsContainer: css({
+      label: 'controlsContainer',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+    }),
+    filters: css({
+      label: 'filters',
+      display: 'flex',
+    }),
+    filtersWrap: css({
+      label: 'filtersWrap',
+      display: 'flex',
+      gap: theme.spacing(2),
+      width: 'calc(100% - 450)',
+      flexWrap: 'wrap',
+      alignItems: 'flex-end',
+    }),
+    controlsWrapper: css({
+      label: 'controlsWrapper',
+      display: 'flex',
+      flexDirection: 'column',
+      marginTop: theme.spacing(0.375),
+    }),
+    timeRangeDatasource: css({
+      label: 'timeRangeDatasource',
+      display: 'flex',
+      gap: theme.spacing(1),
+      flexWrap: 'wrap',
+      justifyContent: 'flex-end',
+    }),
+    timeRange: css({
+      label: 'timeRange',
+      display: 'flex',
+      flexDirection: 'row',
+      gap: theme.spacing(1),
+    }),
+    controls: css({
+      display: 'flex',
+      gap: theme.spacing(1),
+    }),
+    feedback: css({
+      textAlign: 'end',
+    }),
+    rotateIcon: css({
+      svg: { transform: 'rotate(180deg)' },
+    }),
+  };
+}

--- a/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.test.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.test.tsx
@@ -4,8 +4,16 @@ import { addAdHocFilter, addToFilters, AddToFiltersButton, FilterType } from './
 import { BusEvent, createDataFrame, Field, FieldType, LoadingState, PanelData } from '@grafana/data';
 import userEvent from '@testing-library/user-event';
 import { AdHocFiltersVariable, sceneGraph, SceneObject, SceneQueryRunner } from '@grafana/scenes';
-import { FieldValue, LEVEL_VARIABLE_VALUE, VAR_FIELDS, VAR_LABELS, VAR_LEVELS } from 'services/variables';
+import {
+  FieldValue,
+  LEVEL_VARIABLE_VALUE,
+  VAR_FIELDS,
+  VAR_FIELDS_AND_METADATA,
+  VAR_LABELS,
+  VAR_LEVELS,
+} from 'services/variables';
 import { ServiceScene, ServiceSceneState } from '../ServiceScene';
+
 jest.mock('services/favorites', () => {
   return {
     rerenderFavorites: () => {},
@@ -65,7 +73,7 @@ describe('AddToFiltersButton', () => {
           },
         ],
       }),
-      variableName: 'fields',
+      variableName: VAR_LEVELS,
     });
     const lookup = jest.spyOn(sceneGraph, 'lookupVariable').mockReturnValue(new AdHocFiltersVariable({}));
     render(<button.Component model={button} />);
@@ -140,7 +148,7 @@ describe('addToFilters and addAdHocFilter', () => {
       jest.spyOn(sceneGraph, 'getAncestor').mockReturnValue(serviceScene);
       addToFilters('key', 'value', type as FilterType, scene, VAR_FIELDS);
 
-      expect(lookupVariable).toHaveBeenCalledWith(VAR_FIELDS, expect.anything());
+      expect(lookupVariable).toHaveBeenCalledWith(VAR_FIELDS_AND_METADATA, expect.anything());
       expect(adHocVariable.state.filters).toEqual([
         {
           key: 'existing',
@@ -168,7 +176,7 @@ describe('addToFilters and addAdHocFilter', () => {
       jest.spyOn(sceneGraph, 'getAncestor').mockReturnValue(serviceScene);
       addToFilters('existing', 'existingValue', 'toggle', scene, VAR_FIELDS);
 
-      expect(lookupVariable).toHaveBeenCalledWith(VAR_FIELDS, expect.anything());
+      expect(lookupVariable).toHaveBeenCalledWith(VAR_FIELDS_AND_METADATA, expect.anything());
       expect(adHocVariable.state.filters).toEqual([]);
     });
 
@@ -176,17 +184,14 @@ describe('addToFilters and addAdHocFilter', () => {
       const lookupVariable = jest.spyOn(sceneGraph, 'lookupVariable').mockReturnValue(adHocVariable);
       jest.spyOn(sceneGraph, 'getAncestor').mockReturnValue(serviceScene);
       addToFilters('existing', 'existingValue', 'clear', scene);
-
-      expect(lookupVariable).toHaveBeenCalledWith(VAR_FIELDS, expect.anything());
+      expect(lookupVariable).toHaveBeenCalledWith(VAR_FIELDS_AND_METADATA, expect.anything());
       expect(adHocVariable.state.filters).toEqual([]);
     });
 
     it('allows to specify the variable to write to', () => {
-      const variableName = 'fields';
       const lookupVariable = jest.spyOn(sceneGraph, 'lookupVariable').mockReturnValue(adHocVariable);
-      addToFilters('key', 'value', 'include', scene, variableName);
-
-      expect(lookupVariable).toHaveBeenCalledWith(variableName, expect.anything());
+      addToFilters('key', 'value', 'include', scene, VAR_FIELDS);
+      expect(lookupVariable).toHaveBeenCalledWith(VAR_FIELDS_AND_METADATA, expect.anything());
     });
 
     it('identifies indexed labels and uses the appropriate variable', () => {
@@ -217,7 +222,7 @@ describe('addToFilters and addAdHocFilter', () => {
     it(`uses the correct name when filtering for ${LEVEL_VARIABLE_VALUE}`, () => {
       const lookupVariable = jest.spyOn(sceneGraph, 'lookupVariable').mockReturnValue(adHocVariable);
       jest.spyOn(sceneGraph, 'getAncestor').mockReturnValue(serviceScene);
-      addToFilters(LEVEL_VARIABLE_VALUE, 'info', 'include', scene, VAR_FIELDS);
+      addToFilters(LEVEL_VARIABLE_VALUE, 'info', 'include', scene, VAR_LEVELS);
       expect(lookupVariable).toHaveBeenCalledWith(VAR_LEVELS, expect.anything());
     });
   });
@@ -228,7 +233,7 @@ describe('addToFilters and addAdHocFilter', () => {
       jest.spyOn(sceneGraph, 'getAncestor').mockReturnValue(serviceScene);
       addAdHocFilter({ key: 'key', value: 'value', operator }, scene);
 
-      expect(lookupVariable).toHaveBeenCalledWith(VAR_FIELDS, expect.anything());
+      expect(lookupVariable).toHaveBeenCalledWith(VAR_FIELDS_AND_METADATA, expect.anything());
       expect(adHocVariable.state.filters).toEqual([
         {
           key: 'existing',
@@ -252,12 +257,11 @@ describe('addToFilters and addAdHocFilter', () => {
     });
 
     it('allows to specify the variable to write to', () => {
-      const variableName = 'fields';
       const lookupVariable = jest.spyOn(sceneGraph, 'lookupVariable').mockReturnValue(adHocVariable);
       jest.spyOn(sceneGraph, 'getAncestor').mockReturnValue(serviceScene);
-      addAdHocFilter({ key: 'key', value: 'value', operator: '=' }, scene, variableName);
+      addAdHocFilter({ key: 'key', value: 'value', operator: '=' }, scene, VAR_FIELDS);
 
-      expect(lookupVariable).toHaveBeenCalledWith(variableName, expect.anything());
+      expect(lookupVariable).toHaveBeenCalledWith(VAR_FIELDS_AND_METADATA, expect.anything());
     });
 
     it('identifies indexed labels and uses the appropriate variable', () => {
@@ -287,7 +291,7 @@ describe('addToFilters and addAdHocFilter', () => {
     it(`uses the correct name when filtering for ${LEVEL_VARIABLE_VALUE}`, () => {
       const lookupVariable = jest.spyOn(sceneGraph, 'lookupVariable').mockReturnValue(adHocVariable);
       jest.spyOn(sceneGraph, 'getAncestor').mockReturnValue(serviceScene);
-      addAdHocFilter({ key: LEVEL_VARIABLE_VALUE, value: 'info', operator: '=' }, scene, VAR_FIELDS);
+      addAdHocFilter({ key: LEVEL_VARIABLE_VALUE, value: 'info', operator: '=' }, scene, VAR_LEVELS);
 
       expect(lookupVariable).toHaveBeenCalledWith(VAR_LEVELS, expect.anything());
     });

--- a/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
@@ -4,7 +4,12 @@ import React from 'react';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import { SelectLabelActionScene } from './SelectLabelActionScene';
-import { addNumericFilter, removeFilter, validateVariableNameForField, VariableFilterType } from './AddToFiltersButton';
+import {
+  addNumericFilter,
+  removeFilter,
+  validateVariableNameForField,
+  InterpolatedFilterType,
+} from './AddToFiltersButton';
 import { FilterOp } from '../../../services/filterTypes';
 import { getAdHocFiltersVariable, getValueFromFieldsFilter } from '../../../services/variableGetters';
 import { logger } from '../../../services/logger';
@@ -12,7 +17,7 @@ import { testIds } from '../../../services/testIds';
 
 export interface NumericFilterPopoverSceneState extends SceneObjectState {
   labelName: string;
-  variableType: VariableFilterType;
+  variableType: InterpolatedFilterType;
   gt?: number;
   gte?: boolean;
   lt?: number;

--- a/src/Components/ServiceScene/Breakdowns/SelectLabelActionScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SelectLabelActionScene.tsx
@@ -12,7 +12,7 @@ import { navigateToValueBreakdown } from '../../../services/navigate';
 import { getPrimaryLabelFromUrl, ValueSlugs } from '../../../services/routing';
 import { Button, ButtonGroup, ButtonSelect, IconButton, Popover, PopoverController, useStyles2 } from '@grafana/ui';
 import React, { useRef } from 'react';
-import { addToFilters, clearFilters, VariableFilterType } from './AddToFiltersButton';
+import { addToFilters, clearFilters, InterpolatedFilterType } from './AddToFiltersButton';
 import { EMPTY_VARIABLE_VALUE, LEVEL_VARIABLE_VALUE, VAR_FIELDS } from '../../../services/variables';
 import { AdHocVariableFilter, Field, GrafanaTheme2, Labels, LoadingState, SelectableValue } from '@grafana/data';
 import {
@@ -55,7 +55,7 @@ export class SelectLabelActionScene extends SceneObjectBase<SelectLabelActionSce
 
   onChange(value: SelectableValue<string>) {
     const variable = this.getVariable();
-    const variableName = variable.state.name as VariableFilterType;
+    const variableName = variable.state.name as InterpolatedFilterType;
     const existingFilter = this.getExistingFilter(variable);
     const fieldValue = getValueFromAdHocVariableFilter(variable, existingFilter);
     const isIncluded = existingFilter?.operator === FilterOp.NotEqual && fieldValue.value === EMPTY_VARIABLE_VALUE;
@@ -87,7 +87,7 @@ export class SelectLabelActionScene extends SceneObjectBase<SelectLabelActionSce
       fieldType,
     } = model.useState();
     const variable = model.getVariable();
-    const variableName = variable.useState().name as VariableFilterType;
+    const variableName = variable.useState().name as InterpolatedFilterType;
     const existingFilter = model.getExistingFilter(variable);
     const fieldValue = getValueFromAdHocVariableFilter(variable, existingFilter);
     const styles = useStyles2(getStyles);
@@ -263,7 +263,7 @@ export class SelectLabelActionScene extends SceneObjectBase<SelectLabelActionSce
     );
   }
 
-  public onClickNumericFilter = (variableType: VariableFilterType) => {
+  public onClickNumericFilter = (variableType: InterpolatedFilterType) => {
     const detectedFieldFrame = getDetectedFieldsFrame(this);
     const fieldType = getDetectedFieldType(this.state.labelName, detectedFieldFrame);
 
@@ -284,20 +284,20 @@ export class SelectLabelActionScene extends SceneObjectBase<SelectLabelActionSce
     navigateToValueBreakdown(this.state.fieldType, this.state.labelName, serviceScene);
   };
 
-  public onClickExcludeEmpty = (variableType: VariableFilterType) => {
+  public onClickExcludeEmpty = (variableType: InterpolatedFilterType) => {
     addToFilters(this.state.labelName, EMPTY_VARIABLE_VALUE, 'exclude', this, variableType);
   };
 
-  public onClickIncludeEmpty = (variableType: VariableFilterType) => {
+  public onClickIncludeEmpty = (variableType: InterpolatedFilterType) => {
     // If json do we want != '{}'?
     addToFilters(this.state.labelName, EMPTY_VARIABLE_VALUE, 'include', this, variableType);
   };
 
-  public clearFilter = (variableType: VariableFilterType) => {
+  public clearFilter = (variableType: InterpolatedFilterType) => {
     addToFilters(this.state.labelName, EMPTY_VARIABLE_VALUE, 'clear', this, variableType);
   };
 
-  public clearFilters = (variableType: VariableFilterType) => {
+  public clearFilters = (variableType: InterpolatedFilterType) => {
     clearFilters(this.state.labelName, this, variableType);
   };
 

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -39,6 +39,7 @@ import { ActionBarScene } from './ActionBarScene';
 import { breakdownViewsDefinitions, TabNames, valueBreakdownViews } from './BreakdownViews';
 import {
   getDataSourceVariable,
+  getFieldsAndMetadataVariable,
   getFieldsVariable,
   getLabelsVariable,
   getLevelsVariable,
@@ -60,6 +61,7 @@ import { ShowLogsButtonScene } from '../IndexScene/ShowLogsButtonScene';
 import { migrateLineFilterV1 } from '../../services/migrations';
 import { isOperatorInclusive } from '../../services/operators';
 import { VariableHide } from '@grafana/schema';
+import { LEVELS_VARIABLE_SCENE_KEY, LevelsVariableScene } from '../IndexScene/LevelsVariableScene';
 
 export const LOGS_PANEL_QUERY_REFID = 'logsPanelQuery';
 export const LOGS_COUNT_QUERY_REFID = 'logsCountQuery';
@@ -263,9 +265,9 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
   };
 
   private showVariables() {
-    getMetadataVariable(this).setState({ hide: VariableHide.dontHide });
-    getLevelsVariable(this).setState({ hide: VariableHide.dontHide });
-    getFieldsVariable(this).setState({ hide: VariableHide.dontHide });
+    const levelsVar = sceneGraph.findByKeyAndType(this, LEVELS_VARIABLE_SCENE_KEY, LevelsVariableScene);
+    levelsVar.setState({ visible: true });
+    getFieldsAndMetadataVariable(this).setState({ hide: VariableHide.dontHide });
   }
 
   /**
@@ -372,12 +374,14 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     });
   }
 
+  /**
+   * Subscribe to SceneVariableValueChangedEvent and run logs count and detectedFields on update.
+   * In the levels variable renderer we update the ad-hoc filters, but we don't always want to immediately execute queries.
+   */
   private subscribeToLevelsVariable() {
-    return getLevelsVariable(this).subscribeToState((newState, prevState) => {
-      if (!areArraysEqual(newState.filters, prevState.filters)) {
-        this.state.$detectedFieldsData?.runQueries();
-        this.state.$logsCount?.runQueries();
-      }
+    return getLevelsVariable(this).subscribeToEvent(SceneVariableValueChangedEvent, () => {
+      this.state.$detectedFieldsData?.runQueries();
+      this.state.$logsCount?.runQueries();
     });
   }
 

--- a/src/services/TagKeysProviders.ts
+++ b/src/services/TagKeysProviders.ts
@@ -1,16 +1,20 @@
 import { logger } from './logger';
 import { LokiDatasource, LokiQuery } from './lokiQuery';
-import { DataSourceGetTagKeysOptions, GetTagResponse, MetricFindValue, TimeRange } from '@grafana/data';
+import {
+  DataSourceGetTagKeysOptions,
+  getDefaultTimeRange,
+  GetTagResponse,
+  KeyValue,
+  MetricFindValue,
+  ScopedVars,
+  TimeRange,
+} from '@grafana/data';
 import { AdHocFiltersVariable, SceneObject } from '@grafana/scenes';
-import { DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
+import { BackendSrvRequest, DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
 import { getDataSource } from './scenes';
 import { LABELS_TO_REMOVE } from './filters';
 import { joinTagFilters } from './query';
-import {
-  DetectedFieldsResult,
-  FetchDetectedFieldsOptions,
-  LokiLanguageProviderWithDetectedLabelValues,
-} from './TagValuesProviders';
+import { DetectedFieldsResult, LokiLanguageProviderWithDetectedLabelValues } from './TagValuesProviders';
 import { LEVEL_VARIABLE_VALUE, VAR_FIELDS, VAR_LEVELS, VAR_METADATA } from './variables';
 
 export async function getLabelsTagKeysProvider(variable: AdHocFiltersVariable): Promise<{
@@ -43,12 +47,23 @@ export async function getLabelsTagKeysProvider(variable: AdHocFiltersVariable): 
   }
 }
 
-export async function getFieldsKeysProvider(
-  expr: string,
-  sceneRef: SceneObject,
-  timeRange: TimeRange,
-  variableType: typeof VAR_FIELDS | typeof VAR_METADATA | typeof VAR_LEVELS,
-): Promise<{
+type DetectedFieldQueryOptions = {
+  expr: string;
+  timeRange?: TimeRange;
+  limit?: number;
+  scopedVars?: ScopedVars;
+  sceneRef: SceneObject;
+  variableType: typeof VAR_FIELDS | typeof VAR_METADATA | typeof VAR_LEVELS;
+};
+
+export async function getFieldsKeysProvider({
+  limit,
+  timeRange,
+  scopedVars,
+  expr,
+  sceneRef,
+  variableType,
+}: DetectedFieldQueryOptions): Promise<{
   replace?: boolean;
   values: MetricFindValue[];
 }> {
@@ -60,13 +75,34 @@ export async function getFieldsKeysProvider(
   const datasource = datasource_ as LokiDatasource;
   const languageProvider = datasource.languageProvider as LokiLanguageProviderWithDetectedLabelValues;
 
-  if (datasource && typeof languageProvider.fetchDetectedFields === 'function') {
-    const options: FetchDetectedFieldsOptions = {
-      expr,
-      timeRange,
+  const options: DetectedFieldQueryOptions = {
+    expr,
+    timeRange,
+    scopedVars,
+    variableType,
+    sceneRef,
+    limit,
+  };
+
+  // @todo delete after min supported grafana is upgraded to >=11.6
+  // see ced526b3e37baded9082ffc3c2378a21201801b6 before this all got messed up
+  const fetchDetectedFieldsFn =
+    (datasource &&
+      typeof languageProvider.fetchDetectedFields === 'function' &&
+      languageProvider.fetchDetectedFields.bind(languageProvider)) ||
+    function (opts: DetectedFieldQueryOptions) {
+      return fetchDetectedFields(datasource, opts);
     };
 
-    const tagKeys: DetectedFieldsResult = await datasource.languageProvider.fetchDetectedFields(options);
+  // fetchDetectedFields did not make the 11.5 cutoff, so is only available in 11.6, to keep this PR from needing to wait for 2 months before release, we're going to copy over the implementation into Explore Logs
+  if (fetchDetectedFieldsFn && typeof fetchDetectedFieldsFn === 'function') {
+    const tagKeys: DetectedFieldsResult | Error = await fetchDetectedFieldsFn(options);
+
+    if (tagKeys instanceof Error) {
+      logger.error(tagKeys, { msg: 'Failed to fetch detected fields' });
+      throw tagKeys;
+    }
+
     const result: MetricFindValue[] = tagKeys
       .filter((field) => {
         if (variableType === VAR_METADATA && field.label !== LEVEL_VARIABLE_VALUE) {
@@ -86,7 +122,7 @@ export async function getFieldsKeysProvider(
           }
 
           const parser = field.parsers?.length === 1 ? field.parsers[0] : 'mixed';
-          const type = field.type
+          const type = field.type;
 
           return {
             text: field.label,
@@ -94,7 +130,7 @@ export async function getFieldsKeysProvider(
             group: parser,
             meta: {
               parser,
-              type
+              type,
             },
           };
         }
@@ -107,4 +143,46 @@ export async function getFieldsKeysProvider(
     logger.error(new Error('getTagKeysProvider: missing or invalid datasource!'));
     return { replace: true, values: [] };
   }
+}
+
+const EMPTY_SELECTOR = '{}';
+// @todo delete after min supported grafana is upgraded to >=11.6
+async function fetchDetectedFields(
+  datasource: LokiDatasource,
+  queryOptions: DetectedFieldQueryOptions,
+  requestOptions?: Partial<BackendSrvRequest>
+): Promise<DetectedFieldsResult | Error> {
+  if (!('interpolateString' in datasource) || typeof datasource?.interpolateString !== 'function') {
+    throw new Error('Datasource missing interpolateString method');
+  }
+
+  const interpolatedExpr =
+    queryOptions.expr && queryOptions.expr !== EMPTY_SELECTOR
+      ? datasource.interpolateString(queryOptions.expr, queryOptions.scopedVars)
+      : undefined;
+
+  if (!interpolatedExpr) {
+    throw new Error('fetchDetectedFields requires query expression');
+  }
+
+  const url = `detected_fields`;
+  const range = queryOptions?.timeRange ?? getDefaultTimeRange();
+  const rangeParams = datasource.getTimeRangeParams(range);
+  const { start, end } = rangeParams;
+  const params: KeyValue<string | number> = { start, end, limit: queryOptions?.limit ?? 1000 };
+  params.query = interpolatedExpr;
+
+  return new Promise(async (resolve, reject) => {
+    try {
+      const data: { limit: number; fields: DetectedFieldsResult } = await datasource.getResource(
+        url,
+        params,
+        requestOptions
+      );
+      resolve(data.fields);
+    } catch (error) {
+      console.error('error', error);
+      reject(error);
+    }
+  });
 }

--- a/src/services/datasource.test.ts
+++ b/src/services/datasource.test.ts
@@ -32,6 +32,8 @@ let datasource = new DataSourceWithBackend<LokiQuery>({
   readOnly: false,
   uid: '',
 }) as LokiDatasource;
+datasource.interpolateString = (s) => s;
+datasource.getTimeRangeParams = () => ({ start: 0, end: 0 });
 
 jest.mock('./scenes', () => ({
   ...jest.requireActual('./scenes'),

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -320,10 +320,8 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
         }
       );
 
-      const { labelName: primaryLabelName } = getPrimaryLabelFromUrl();
-
       const labels = response.detectedLabels
-        ?.filter((label) => primaryLabelName !== label.label && !LABELS_TO_REMOVE.includes(label.label))
+        ?.filter((label) => !LABELS_TO_REMOVE.includes(label.label))
         ?.sort((a, b) => sortLabelsByCardinality(a, b));
 
       const detectedLabelFields: Array<Partial<Field>> = labels?.map((label) => {

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -13,7 +13,6 @@ import { RuntimeDataSource, sceneUtils } from '@grafana/scenes';
 import { DataQuery, LogsSortOrder } from '@grafana/schema';
 import { Observable, Subscriber } from 'rxjs';
 import { getDataSource } from './scenes';
-import { getPrimaryLabelFromUrl } from './routing';
 import { DetectedFieldsResponse, DetectedLabelsResponse } from './fields';
 import { FIELDS_TO_REMOVE, LABELS_TO_REMOVE, sortLabelsByCardinality } from './filters';
 import { SERVICE_NAME } from './variables';
@@ -87,7 +86,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
       getDataSourceSrv()
         .get(getDataSource(request.scopedVars.__sceneObject.valueOf()))
         .then(async (ds) => {
-          if (!(ds instanceof DataSourceWithBackend)) {
+          if (!(ds instanceof DataSourceWithBackend) || !('interpolateString' in ds) || !('getTimeRangeParams' in ds)) {
             throw new Error('Invalid datasource!');
           }
 

--- a/src/services/expressions.ts
+++ b/src/services/expressions.ts
@@ -1,10 +1,14 @@
 import {
+  DETECTED_FIELD_AND_METADATA_VALUES_EXPR,
+  DETECTED_LEVELS_VALUES_EXPR,
   JSON_FORMAT_EXPR,
   LEVEL_VARIABLE_VALUE,
   LOGS_FORMAT_EXPR,
   MIXED_FORMAT_EXPR,
+  VAR_FIELDS_AND_METADATA,
   VAR_FIELDS_EXPR,
   VAR_LABELS_EXPR,
+  VAR_LEVELS,
   VAR_LINE_FILTERS_EXPR,
   VAR_METADATA_EXPR,
   VAR_PATTERNS_EXPR,
@@ -12,6 +16,8 @@ import {
 import { SceneObject } from '@grafana/scenes';
 import { getParserFromFieldsFilters } from './fields';
 import { getFieldsVariable } from './variableGetters';
+import { UIVariableFilterType } from '../Components/ServiceScene/Breakdowns/AddToFiltersButton';
+import { logger } from './logger';
 
 /**
  * Crafts count over time query that excludes empty values for stream selector name
@@ -47,4 +53,24 @@ export function getTimeSeriesExpr(sceneRef: SceneObject, streamSelectorName: str
     }
   }
   return `sum(count_over_time({${VAR_LABELS_EXPR}} ${metadataExpressionToAdd} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${VAR_FIELDS_EXPR} [$__auto])) by (${streamSelectorName})`;
+}
+
+/**
+ * Get expressions for UI variables
+ * @param variableType
+ */
+export function getFieldsTagValuesExpression(variableType: UIVariableFilterType) {
+  switch (variableType) {
+    case VAR_LEVELS:
+      return DETECTED_LEVELS_VALUES_EXPR;
+    case VAR_FIELDS_AND_METADATA:
+      return DETECTED_FIELD_AND_METADATA_VALUES_EXPR;
+    default:
+      const error = new Error(`Unknown variable type: ${variableType}`);
+      logger.error(error, {
+        variableType,
+        msg: `getFieldsTagValuesExpression: Unknown variable type: ${variableType}`,
+      });
+      throw error;
+  }
 }

--- a/src/services/fields.ts
+++ b/src/services/fields.ts
@@ -7,7 +7,7 @@ import {
   SceneDataTransformer,
   SceneObject,
 } from '@grafana/scenes';
-import { AddToFiltersButton, VariableFilterType } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
+import { AddToFiltersButton, InterpolatedFilterType } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
 import {
   DetectedFieldType,
   LEVEL_VARIABLE_VALUE,
@@ -197,7 +197,7 @@ export function getVariableForLabel(
   frame: DataFrame | undefined,
   key: string,
   sceneRef: SceneObject
-): VariableFilterType {
+): InterpolatedFilterType {
   const labelType = frame ? getLabelTypeFromFrame(key, frame) : LabelType.Parsed;
 
   if (labelType) {
@@ -219,7 +219,7 @@ export function getVariableForLabel(
   return VAR_FIELDS;
 }
 
-export function getFilterTypeFromLabelType(type: LabelType, key: string): VariableFilterType {
+export function getFilterTypeFromLabelType(type: LabelType, key: string): InterpolatedFilterType {
   switch (type) {
     case LabelType.Indexed: {
       return VAR_LABELS;

--- a/src/services/filters.ts
+++ b/src/services/filters.ts
@@ -1,6 +1,6 @@
 import { DetectedLabel } from './fields';
 import { ALL_VARIABLE_VALUE, LEVEL_VARIABLE_VALUE } from './variables';
-import { VariableValueOption } from '@grafana/scenes';
+import { AdHocFilterWithLabels, VariableValueOption } from '@grafana/scenes';
 
 // We want to show labels with cardinality 1 at the end of the list because they are less useful
 // And then we want to sort by cardinality - from lowest to highest
@@ -41,4 +41,9 @@ export function getFieldOptions(labels: string[]) {
   }));
 
   return [{ label: 'All', value: ALL_VARIABLE_VALUE }, ...labelOptions];
+}
+
+// Since "meta" is not saved in the URL state, it's ephemeral and can only be used for wip keys, but we can differentiate fields from metadata if the value is not encoded (and therefore different then the label)
+export function isFilterMetadata(filter: AdHocFilterWithLabels) {
+  return filter.value === filter.valueLabels?.[0];
 }

--- a/src/services/levels.test.ts
+++ b/src/services/levels.test.ts
@@ -297,6 +297,6 @@ describe('toggleLevelFromFilter', () => {
     setup([]);
 
     expect(toggleLevelFromFilter('logs', scene)).toBe('add');
-    expect(replaceFilter).toHaveBeenCalledWith(LEVEL_NAME, '""', 'include', scene);
+    expect(replaceFilter).toHaveBeenCalledWith(LEVEL_NAME, '""', 'include', scene, VAR_LEVELS);
   });
 });

--- a/src/services/levels.ts
+++ b/src/services/levels.ts
@@ -1,6 +1,6 @@
 import { DataFrame } from '@grafana/data';
 import { SeriesVisibilityChangeMode } from '@grafana/ui';
-import { LEVEL_VARIABLE_VALUE } from './variables';
+import { LEVEL_VARIABLE_VALUE, VAR_LEVELS } from './variables';
 import { SceneObject } from '@grafana/scenes';
 import { addToFilters, replaceFilter } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
 import { getLevelsVariable } from './variableGetters';
@@ -102,10 +102,10 @@ export function toggleLevelFromFilter(level: string, sceneRef: SceneObject) {
 
   let action;
   if (empty || !filterExists) {
-    replaceFilter(LEVEL_VARIABLE_VALUE, level, 'include', sceneRef);
+    replaceFilter(LEVEL_VARIABLE_VALUE, level, 'include', sceneRef, VAR_LEVELS);
     action = 'add';
   } else {
-    addToFilters(LEVEL_VARIABLE_VALUE, level, 'toggle', sceneRef);
+    addToFilters(LEVEL_VARIABLE_VALUE, level, 'toggle', sceneRef, VAR_LEVELS);
     action = 'remove';
   }
 

--- a/src/services/lokiQuery.ts
+++ b/src/services/lokiQuery.ts
@@ -1,7 +1,7 @@
 // Warning: This file (and any imports) are included in the main bundle with Grafana in order to provide link extension support in Grafana core, in an effort to keep Grafana loading quickly, please do not add any unnecessary imports to this file and run the bundle analyzer before committing any changes!
 import { DataSourceRef } from '@grafana/schema';
 import { DataSourceWithBackend } from '@grafana/runtime';
-import { DataFrame, DataSourceJsonData } from '@grafana/data';
+import { DataFrame, DataSourceJsonData, ScopedVars, TimeRange } from '@grafana/data';
 import { LabelType } from './fieldsTypes';
 
 export enum LokiQueryDirection {
@@ -25,7 +25,13 @@ export type LokiQuery = {
 
 export type LokiQueryType = 'instant' | 'range' | 'stream' | string;
 
-export type LokiDatasource = DataSourceWithBackend<LokiQuery, DataSourceJsonData> & { maxLines?: number };
+export type LokiDatasource = DataSourceWithBackend<LokiQuery, DataSourceJsonData> & {
+  maxLines?: number;
+} & // @todo delete after min supported grafana is upgraded to >=11.6
+{
+  interpolateString?: (string: string, scopedVars?: ScopedVars) => string;
+  getTimeRangeParams: (timeRange: TimeRange) => { start: number; end: number };
+};
 
 export function getLabelTypeFromFrame(labelKey: string, frame: DataFrame, index = 0): null | LabelType {
   const typeField = frame.fields.find((field) => field.name === 'labelTypes')?.values[index];

--- a/src/services/migrations.ts
+++ b/src/services/migrations.ts
@@ -3,6 +3,8 @@ import { getLineFiltersVariable } from './variableGetters';
 import { LineFilterCaseSensitive, LineFilterOp } from './filterTypes';
 import { ServiceScene } from '../Components/ServiceScene/ServiceScene';
 import { urlUtil } from '@grafana/data';
+import { sceneGraph } from '@grafana/scenes';
+import { IndexScene } from '../Components/IndexScene/IndexScene';
 
 function removeEscapeChar(value: string, caseSensitive: boolean) {
   const charsEscapedByEscapeRegExp = ['^', '$', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|'];
@@ -36,11 +38,12 @@ export function migrateLineFilterV1(serviceScene: ServiceScene) {
     return;
   }
 
+  const indexScene = sceneGraph.getAncestor(serviceScene, IndexScene);
   const globalLineFilterVars = getLineFiltersVariable(serviceScene);
   const caseSensitiveMatches = deprecatedLineFilter?.match(/\|=.`(.+?)`/);
 
   if (caseSensitiveMatches && caseSensitiveMatches.length === 2) {
-    globalLineFilterVars.addActivationHandler(() => {
+    indexScene.state.body?.state.lineFilterRenderer?.addActivationHandler(() => {
       globalLineFilterVars.setState({
         filters: [
           {
@@ -56,7 +59,7 @@ export function migrateLineFilterV1(serviceScene: ServiceScene) {
 
   const caseInsensitiveMatches = deprecatedLineFilter?.match(/`\(\?i\)(.+)`/);
   if (caseInsensitiveMatches && caseInsensitiveMatches.length === 2) {
-    globalLineFilterVars.addActivationHandler(() => {
+    indexScene.state.body?.state.lineFilterRenderer?.addActivationHandler(() => {
       globalLineFilterVars.updateFilters([
         {
           key: LineFilterCaseSensitive.caseInsensitive,

--- a/src/services/operators.ts
+++ b/src/services/operators.ts
@@ -1,34 +1,50 @@
 import { FilterOp, LineFilterOp } from './filterTypes';
 import { SelectableValue } from '@grafana/data';
+import { logger } from './logger';
 
-// function getOperatorLabel(op: FilterOp): string {
-//   if (op === FilterOp.NotEqual) {
-//     return 'Not equal';
-//   }
-//   if (op === FilterOp.RegexNotEqual) {
-//     return 'Regex: Not equal';
-//   }
-//   if (op === FilterOp.Equal) {
-//     return 'Equal';
-//   }
-//   if (op === FilterOp.RegexEqual) {
-//     return 'Regex: Equal';
-//   }
-//
-//   return op.toString();
-// }
+function getOperatorDescription(op: FilterOp): string {
+  if (op === FilterOp.NotEqual) {
+    return 'Not equal';
+  }
+  if (op === FilterOp.RegexNotEqual) {
+    return 'Does not match regex';
+  }
+  if (op === FilterOp.Equal) {
+    return 'Equals';
+  }
+  if (op === FilterOp.RegexEqual) {
+    return 'Matches regex';
+  }
+  if (op === FilterOp.lt) {
+    return 'Less than';
+  }
+  if (op === FilterOp.gt) {
+    return 'Greater than';
+  }
+  if (op === FilterOp.gte) {
+    return 'Greater than or equal to';
+  }
+  if (op === FilterOp.lte) {
+    return 'Less than or equal to';
+  }
+
+  const error = new Error('Invalid operator!');
+  logger.error(error, { msg: 'Invalid operator', operator: op });
+  throw error;
+}
 
 export const operators = [FilterOp.Equal, FilterOp.NotEqual, FilterOp.RegexEqual, FilterOp.RegexNotEqual].map<
   SelectableValue<string>
 >((value, index, array) => {
   return {
-    // label: getOperatorLabel(value), // @todo return better labels?
-    label: value, // @todo return better labels?
+    description: getOperatorDescription(value),
+    label: value,
     value,
   };
 });
 
 export const includeOperators = [FilterOp.Equal, FilterOp.RegexEqual].map<SelectableValue<string>>((value) => ({
+  description: getOperatorDescription(value),
   label: value,
   value,
 }));
@@ -36,6 +52,7 @@ export const includeOperators = [FilterOp.Equal, FilterOp.RegexEqual].map<Select
 export const numericOperatorArray = [FilterOp.gt, FilterOp.gte, FilterOp.lt, FilterOp.lte];
 
 export const numericOperators = numericOperatorArray.map<SelectableValue<string>>((value) => ({
+  description: getOperatorDescription(value),
   label: value,
   value,
 }));

--- a/src/services/query.test.ts
+++ b/src/services/query.test.ts
@@ -12,7 +12,7 @@ import {
 } from './query';
 
 import { FieldValue } from './variables';
-import { AdHocFiltersVariable } from '@grafana/scenes';
+import { AdHocFiltersVariable, AdHocFilterWithLabels } from '@grafana/scenes';
 import { FilterOp, LineFilterCaseSensitive, LineFilterOp } from './filterTypes';
 
 describe('buildDataQuery', () => {
@@ -177,16 +177,22 @@ describe('renderLogQLFieldFilters', () => {
     expect(renderLogQLFieldFilters(filters)).toEqual('| level=~"info" | cluster=~"lil\\"-cluster"');
   });
   test('Escapes regex', () => {
-    const filters: AdHocVariableFilter[] = [
+    const filters: AdHocFilterWithLabels[] = [
       {
         key: 'host',
         operator: FilterOp.RegexEqual,
-        value: '((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}',
+        value: JSON.stringify({
+          value: '((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}',
+          parser: 'logfmt',
+        } as FieldValue),
       },
       {
         key: 'level',
         operator: FilterOp.RegexEqual,
-        value: 'error',
+        value: JSON.stringify({
+          value: 'error',
+          parser: 'logfmt',
+        } as FieldValue),
       },
     ];
 
@@ -195,7 +201,7 @@ describe('renderLogQLFieldFilters', () => {
     );
   });
   test('Renders negative regex filters', () => {
-    const filters: AdHocVariableFilter[] = [
+    const filters: AdHocFilterWithLabels[] = [
       {
         key: 'level',
         operator: FilterOp.RegexNotEqual,

--- a/src/services/query.test.ts
+++ b/src/services/query.test.ts
@@ -201,7 +201,7 @@ describe('renderLogQLFieldFilters', () => {
     ];
 
     // Filters do not yet support regex operators
-    expect(renderLogQLFieldFilters(filters)).toEqual('');
+    expect(renderLogQLFieldFilters(filters)).toEqual('| level!~`info` | cluster!~`lil-cluster`');
   });
 });
 describe('renderLogQLLineFilter not containing backticks', () => {

--- a/src/services/query.test.ts
+++ b/src/services/query.test.ts
@@ -58,7 +58,7 @@ describe('renderLogQLFieldFilters', () => {
       },
     ];
 
-    expect(renderLogQLFieldFilters(filters)).toEqual('| level=`info` | cluster=`lil-cluster`');
+    expect(renderLogQLFieldFilters(filters)).toEqual('| level="info" | cluster="lil-cluster"');
   });
 
   test('Renders negative filters', () => {
@@ -81,9 +81,8 @@ describe('renderLogQLFieldFilters', () => {
       },
     ];
 
-    expect(renderLogQLFieldFilters(filters)).toEqual('| level!=`info` | cluster!=`lil-cluster`');
+    expect(renderLogQLFieldFilters(filters)).toEqual('| level!="info" | cluster!="lil-cluster"');
   });
-
   test('Groups positive filters', () => {
     const filters: AdHocVariableFilter[] = [
       {
@@ -104,9 +103,8 @@ describe('renderLogQLFieldFilters', () => {
       },
     ];
 
-    expect(renderLogQLFieldFilters(filters)).toEqual('| level=`info` or level=`error`');
+    expect(renderLogQLFieldFilters(filters)).toEqual('| level="info" or level="error"');
   });
-
   test('Renders grouped and ungrouped positive and negative filters', () => {
     const filters: AdHocVariableFilter[] = [
       {
@@ -152,10 +150,9 @@ describe('renderLogQLFieldFilters', () => {
     ];
 
     expect(renderLogQLFieldFilters(filters)).toEqual(
-      '| level=`info` or level=`error` | cluster=`lil-cluster` | component!=`comp1` | pod!=`pod1`'
+      '| level="info" or level="error" | cluster="lil-cluster" | component!="comp1" | pod!="pod1"'
     );
   });
-
   test('Renders positive regex filters', () => {
     const filters: AdHocVariableFilter[] = [
       {
@@ -170,16 +167,33 @@ describe('renderLogQLFieldFilters', () => {
         key: 'cluster',
         operator: FilterOp.RegexEqual,
         value: JSON.stringify({
-          value: 'lil-cluster',
+          value: 'lil"-cluster',
           parser: 'logfmt',
         } as FieldValue),
       },
     ];
 
     // Filters do not yet support regex operators
-    expect(renderLogQLFieldFilters(filters)).toEqual('');
+    expect(renderLogQLFieldFilters(filters)).toEqual('| level=~"info" | cluster=~"lil\\"-cluster"');
   });
+  test('Escapes regex', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'host',
+        operator: FilterOp.RegexEqual,
+        value: '((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}',
+      },
+      {
+        key: 'level',
+        operator: FilterOp.RegexEqual,
+        value: 'error',
+      },
+    ];
 
+    expect(renderLogQLFieldFilters(filters)).toEqual(
+      '| host=~"((25[0-5]|(2[0-4]|1\\\\d|[1-9]|)\\\\d)\\\\.?\\\\b){4}" | level=~"error"'
+    );
+  });
   test('Renders negative regex filters', () => {
     const filters: AdHocVariableFilter[] = [
       {
@@ -200,8 +214,7 @@ describe('renderLogQLFieldFilters', () => {
       },
     ];
 
-    // Filters do not yet support regex operators
-    expect(renderLogQLFieldFilters(filters)).toEqual('| level!~`info` | cluster!~`lil-cluster`');
+    expect(renderLogQLFieldFilters(filters)).toEqual('| level!~"info" | cluster!~"lil-cluster"');
   });
 });
 describe('renderLogQLLineFilter not containing backticks', () => {
@@ -379,7 +392,7 @@ describe('renderLogQLLabelFilters', () => {
       },
     ];
 
-    expect(renderLogQLLabelFilters(filters)).toEqual('level=`info`, cluster=`lil-cluster`');
+    expect(renderLogQLLabelFilters(filters)).toEqual('level="info", cluster="lil-cluster"');
   });
   test('Renders negative filters', () => {
     const filters: AdHocVariableFilter[] = [
@@ -395,7 +408,7 @@ describe('renderLogQLLabelFilters', () => {
       },
     ];
 
-    expect(renderLogQLLabelFilters(filters)).toEqual('level!=`info`, cluster!=`lil-cluster`');
+    expect(renderLogQLLabelFilters(filters)).toEqual('level!="info", cluster!="lil-cluster"');
   });
   test('Groups positive filters', () => {
     const filters: AdHocVariableFilter[] = [
@@ -459,7 +472,7 @@ describe('renderLogQLLabelFilters', () => {
       },
     ];
 
-    expect(renderLogQLLabelFilters(filters)).toEqual('level=~`info`, level!~`error`');
+    expect(renderLogQLLabelFilters(filters)).toEqual('level=~"info", level!~"error"');
   });
   test('Renders grouped and ungrouped positive and negative filters', () => {
     const filters: AdHocVariableFilter[] = [
@@ -491,7 +504,7 @@ describe('renderLogQLLabelFilters', () => {
     ];
 
     expect(renderLogQLLabelFilters(filters)).toEqual(
-      'level=~"info|error", cluster=`lil-cluster`, component!=`comp1`, pod!=`pod1`'
+      'level=~"info|error", cluster="lil-cluster", component!="comp1", pod!="pod1"'
     );
   });
 });
@@ -700,11 +713,11 @@ describe('renderLogQLMetadataFilters', () => {
       {
         key: 'cluster',
         operator: FilterOp.Equal,
-        value: 'lil-cluster',
+        value: 'lil"-cluster',
       },
     ];
 
-    expect(renderLogQLMetadataFilters(filters)).toEqual('| level=`info` | cluster=`lil-cluster`');
+    expect(renderLogQLMetadataFilters(filters)).toEqual('| level="info" | cluster="lil\\"-cluster"');
   });
   test('Renders negative filters', () => {
     const filters: AdHocVariableFilter[] = [
@@ -720,7 +733,7 @@ describe('renderLogQLMetadataFilters', () => {
       },
     ];
 
-    expect(renderLogQLMetadataFilters(filters)).toEqual('| level!=`info` | cluster!=`lil-cluster`');
+    expect(renderLogQLMetadataFilters(filters)).toEqual('| level!="info" | cluster!="lil-cluster"');
   });
   test('Groups positive filters', () => {
     const filters: AdHocVariableFilter[] = [
@@ -736,7 +749,7 @@ describe('renderLogQLMetadataFilters', () => {
       },
     ];
 
-    expect(renderLogQLMetadataFilters(filters)).toEqual('| level=`info` or level=`error`');
+    expect(renderLogQLMetadataFilters(filters)).toEqual('| level="info" or level="error"');
   });
   test('Renders grouped and ungrouped positive and negative filters', () => {
     const filters: AdHocVariableFilter[] = [
@@ -768,7 +781,7 @@ describe('renderLogQLMetadataFilters', () => {
     ];
 
     expect(renderLogQLMetadataFilters(filters)).toEqual(
-      '| level=`info` or level=`error` | cluster=`lil-cluster` | component!=`comp1` | pod!=`pod1`'
+      '| level="info" or level="error" | cluster="lil-cluster" | component!="comp1" | pod!="pod1"'
     );
   });
   test('Renders positive regex filters', () => {
@@ -785,7 +798,7 @@ describe('renderLogQLMetadataFilters', () => {
       },
     ];
 
-    expect(renderLogQLMetadataFilters(filters)).toEqual('| level=~`info` | cluster=~`lil-cluster`');
+    expect(renderLogQLMetadataFilters(filters)).toEqual('| level=~"info" | cluster=~"lil-cluster"');
   });
   test('Renders negative regex filters', () => {
     const filters: AdHocVariableFilter[] = [
@@ -801,7 +814,7 @@ describe('renderLogQLMetadataFilters', () => {
       },
     ];
 
-    expect(renderLogQLMetadataFilters(filters)).toEqual('| level!~`info` | cluster!~`lil-cluster`');
+    expect(renderLogQLMetadataFilters(filters)).toEqual('| level!~"info" | cluster!~"lil-cluster"');
   });
   test('Groups positive regex filters', () => {
     const filters: AdHocVariableFilter[] = [
@@ -817,7 +830,25 @@ describe('renderLogQLMetadataFilters', () => {
       },
     ];
 
-    expect(renderLogQLMetadataFilters(filters)).toEqual('| level=~`info` or level=~`error`');
+    expect(renderLogQLMetadataFilters(filters)).toEqual('| level=~"info" or level=~"error"');
+  });
+  test('Escapes regex filters', () => {
+    const filters: AdHocVariableFilter[] = [
+      {
+        key: 'host',
+        operator: FilterOp.RegexEqual,
+        value: '((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}',
+      },
+      {
+        key: 'level',
+        operator: FilterOp.RegexEqual,
+        value: 'error',
+      },
+    ];
+
+    expect(renderLogQLMetadataFilters(filters)).toEqual(
+      '| host=~"((25[0-5]|(2[0-4]|1\\\\d|[1-9]|)\\\\d)\\\\.?\\\\b){4}" | level=~"error"'
+    );
   });
   test('Renders grouped and ungrouped positive and negative regex filters', () => {
     const filters: AdHocVariableFilter[] = [
@@ -849,7 +880,7 @@ describe('renderLogQLMetadataFilters', () => {
     ];
 
     expect(renderLogQLMetadataFilters(filters)).toEqual(
-      '| level=~`info` or level=~`error` | cluster=~`lil-cluster` | component!~`comp1` | pod!~`pod1`'
+      '| level=~"info" or level=~"error" | cluster=~"lil-cluster" | component!~"comp1" | pod!~"pod1"'
     );
   });
   test('Renders grouped and ungrouped positive and negative regex and non-regex filters', () => {
@@ -882,7 +913,7 @@ describe('renderLogQLMetadataFilters', () => {
     ];
 
     expect(renderLogQLMetadataFilters(filters)).toEqual(
-      '| level=~`info` or level=~`error` | cluster=`lil-cluster` | component!~`comp1` | pod!=`pod1`'
+      '| level=~"info" or level=~"error" | cluster="lil-cluster" | component!~"comp1" | pod!="pod1"'
     );
   });
 });

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -110,7 +110,6 @@ export function onAddCustomValue(
   item: SelectableValue<string> & { isCustom?: boolean },
   filter: AdHocFiltersWithLabelsAndMeta
 ): { value: string | undefined; valueLabels: string[] } {
-  console.warn('onAddCustomValue', { item, filter });
   const field: FieldValue = {
     value: item.value ?? '',
     parser: filter?.meta?.parser ?? 'mixed',

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -1,11 +1,6 @@
-import {AdHocVariableFilter, SelectableValue} from '@grafana/data';
+import { AdHocVariableFilter, SelectableValue } from '@grafana/data';
 import { AppliedPattern } from 'Components/IndexScene/IndexScene';
-import {
-  AdHocFiltersWithLabelsAndMeta,
-  EMPTY_VARIABLE_VALUE,
-  FieldValue,
-  VAR_DATASOURCE_EXPR
-} from './variables';
+import { AdHocFiltersWithLabelsAndMeta, EMPTY_VARIABLE_VALUE, FieldValue, VAR_DATASOURCE_EXPR } from './variables';
 import { groupBy, trim } from 'lodash';
 import { getValueFromFieldsFilter } from './variableGetters';
 import { LokiQuery } from './lokiQuery';
@@ -111,23 +106,26 @@ export function renderLogQLLabelFilters(filters: AdHocFilterWithLabels[]) {
   return result;
 }
 
-export function onAddCustomValue(item: SelectableValue<string> & {isCustom?: boolean}, filter: AdHocFiltersWithLabelsAndMeta): {value: string | undefined, valueLabels: string[]} {
-  console.warn('onAddCustomValue', {item, filter})
+export function onAddCustomValue(
+  item: SelectableValue<string> & { isCustom?: boolean },
+  filter: AdHocFiltersWithLabelsAndMeta
+): { value: string | undefined; valueLabels: string[] } {
+  console.warn('onAddCustomValue', { item, filter });
   const field: FieldValue = {
     value: item.value ?? '',
-    parser: filter?.meta?.parser ?? 'mixed'
-  }
+    parser: filter?.meta?.parser ?? 'mixed',
+  };
   return {
     value: JSON.stringify(field),
-    valueLabels: [item.label ?? field.value]
-  }
+    valueLabels: [item.label ?? field.value],
+  };
 }
 
 export function renderLogQLFieldFilters(filters: AdHocVariableFilter[]) {
   // @todo partition instead of looping through again and again
   // @todo support regex operators
-  const positive = filters.filter((filter) => filter.operator === FilterOp.Equal);
-  const negative = filters.filter((filter) => filter.operator === FilterOp.NotEqual);
+  const positive = filters.filter((filter) => isOperatorInclusive(filter.operator));
+  const negative = filters.filter((filter) => isOperatorExclusive(filter.operator));
 
   const numeric = filters.filter((filter) => {
     const numericValues: string[] = numericOperatorArray;

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -123,7 +123,6 @@ export function onAddCustomValue(
 
 export function renderLogQLFieldFilters(filters: AdHocVariableFilter[]) {
   // @todo partition instead of looping through again and again
-  // @todo support regex operators
   const positive = filters.filter((filter) => isOperatorInclusive(filter.operator));
   const negative = filters.filter((filter) => isOperatorExclusive(filter.operator));
 
@@ -140,7 +139,6 @@ export function renderLogQLFieldFilters(filters: AdHocVariableFilter[]) {
   }
 
   const negativeFilters = negative.map((filter) => `| ${fieldFilterToQueryString(filter)}`).join(' ');
-
   let numericFilters = numeric.map((filter) => `| ${fieldNumericFilterToQueryString(filter)}`).join(' ');
 
   return `${positiveFilters} ${negativeFilters} ${numericFilters}`.trim();
@@ -212,17 +210,17 @@ function renderMetadata(filter: AdHocVariableFilter) {
   if (filter.value === EMPTY_VARIABLE_VALUE) {
     return `${filter.key}${filter.operator}${filter.value}`;
   }
-  return `${filter.key}${filter.operator}\`${filter.value}\``;
+  return `${filter.key}${filter.operator}"${sceneUtils.escapeLabelValueInExactSelector(filter.value)}"`;
 }
 
 function fieldFilterToQueryString(filter: AdHocVariableFilter) {
   const fieldObject = getValueFromFieldsFilter(filter);
   const value = fieldObject.value;
-  // If the filter value is an empty string, we don't want to wrap it in backticks!
+  // If the filter value is an empty string, we don't want to wrap it in quotes!
   if (value === EMPTY_VARIABLE_VALUE) {
     return `${filter.key}${filter.operator}${value}`;
   }
-  return `${filter.key}${filter.operator}\`${value}\``;
+  return `${filter.key}${filter.operator}"${sceneUtils.escapeLabelValueInExactSelector(value)}"`;
 }
 
 function fieldNumericFilterToQueryString(filter: AdHocVariableFilter) {

--- a/src/services/testIds.ts
+++ b/src/services/testIds.ts
@@ -19,6 +19,9 @@ export const testIds = {
     serviceName: {
       label: 'data-testid Dashboard template variables submenu Label Labels',
     },
+    levels: {
+      inputWrap: 'data-testid detected_level filter variable',
+    },
   },
   breakdowns: {
     labels: {},

--- a/src/services/variableHelpers.ts
+++ b/src/services/variableHelpers.ts
@@ -61,12 +61,13 @@ export const operatorFunction = function (variable: AdHocFiltersVariable) {
     return includeOperators;
   }
 
-  // Labels should not be able to replace the last include operator
-  if (
-    variable.state.name === VAR_LABELS &&
-    !wip?.key &&
-    variable.state.filters.filter((filter) => isOperatorInclusive(filter.operator)).length === 1
-  ) {
+  const isLabelsVar = variable.state.name === VAR_LABELS;
+  const inclusiveOperatorCount = variable.state.filters.filter((filter) => isOperatorInclusive(filter.operator)).length;
+  const isEditingOnlyFilter = !wip?.key && inclusiveOperatorCount === 1;
+  const isAddingFirstFilter = wip?.key && inclusiveOperatorCount < 1;
+
+  // Should not be able to exclude the only operator
+  if (isLabelsVar && (isEditingOnlyFilter || isAddingFirstFilter)) {
     return includeOperators;
   }
 

--- a/src/services/variables.ts
+++ b/src/services/variables.ts
@@ -1,6 +1,6 @@
 // Warning, this file is included in the main module.tsx bundle, and doesn't contain any imports to keep that bundle size small. Don't add imports to this file!
 
-import {AdHocFilterWithLabels} from "@grafana/scenes";
+import { AdHocFilterWithLabels } from '@grafana/scenes';
 
 export interface FieldValue {
   value: string;
@@ -14,8 +14,8 @@ export interface AdHocFieldValue {
 
 export type ParserType = 'logfmt' | 'json' | 'mixed' | 'structuredMetadata';
 export type DetectedFieldType = 'int' | 'float' | 'duration' | 'bytes' | 'boolean' | 'string';
-export type AdHocFilterWithLabelsMeta = { parser?: 'json' | 'logfmt' | 'mixed', type?: DetectedFieldType }
-export type AdHocFiltersWithLabelsAndMeta = AdHocFilterWithLabels<AdHocFilterWithLabelsMeta>
+export type AdHocFilterWithLabelsMeta = { parser?: ParserType; type?: DetectedFieldType };
+export type AdHocFiltersWithLabelsAndMeta = AdHocFilterWithLabels<AdHocFilterWithLabelsMeta>;
 
 export type LogsQueryOptions = {
   labelExpressionToAdd?: string;
@@ -32,6 +32,8 @@ export const VAR_LABELS_REPLICA_EXPR = '${filters_replica}';
 export const VAR_FIELDS = 'fields';
 export const VAR_FIELDS_EXPR = '${fields}';
 export const PENDING_FIELDS_EXPR = '${pendingFields}';
+export const PENDING_METADATA_EXPR = '${pendingMetadata}';
+export const VAR_FIELDS_AND_METADATA = 'all-fields';
 export const VAR_METADATA = 'metadata';
 export const VAR_METADATA_EXPR = '${metadata}';
 export const VAR_PATTERNS = 'patterns';
@@ -64,6 +66,7 @@ export const VAR_LINE_FILTERS_EXPR = '${lineFilters}';
 export const LOG_STREAM_SELECTOR_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${VAR_LOGS_FORMAT_EXPR} ${VAR_FIELDS_EXPR}`;
 // Same as the LOG_STREAM_SELECTOR_EXPR, but without the fields as they will need to be built manually to exclude the current filter value
 export const DETECTED_FIELD_VALUES_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${VAR_LOGS_FORMAT_EXPR} ${PENDING_FIELDS_EXPR}`;
+export const DETECTED_FIELD_AND_METADATA_VALUES_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_LEVELS_EXPR} ${PENDING_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${VAR_LOGS_FORMAT_EXPR} ${PENDING_FIELDS_EXPR}`;
 export const DETECTED_METADATA_VALUES_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_LEVELS_EXPR} ${PENDING_FIELDS_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${VAR_LOGS_FORMAT_EXPR} ${VAR_FIELDS_EXPR}`;
 export const DETECTED_LEVELS_VALUES_EXPR = `{${VAR_LABELS_EXPR}} ${PENDING_FIELDS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${VAR_LOGS_FORMAT_EXPR} ${VAR_FIELDS_EXPR}`;
 export const PATTERNS_SAMPLE_SELECTOR_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LOGS_FORMAT_EXPR}`;

--- a/tests/appNavigation.spec.ts
+++ b/tests/appNavigation.spec.ts
@@ -26,7 +26,7 @@ test.describe('navigating app', () => {
     // assert panels are showing
     const actualSearchParams = new URLSearchParams(page.url().split('?')[1]);
     const expectedSearchParams = new URLSearchParams(
-      '?patterns=%5B%5D&from=now-15m&to=now&var-ds=gdev-loki&var-filters=&var-fields=&var-levels=&var-patterns=&var-lineFilterV2=&var-lineFilters=&var-metadata=&timezone=browser&var-primary_label=service_name%7C%3D~%7C.%2B'
+      '?patterns=%5B%5D&from=now-15m&to=now&var-all-fields=&var-ds=gdev-loki&var-filters=&var-fields=&var-levels=&var-patterns=&var-lineFilterV2=&var-lineFilters=&var-metadata=&timezone=browser&var-primary_label=service_name%7C%3D~%7C.%2B'
     );
     actualSearchParams.sort();
     expectedSearchParams.sort();
@@ -54,7 +54,7 @@ test.describe('navigating app', () => {
     await expect(page.getByTestId('data-testid Show logs').first()).toHaveCount(1);
     const actualSearchParams = new URLSearchParams(page.url().split('?')[1]);
     const expectedSearchParams = new URLSearchParams(
-      '?patterns=%5B%5D&from=now-15m&to=now&var-ds=gdev-loki&var-filters=service_name%7C%3D%7Ctempo-ingester&var-fields=&var-filters_replica=&var-levels=&var-patterns=&var-lineFilterV2=&var-lineFilters=&var-metadata=&timezone=browser&var-primary_label=service_name%7C%3D~%7C%28%3Fi%29.%2ATempo-i.%2A'
+      '?patterns=%5B%5D&from=now-15m&to=now&var-all-fields=&var-ds=gdev-loki&var-filters=service_name%7C%3D%7Ctempo-ingester&var-fields=&var-filters_replica=&var-levels=&var-patterns=&var-lineFilterV2=&var-lineFilters=&var-metadata=&timezone=browser&var-primary_label=service_name%7C%3D~%7C%28%3Fi%29.%2ATempo-i.%2A'
     );
     actualSearchParams.sort();
     expectedSearchParams.sort();

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@grafana/plugin-e2e';
-import { E2EComboboxStrings, ExplorePage } from './fixtures/explore';
+import { E2EComboboxStrings, ExplorePage, levelTextMatch } from './fixtures/explore';
 import { testIds } from '../src/services/testIds';
 import { getMockVolumeApiResponse } from './mocks/getMockVolumeApiResponse';
 import { isNumber } from 'lodash';
@@ -148,12 +148,12 @@ test.describe('explore services page', () => {
       await explorePage.scrollToBottom();
       await page.getByTestId(testIds.exploreServiceDetails.buttonFilterInclude).nth(1).click();
 
-      await expect(page.getByLabel('Edit filter with key detected_level')).toBeVisible();
+      await expect(page.getByTestId(testIds.variables.levels.inputWrap)).toBeVisible();
+      await expect(page.getByTestId(testIds.variables.levels.inputWrap)).toContainText(levelTextMatch);
 
       // Navigate to patterns so the scene is cached
       await page.getByTestId(testIds.exploreServiceDetails.tabPatterns).click();
-
-      await expect(page.getByLabel('Edit filter with key detected_level')).toBeVisible();
+      await expect(page.getByTestId(testIds.variables.levels.inputWrap)).toContainText(levelTextMatch);
 
       // Remove service so we're redirected back to the start
       await page.getByLabel(E2EComboboxStrings.labels.removeServiceLabel).click();
@@ -163,11 +163,11 @@ test.describe('explore services page', () => {
 
       await explorePage.addServiceName();
 
-      await expect(page.getByLabel('Edit filter with key detected_level')).not.toBeVisible();
+      await expect(page.getByTestId(testIds.variables.levels.inputWrap)).toBeVisible();
+      await expect(page.getByTestId(testIds.variables.levels.inputWrap)).not.toContainText(levelTextMatch);
 
       await page.getByTestId(testIds.exploreServiceDetails.tabPatterns).click();
-
-      await expect(page.getByLabel('Edit filter with key detected_level')).not.toBeVisible();
+      await expect(page.getByTestId(testIds.variables.levels.inputWrap)).not.toContainText(levelTextMatch);
     });
 
     test('should add multiple includes on service selection', async ({ page }) => {

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@grafana/plugin-e2e';
-import { E2EComboboxLabels, ExplorePage } from './fixtures/explore';
+import { E2EComboboxStrings, ExplorePage } from './fixtures/explore';
 import { testIds } from '../src/services/testIds';
 import { getMockVolumeApiResponse } from './mocks/getMockVolumeApiResponse';
 import { isNumber } from 'lodash';
@@ -156,7 +156,7 @@ test.describe('explore services page', () => {
       await expect(page.getByLabel('Edit filter with key detected_level')).toBeVisible();
 
       // Remove service so we're redirected back to the start
-      await page.getByLabel(E2EComboboxLabels.labels.removeServiceLabel).click();
+      await page.getByLabel(E2EComboboxStrings.labels.removeServiceLabel).click();
 
       // Assert we're rendering the right scene and the services have loaded
       await expect(page.getByText(/Showing \d+ of \d+/)).toBeVisible();
@@ -309,7 +309,7 @@ test.describe('explore services page', () => {
       // Since the addition of the runtime datasource, the query doesn't contain the datasource, and won't re-run when the datasource is changed, as such we need to manually re-run volume queries when the service selection scene is activated or users could be presented with an invalid set of services
       // This isn't ideal as we won't take advantage of being able to use the cached volume result for users that did not change the datasource any longer
       test('navigating back will re-run volume query', async ({ page }) => {
-        const removeVariableBtn = page.getByLabel(E2EComboboxLabels.labels.removeServiceLabel);
+        const removeVariableBtn = page.getByLabel(E2EComboboxStrings.labels.removeServiceLabel);
         await page.waitForFunction(() => !document.querySelector('[title="Cancel query"]'));
         expect(logsVolumeCount).toEqual(1);
         expect(logsQueryCount).toBeLessThanOrEqual(4);
@@ -431,7 +431,7 @@ test.describe('explore services page', () => {
 
           const serviceNameVariableLoc = page.getByTestId(testIds.variables.serviceName.label);
           await expect(serviceNameVariableLoc).toHaveCount(1);
-          const removeVariableBtn = page.getByLabel(E2EComboboxLabels.labels.removeServiceLabel);
+          const removeVariableBtn = page.getByLabel(E2EComboboxStrings.labels.removeServiceLabel);
           await expect(serviceNameVariableLoc).toHaveCount(1);
           await expect(removeVariableBtn).toHaveCount(1);
 

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -100,7 +100,7 @@ test.describe('explore services breakdown page', () => {
   });
   test(`combobox should replace service_name with regex ${labelName} in url`, async ({ page }) => {
     explorePage.blockAllQueriesExcept({
-      refIds: ['logsPanelQuery', 'LABEL_BREAKDOWN_VALUES'],
+      refIds: ['LABEL_BREAKDOWN_VALUES'],
     });
 
     await explorePage.assertTabsNotLoading();
@@ -496,6 +496,34 @@ test.describe('explore services breakdown page', () => {
     await explorePage.assertFieldsIndex();
     await expect(page.getByLabel(E2EComboboxStrings.editByKey(fieldName))).toBeVisible();
     await expect(page.getByText('=').nth(1)).toBeVisible();
+  });
+
+  test.only(`Fields: can regex include ${fieldName} values containing "st"`, async ({ page }) => {
+    await explorePage.goToFieldsTab();
+    await page.pause();
+
+    // Go to caller values breakdown
+    await page.getByLabel(`Select ${fieldName}`).click();
+
+    // Open fields combobox
+    const comboboxLocator = page.getByPlaceholder('Filter by label values').last();
+    await comboboxLocator.click();
+
+    // Select cluster key
+    await page.getByRole('option', { name: 'caller' }).click();
+    // Select regex equal operator
+    await explorePage.getOperatorLocator(FilterOp.RegexEqual).click();
+    // Enter custom value
+    await page.keyboard.type(`.+st.+`);
+    // Select custom value
+    await page.getByRole('option', { name: /Use custom value/ }).click();
+
+    await expect(page.getByLabel(E2EComboboxStrings.editByKey(fieldName))).toBeVisible();
+    await page.pause();
+    await expect(page.getByText('=~')).toBeVisible();
+    const panels = explorePage.getAllPanelsLocator();
+    await expect(panels).toHaveCount(4);
+    await expect(page.getByTestId(/data-testid Panel header .+st.+/)).toHaveCount(3);
   });
 
   test('should only load fields that are in the viewport', async ({ page }) => {

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -265,7 +265,7 @@ test.describe('explore services breakdown page', () => {
     await explorePage.goToLogsTab();
     await explorePage.getLogsVolumePanelLocator().click();
     await page.getByTestId('data-testid Panel menu item Explore').click();
-    await expect(page.getByText(`{service_name=\`tempo-distributor\`} | ${levelName}=\`${valueName}\``)).toBeVisible();
+    await expect(page.getByText(`{service_name="tempo-distributor"} | ${levelName}="${valueName}"`)).toBeVisible();
   });
 
   test(`should select label ${labelName}, update filters, open in explore`, async ({ page, browser }) => {
@@ -287,7 +287,7 @@ test.describe('explore services breakdown page', () => {
 
     await expect(
       page.getByText(
-        `{service_name=\`tempo-distributor\`, ${labelName}=\`${valueName}\`} | json | logfmt | drop __error__, __error_details__`
+        `{service_name="tempo-distributor", ${labelName}="${valueName}"} | json | logfmt | drop __error__, __error_details__`
       )
     ).toBeVisible();
 
@@ -498,7 +498,7 @@ test.describe('explore services breakdown page', () => {
     await expect(page.getByText('=').nth(1)).toBeVisible();
   });
 
-  test.only(`Fields: can regex include ${fieldName} values containing "st"`, async ({ page }) => {
+  test(`Fields: can regex include ${fieldName} values containing "st"`, async ({ page }) => {
     await explorePage.goToFieldsTab();
     await page.pause();
 
@@ -841,7 +841,7 @@ test.describe('explore services breakdown page', () => {
     );
 
     expect(expressions[0]).toEqual(
-      'sum by (pod) (count_over_time({service_name=`tempo-distributor`} | pod!=""       [$__auto]))'
+      'sum by (pod) (count_over_time({service_name="tempo-distributor"} | pod!=""       [$__auto]))'
     );
 
     const bytesIncludeButton = page
@@ -915,7 +915,7 @@ test.describe('explore services breakdown page', () => {
     );
 
     expect(expressionsAfterNumericFilter[0]).toEqual(
-      'sum by (pod) (count_over_time({service_name=`tempo-distributor`} | pod!=""     | logfmt  | bytes>500B | bytes<=2KB [$__auto]))'
+      'sum by (pod) (count_over_time({service_name="tempo-distributor"} | pod!=""     | logfmt  | bytes>500B | bytes<=2KB [$__auto]))'
     );
 
     // Assert that the variables were added to the UI
@@ -1291,7 +1291,7 @@ test.describe('explore services breakdown page', () => {
     const newPageCodeEditor = page.getByRole('code').locator('div').filter({ hasText: 'sum(count_over_time({' }).nth(4);
     await expect(newPageCodeEditor).toBeInViewport();
     await expect(newPageCodeEditor).toContainText(
-      'sum(count_over_time({service_name=`tempo-distributor`} | detected_level != "" [$__auto])) by (detected_level)'
+      'sum(count_over_time({service_name="tempo-distributor"} | detected_level != "" [$__auto])) by (detected_level)'
     );
   });
 
@@ -1307,7 +1307,7 @@ test.describe('explore services breakdown page', () => {
     const newPageCodeEditor = page.getByRole('code').locator('div').filter({ hasText: 'sum(count_over_time({' }).nth(4);
     await expect(newPageCodeEditor).toBeInViewport();
     await expect(newPageCodeEditor).toContainText(
-      'sum(count_over_time({service_name=`tempo-distributor`} | detected_level != "" [$__auto])) by (detected_level)'
+      'sum(count_over_time({service_name="tempo-distributor"} | detected_level != "" [$__auto])) by (detected_level)'
     );
   });
 
@@ -1326,7 +1326,7 @@ test.describe('explore services breakdown page', () => {
       .nth(4);
     await expect(newPageCodeEditor).toBeInViewport();
     await expect(newPageCodeEditor).toContainText(
-      `sum by (${fieldName}) (count_over_time({service_name=\`tempo-distributor\`} | logfmt | ${fieldName}!="" [$__auto]))`
+      `sum by (${fieldName}) (count_over_time({service_name="tempo-distributor"} | logfmt | ${fieldName}!="" [$__auto]))`
     );
   });
 
@@ -1349,7 +1349,7 @@ test.describe('explore services breakdown page', () => {
       .nth(4);
     await expect(newPageCodeEditor).toBeInViewport();
     await expect(newPageCodeEditor).toContainText(
-      `sum by (${fieldName}) (count_over_time({service_name=\`tempo-distributor\`} | logfmt | ${fieldName}!="" [$__auto]))`
+      `sum by (${fieldName}) (count_over_time({service_name="tempo-distributor"} | logfmt | ${fieldName}!="" [$__auto]))`
     );
   });
 
@@ -1613,9 +1613,11 @@ test.describe('explore services breakdown page', () => {
         legendFormats: [],
       });
 
-      // raw logQL query: '{cluster=`us-west-1`} |~ "\\\\n" |= "\\n" |= "getBookTitles(Author.java:25)\\n" |~ "getBookTitles\\(Author\\.java:25\\)\\\\n" | json | logfmt | drop __error__, __error_details__'
+      await page.pause();
+
+      // raw logQL query: '{cluster="us-west-1"} |~ "\\\\n" |= "\\n" |= "getBookTitles(Author.java:25)\\n" |~ "getBookTitles\\(Author\\.java:25\\)\\\\n" | json | logfmt | drop __error__, __error_details__'
       const queryInUrl =
-        '{cluster=`us-west-1`} |~ \\"\\\\\\\\\\\\\\\\n\\" |= \\"\\\\\\\\n\\" |= \\"getBookTitles(Author.java:25)\\\\\\\\n\\" |~ \\"getBookTitles\\\\\\\\(Author\\\\\\\\.java:25\\\\\\\\)\\\\\\\\\\\\\\\\n\\" | json | logfmt | drop __error__, __error_details__';
+        '{cluster=\\"us-west-1\\"} |~ \\"\\\\\\\\\\\\\\\\n\\" |= \\"\\\\\\\\n\\" |= \\"getBookTitles(Author.java:25)\\\\\\\\n\\" |~ \\"getBookTitles\\\\\\\\(Author\\\\\\\\.java:25\\\\\\\\)\\\\\\\\\\\\\\\\n\\" | json | logfmt | drop __error__, __error_details__';
       await page.goto(
         `/explore?schemaVersion=1&panes={"dx6":{"datasource":"gdev-loki","queries":[{"refId":"logsPanelQuery","expr":"${queryInUrl}","datasource":{"type":"loki","uid":"gdev-loki"}}],"range":{"from":"now-30m","to":"now"},"panelsState":{"logs":{"visualisationType":"logs"}}}}&orgId=1`
       );

--- a/tests/exploreServicesJsonBreakDown.spec.ts
+++ b/tests/exploreServicesJsonBreakDown.spec.ts
@@ -53,7 +53,7 @@ test.describe('explore nginx-json breakdown pages ', () => {
       const queries: LokiQuery[] = post.queries;
       queries.forEach((query) => {
         expect(query.expr).toContain(
-          `sum by (${fieldName}) (count_over_time({service_name=\`nginx-json\`}      | json | drop __error__, __error_details__ | ${fieldName}!=""`
+          `sum by (${fieldName}) (count_over_time({service_name="nginx-json"}      | json | drop __error__, __error_details__ | ${fieldName}!=""`
         );
       });
     });

--- a/tests/exploreServicesJsonBreakDown.spec.ts
+++ b/tests/exploreServicesJsonBreakDown.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@grafana/plugin-e2e';
-import { E2EComboboxLabels, ExplorePage, PlaywrightRequest } from './fixtures/explore';
+import { E2EComboboxStrings, ExplorePage, PlaywrightRequest } from './fixtures/explore';
 
 import { LokiQuery } from '../src/services/lokiQuery';
 
@@ -45,7 +45,7 @@ test.describe('explore nginx-json breakdown pages ', () => {
     await expect(allPanels).toHaveCount(6);
 
     // Adhoc content filter should be added
-    await expect(page.getByLabel(E2EComboboxLabels.editByKey(fieldName))).toBeVisible();
+    await expect(page.getByLabel(E2EComboboxStrings.editByKey(fieldName))).toBeVisible();
     await expect(page.getByText('!=')).toBeVisible();
 
     requests.forEach((req) => {

--- a/tests/exploreServicesJsonMixedBreakDown.spec.ts
+++ b/tests/exploreServicesJsonMixedBreakDown.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@grafana/plugin-e2e';
-import { E2EComboboxLabels, ExplorePage, PlaywrightRequest } from './fixtures/explore';
+import { E2EComboboxStrings, ExplorePage, PlaywrightRequest } from './fixtures/explore';
 
 import { LokiQuery } from '../src/services/lokiQuery';
 
@@ -51,7 +51,7 @@ test.describe('explore nginx-json-mixed breakdown pages ', () => {
     await expect(allPanels).toHaveCount(6);
 
     // Adhoc content filter should be added
-    await expect(page.getByLabel(E2EComboboxLabels.editByKey(mixedFieldName))).toBeVisible();
+    await expect(page.getByLabel(E2EComboboxStrings.editByKey(mixedFieldName))).toBeVisible();
     await expect(page.getByText('!=')).toBeVisible();
 
     requests.forEach((req) => {
@@ -94,7 +94,7 @@ test.describe('explore nginx-json-mixed breakdown pages ', () => {
     await expect(allPanels).toHaveCount(13);
 
     // Adhoc content filter should be added
-    await expect(page.getByLabel(E2EComboboxLabels.editByKey(logFmtFieldName))).toBeVisible();
+    await expect(page.getByLabel(E2EComboboxStrings.editByKey(logFmtFieldName))).toBeVisible();
     await expect(page.getByText('!=')).toBeVisible();
 
     requests.forEach((req, index) => {
@@ -141,7 +141,7 @@ test.describe('explore nginx-json-mixed breakdown pages ', () => {
     await expect(allPanels).toHaveCount(3);
 
     // Adhoc content filter should be added
-    await expect(page.getByLabel(E2EComboboxLabels.editByKey(jsonFmtFieldName))).toBeVisible();
+    await expect(page.getByLabel(E2EComboboxStrings.editByKey(jsonFmtFieldName))).toBeVisible();
     await expect(page.getByText('!=')).toBeVisible();
 
     requests.forEach((req) => {
@@ -179,7 +179,7 @@ test.describe('explore nginx-json-mixed breakdown pages ', () => {
     await expect.poll(() => allPanels.count()).toBeGreaterThanOrEqual(actualCount - 1);
 
     // Adhoc content filter should be added
-    await expect(page.getByLabel(E2EComboboxLabels.editByKey(metadataFieldName))).toBeVisible();
+    await expect(page.getByLabel(E2EComboboxStrings.editByKey(metadataFieldName))).toBeVisible();
     await expect(page.getByText('!=')).toBeVisible();
 
     await expect.poll(() => requests).toHaveLength(3);

--- a/tests/exploreServicesJsonMixedBreakDown.spec.ts
+++ b/tests/exploreServicesJsonMixedBreakDown.spec.ts
@@ -59,7 +59,7 @@ test.describe('explore nginx-json-mixed breakdown pages ', () => {
       const queries: LokiQuery[] = post.queries;
       queries.forEach((query) => {
         expect(query.expr).toContain(
-          `sum by (${mixedFieldName}) (count_over_time({service_name=\`${serviceName}\`}      | json | logfmt | drop __error__, __error_details__ | ${mixedFieldName}!=""`
+          `sum by (${mixedFieldName}) (count_over_time({service_name="${serviceName}"}      | json | logfmt | drop __error__, __error_details__ | ${mixedFieldName}!=""`
         );
       });
     });
@@ -103,12 +103,12 @@ test.describe('explore nginx-json-mixed breakdown pages ', () => {
       queries.forEach((query) => {
         if (index < 2) {
           expect(query.expr).toContain(
-            `sum by (${logFmtFieldName}) (count_over_time({service_name=\`${serviceName}\`}      | logfmt | ${logFmtFieldName}!=""  [$__auto]))`
+            `sum by (${logFmtFieldName}) (count_over_time({service_name="${serviceName}"}      | logfmt | ${logFmtFieldName}!=""  [$__auto]))`
           );
         }
         if (index >= 2) {
           expect(query.expr).toContain(
-            `sum by (${logFmtFieldName}) (count_over_time({service_name=\`${serviceName}\`}      | logfmt | ${logFmtFieldName}!="" | caller!=\`flush.go:253\` [$__auto]))`
+            `sum by (${logFmtFieldName}) (count_over_time({service_name="${serviceName}"}      | logfmt | ${logFmtFieldName}!="" | caller!="flush.go:253" [$__auto]))`
           );
         }
       });
@@ -149,7 +149,7 @@ test.describe('explore nginx-json-mixed breakdown pages ', () => {
       const queries: LokiQuery[] = post.queries;
       queries.forEach((query) => {
         expect(query.expr).toContain(
-          `sum by (${jsonFmtFieldName}) (count_over_time({service_name=\`${serviceName}\`}      | json | drop __error__, __error_details__ | ${jsonFmtFieldName}!=""`
+          `sum by (${jsonFmtFieldName}) (count_over_time({service_name="${serviceName}"}      | json | drop __error__, __error_details__ | ${jsonFmtFieldName}!=""`
         );
       });
     });
@@ -189,7 +189,7 @@ test.describe('explore nginx-json-mixed breakdown pages ', () => {
       const queries: LokiQuery[] = post.queries;
       queries.forEach((query) => {
         expect(query.expr).toContain(
-          `sum by (${metadataFieldName}) (count_over_time({service_name=\`${serviceName}\`} | ${metadataFieldName}!=""`
+          `sum by (${metadataFieldName}) (count_over_time({service_name="${serviceName}"} | ${metadataFieldName}!=""`
         );
       });
     });

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -266,6 +266,7 @@ export class ExplorePage {
   blockAllQueriesExcept(options: {
     refIds?: Array<string | RegExp>;
     legendFormats?: string[];
+
     responses?: Array<{ [refIDOrLegendFormat: string]: any }>;
     requests?: PlaywrightRequest[];
   }) {
@@ -316,6 +317,8 @@ export class ExplorePage {
         return this.page.getByRole('option', { name: E2EComboboxStrings.operatorNames.regexEqual, exact: true });
       case FilterOp.RegexNotEqual:
         return this.page.getByRole('option', { name: E2EComboboxStrings.operatorNames.regexNotEqual, exact: true });
+      default:
+        throw new Error('invalid filter op');
     }
   }
 }

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -259,14 +259,13 @@ export class ExplorePage {
     sortOrder: 'Ascending' | 'Descending' = 'Descending',
     wrapLogMessage: 'true' | 'false' = 'false'
   ) {
-    const url = `/a/grafana-lokiexplore-app/explore/service/tempo-distributor/logs?patterns=[]&from=now-5m&to=now&var-ds=gdev-loki&var-filters=service_name|=|tempo-distributor&var-fields=&var-levels=&var-metadata=&var-patterns=&var-lineFilter=&timezone=utc&urlColumns=["Time","Line"]&visualizationType="logs"&displayedFields=[]&sortOrder="${sortOrder}"&wrapLogMessage=${wrapLogMessage}&var-lineFilterV2=&var-lineFilters=`;
+    const url = `/a/grafana-lokiexplore-app/explore/service/tempo-distributor/logs?patterns=[]&from=now-5m&to=now&var-all-fields=&var-ds=gdev-loki&var-filters=service_name|=|tempo-distributor&var-fields=&var-levels=&var-metadata=&var-patterns=&var-lineFilter=&timezone=utc&urlColumns=["Time","Line"]&visualizationType="logs"&displayedFields=[]&sortOrder="${sortOrder}"&wrapLogMessage=${wrapLogMessage}&var-lineFilterV2=&var-lineFilters=`;
     await this.page.goto(url);
   }
 
   blockAllQueriesExcept(options: {
     refIds?: Array<string | RegExp>;
     legendFormats?: string[];
-
     responses?: Array<{ [refIDOrLegendFormat: string]: any }>;
     requests?: PlaywrightRequest[];
   }) {
@@ -336,3 +335,5 @@ export const E2EComboboxStrings = {
     regexNotEqual: '!~ Does not match regex',
   },
 };
+
+export const levelTextMatch = /error|warn|info|debug/;

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -4,6 +4,7 @@ import { testIds } from '../../src/services/testIds';
 import { expect } from '@grafana/plugin-e2e';
 
 import { LokiQuery } from '../../src/services/lokiQuery';
+import { FilterOp } from '../../src/services/filterTypes';
 
 export interface PlaywrightRequest {
   post: any;
@@ -304,11 +305,31 @@ export class ExplorePage {
       }
     });
   }
+
+  getOperatorLocator(filter: FilterOp): Locator {
+    switch (filter) {
+      case FilterOp.Equal:
+        return this.page.getByRole('option', { name: E2EComboboxStrings.operatorNames.equal, exact: true });
+      case FilterOp.NotEqual:
+        return this.page.getByRole('option', { name: E2EComboboxStrings.operatorNames.notEqual, exact: true });
+      case FilterOp.RegexEqual:
+        return this.page.getByRole('option', { name: E2EComboboxStrings.operatorNames.regexEqual, exact: true });
+      case FilterOp.RegexNotEqual:
+        return this.page.getByRole('option', { name: E2EComboboxStrings.operatorNames.regexNotEqual, exact: true });
+    }
+  }
 }
 
-export const E2EComboboxLabels = {
-  editByKey: (keyName) => `Edit filter with key ${keyName}`,
+export const E2EComboboxStrings = {
+  editByKey: (keyName: string) => `Edit filter with key ${keyName}`,
+  removeByKey: (keyName: string) => `Remove filter with key ${keyName}`,
   labels: {
     removeServiceLabel: 'Remove filter with key service_name',
+  },
+  operatorNames: {
+    equal: '= Equals',
+    notEqual: '!= Not equal',
+    regexEqual: '=~ Matches regex',
+    regexNotEqual: '!~ Does not match regex',
   },
 };


### PR DESCRIPTION
This PR adds descriptions to the operators, fixes some bugs with generating regex fields, e2e coverage, and converts fields and metadata to use doublequotes instead of backticks.

NOTE: We had to copy the `fetchDetectedFields` from core Grafana since [that PR](https://github.com/grafana/grafana/pull/99394) missed the 11.5 cutoff. The implementation in this PR is not tested but it is a direct lift from the PR linked above, I'm hoping that we can upgrade quickly and remove this tech debt. The good news is that Grafana 11.3 should still work with this feature.

Parent branch: https://github.com/grafana/explore-logs/pull/1023
Child branch: https://github.com/grafana/explore-logs/pull/1029