### PR TITLE
E2E: Fix flake - not scrolling

### DIFF
--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -147,10 +147,17 @@ test.describe('explore services page', () => {
       await page.getByTestId(testIds.exploreServiceDetails.tabLabels).click();
       await page.getByLabel('Select detected_level').click();
       await explorePage.assertNotLoading();
-      // Assert that 5 panels are visible (4 levels and summary panel) before attempting to scroll
-      await expect(explorePage.getAllPanelsLocator()).toHaveCount(5);
+      await explorePage.assertPanelsNotLoading();
 
-      await explorePage.scrollToBottom();
+      // Scroll to the bottom of the page
+      await expect
+        .poll(async () => {
+          await explorePage.scrollToBottom();
+          return explorePage.getAllPanelsLocator().count();
+        })
+        .toBe(5);
+
+      // Assert that the button exists
       await page.getByTestId(testIds.exploreServiceDetails.buttonFilterInclude).nth(1).click();
 
       await expect(page.getByTestId(testIds.variables.levels.inputWrap)).toBeVisible();

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -139,9 +139,7 @@ test.describe('explore services page', () => {
       await expect(page.getByText(/level=info/)).not.toBeVisible();
     });
 
-    test.only('should clear filters and levels when navigating back to previously activated service', async ({
-      page,
-    }) => {
+    test('should clear filters and levels when navigating back to previously activated service', async ({ page }) => {
       await explorePage.addServiceName();
       // Add detected_level filter
       await page.getByTestId(testIds.exploreServiceDetails.tabLabels).click();

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -139,12 +139,17 @@ test.describe('explore services page', () => {
       await expect(page.getByText(/level=info/)).not.toBeVisible();
     });
 
-    test('should clear filters and levels when navigating back to previously activated service', async ({ page }) => {
+    test.only('should clear filters and levels when navigating back to previously activated service', async ({
+      page,
+    }) => {
       await explorePage.addServiceName();
       // Add detected_level filter
       await page.getByTestId(testIds.exploreServiceDetails.tabLabels).click();
       await page.getByLabel('Select detected_level').click();
       await explorePage.assertNotLoading();
+      // Assert that 5 panels are visible (4 levels and summary panel) before attempting to scroll
+      await expect(explorePage.getAllPanelsLocator()).toHaveCount(5);
+
       await explorePage.scrollToBottom();
       await page.getByTestId(testIds.exploreServiceDetails.buttonFilterInclude).nth(1).click();
 


### PR DESCRIPTION
Fix: `should clear filters and levels when navigating back to previously activated service` e2e test, which appears to attempt to scroll before the panels are rendered