### PR TITLE
Logs: apply query direction in query runner

### DIFF
--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -19,13 +19,14 @@ import {
   VizPanel,
 } from '@grafana/scenes';
 import { map, Observable } from 'rxjs';
-import { HideSeriesConfig } from '@grafana/schema';
+import { HideSeriesConfig, LogsSortOrder } from '@grafana/schema';
 import { WRAPPED_LOKI_DS_UID } from './datasource';
 import { LogsSceneQueryRunner } from './LogsSceneQueryRunner';
 import { DrawStyle, StackingMode } from '@grafana/ui';
 import { getLabelsFromSeries, getVisibleLevels } from './levels';
-import { LokiQuery } from './lokiQuery';
+import { LokiQuery, LokiQueryDirection } from './lokiQuery';
 import { LOGS_COUNT_QUERY_REFID, LOGS_PANEL_QUERY_REFID } from '../Components/ServiceScene/ServiceScene';
+import { getLogsPanelSortOrderFromStore, getLogsPanelSortOrderFromURL } from 'Components/ServiceScene/LogOptionsScene';
 
 const UNKNOWN_LEVEL_LOGS = 'logs';
 export function setLevelColorOverrides(overrides: FieldConfigOverridesBuilder<FieldConfig>) {
@@ -200,6 +201,12 @@ export function getQueryRunner(queries: LokiQuery[], queryRunnerOptions?: Partia
       }),
       transformations: [setColorByDisplayNameTransformation],
     });
+  } else {
+    const sortOrder = getLogsPanelSortOrderFromURL() || getLogsPanelSortOrderFromStore();
+    queries = queries.map((query) => ({
+      ...query,
+      direction: sortOrder === LogsSortOrder.Descending ? LokiQueryDirection.Backward : LokiQueryDirection.Forward,
+    }));
   }
 
   return getSceneQueryRunner({


### PR DESCRIPTION
When the core Logs Panel created a new request for infinite scrolling, the direction was missing, resulting in a query always with `backwards` direction. With the direction applied when creating the query runner, now the panel has that property defined and available when a new request is created for infinite scrolling.

Can be reproduced with `Oldest first` sort order.

Before:

https://github.com/user-attachments/assets/ba851fb0-f3ce-443b-9c3c-cdf18ddbba00

After:

https://github.com/user-attachments/assets/07c00507-f19c-4939-8282-dcb806f31b38
