### PR TITLE
E2E fix: add more deterministic pod value to generator, update e2e

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -122,7 +122,7 @@ func lokiOtelPod(svc string) LogGenerator {
 			go func() {
 				for ctx.Err() == nil {
 					t := time.Now()
-					logger.LogWithMetadata(k, t, v, log.RandStructuredMetadata("loki-ingester"))
+					logger.LogWithMetadata(k, t, v, log.RandStructuredMetadata("loki-ingester", 0))
 					time.Sleep(time.Duration(rand.Intn(5000)) * time.Millisecond)
 				}
 			}()
@@ -217,14 +217,14 @@ func startFailingMimirPod(ctx context.Context, logger log.Logger) {
 	go func() {
 		for ctx.Err() == nil {
 			t := time.Now()
-			appLogger.LogWithMetadata(log.ERROR, t, mimirGRPCLog("connection refused to object store", "/cortex.Ingester/Push"), log.RandStructuredMetadata("mimir-ingester"))
+			appLogger.LogWithMetadata(log.ERROR, t, mimirGRPCLog("connection refused to object store", "/cortex.Ingester/Push"), log.RandStructuredMetadata("mimir-ingester", 0))
 			time.Sleep(time.Duration(rand.Intn(10000)) * time.Millisecond)
 		}
 	}()
 	go func() {
 		for ctx.Err() == nil {
 			t := time.Now()
-			appLogger.LogWithMetadata(log.INFO, t, mimirGRPCLog("", "/cortex.Ingester/Push"), log.RandStructuredMetadata("mimir-ingester"))
+			appLogger.LogWithMetadata(log.INFO, t, mimirGRPCLog("", "/cortex.Ingester/Push"), log.RandStructuredMetadata("mimir-ingester", 0))
 			time.Sleep(time.Duration(rand.Intn(500)) * time.Millisecond)
 		}
 	}()

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -534,7 +534,7 @@ test.describe('explore services breakdown page', () => {
     );
   });
 
-  test.only(`Metadata: can regex include ${metadataName} values containing "0\\d"`, async ({ page }) => {
+  test(`Metadata: can regex include ${metadataName} values containing "0\\d"`, async ({ page }) => {
     explorePage.blockAllQueriesExcept({
       refIds: [metadataName],
     });

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -306,6 +306,26 @@ export class ExplorePage {
     });
   }
 
+  async addCustomValueToCombobox(labelName: string, operator: FilterOp, comboBox: ComboBoxIndex, text: string) {
+    // Open combobox
+    const comboboxLocator = this.page.getByPlaceholder('Filter by label values').nth(comboBox);
+    await comboboxLocator.click();
+    // Select detected_level key
+    await this.page.getByRole('option', { name: labelName }).click();
+    await expect(this.getOperatorLocator(operator)).toHaveCount(1);
+    await expect(this.getOperatorLocator(operator)).toBeVisible();
+    // Select operator
+    await this.getOperatorLocator(operator).click();
+    // Enter custom value
+    await this.page.keyboard.type(text);
+    // Need to scroll to the bottom of the list
+    await this.page.keyboard.press('ArrowUp');
+    // Select custom value
+    await this.page.getByRole('option', { name: /Use custom value/ }).click();
+    // Close the label name dropdown that opens after adding a value
+    await this.page.keyboard.press('Escape');
+  }
+
   getOperatorLocator(filter: FilterOp): Locator {
     switch (filter) {
       case FilterOp.Equal:
@@ -337,3 +357,8 @@ export const E2EComboboxStrings = {
 };
 
 export const levelTextMatch = /error|warn|info|debug/;
+
+export enum ComboBoxIndex {
+  labels,
+  fields,
+}


### PR DESCRIPTION
I made some assumptions about the format and count of pod label values, which were being randomly generated.
Updating the `pod` values for tempo-ingester in the generator to have a more consistent and differentiable value format, so we can assert that metadata regex is working as expected.