### PR TITLE
Table: Hide custom pixel width, surface field menu options in column header

### DIFF
--- a/src/Components/Table/ColumnSelection/LogsTableNavField.tsx
+++ b/src/Components/Table/ColumnSelection/LogsTableNavField.tsx
@@ -6,48 +6,6 @@ import { Checkbox, Icon, useTheme2 } from '@grafana/ui';
 
 import { FieldNameMeta } from '../TableTypes';
 
-function getStyles(theme: GrafanaTheme2) {
-  return {
-    dragIcon: css({
-      cursor: 'drag',
-      marginLeft: theme.spacing(1),
-      opacity: 0.4,
-    }),
-    labelCount: css({
-      marginLeft: theme.spacing(0.5),
-      marginRight: theme.spacing(0.5),
-      appearance: 'none',
-      background: 'none',
-      border: 'none',
-      fontSize: theme.typography.pxToRem(11),
-      opacity: 0.6,
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'self-end',
-    }),
-    contentWrap: css({
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      width: '100%',
-    }),
-    customWidthWrap: css({
-      fontSize: theme.typography.bodySmall.fontSize,
-      cursor: 'pointer',
-    }),
-    // Hide text that overflows, had to select elements within the Checkbox component, so this is a bit fragile
-    checkboxLabel: css({
-      '> span': {
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-        display: 'block',
-        maxWidth: '100%',
-      },
-    }),
-  };
-}
-
 export function LogsTableNavField(props: {
   label: string;
   onChange: () => void;
@@ -88,7 +46,7 @@ export function LogsTableNavField(props: {
               title={'Clear column width override'}
               className={styles.customWidthWrap}
             >
-              Width: {props.columnWidthMap?.[props.label]}
+              Reset column width
               <Icon name={'x'} />
             </div>
           )}
@@ -107,4 +65,46 @@ export function LogsTableNavField(props: {
   }
 
   return null;
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    dragIcon: css({
+      cursor: 'drag',
+      marginLeft: theme.spacing(1),
+      opacity: 0.4,
+    }),
+    labelCount: css({
+      marginLeft: theme.spacing(0.5),
+      marginRight: theme.spacing(0.5),
+      appearance: 'none',
+      background: 'none',
+      border: 'none',
+      fontSize: theme.typography.pxToRem(11),
+      opacity: 0.6,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'self-end',
+    }),
+    contentWrap: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      width: '100%',
+    }),
+    customWidthWrap: css({
+      fontSize: theme.typography.bodySmall.fontSize,
+      cursor: 'pointer',
+    }),
+    // Hide text that overflows, had to select elements within the Checkbox component, so this is a bit fragile
+    checkboxLabel: css({
+      '> span': {
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        display: 'block',
+        maxWidth: '100%',
+      },
+    }),
+  };
 }

--- a/src/Components/Table/LogsTableHeader.tsx
+++ b/src/Components/Table/LogsTableHeader.tsx
@@ -73,8 +73,7 @@ export const LogsTableHeader = (props: LogsTableHeaderProps) => {
   const referenceElement = useRef<HTMLButtonElement | null>(null);
   const theme = useTheme2();
   const styles = getStyles(theme, props.fieldIndex === 0, props.field.name === getBodyName(logsFrame));
-  const { columnWidthMap, setColumnWidthMap } = useTableColumnContext();
-  const { setBodyState, bodyState } = useTableColumnContext();
+  const { columnWidthMap, setColumnWidthMap, setBodyState, bodyState } = useTableColumnContext();
   const isBodyField = props.field.name === getBodyName(logsFrame);
 
   const onLogTextToggle = () => {

--- a/src/Components/Table/LogsTableHeader.tsx
+++ b/src/Components/Table/LogsTableHeader.tsx
@@ -78,11 +78,7 @@ export const LogsTableHeader = (props: LogsTableHeaderProps) => {
   const isBodyField = props.field.name === getBodyName(logsFrame);
 
   const onLogTextToggle = () => {
-    if (bodyState === LogLineState.text) {
-      setBodyState(LogLineState.labels);
-    } else {
-      setBodyState(LogLineState.text);
-    }
+    setBodyState(bodyState === LogLineState.text ? LogLineState.labels : LogLineState.text);
   };
 
   return (

--- a/src/Components/Table/LogsTableHeader.tsx
+++ b/src/Components/Table/LogsTableHeader.tsx
@@ -2,11 +2,12 @@ import React, { PropsWithChildren, useRef } from 'react';
 import { css } from '@emotion/css';
 
 import { Field, GrafanaTheme2 } from '@grafana/data';
-import { ClickOutsideWrapper, Icon, Popover, useTheme2 } from '@grafana/ui';
+import { ClickOutsideWrapper, IconButton, Popover, useTheme2 } from '@grafana/ui';
 
 import { useTableHeaderContext } from 'Components/Table/Context/TableHeaderContext';
 import { useQueryContext } from './Context/QueryContext';
 import { getBodyName } from '../../services/logsFrame';
+import { LogLineState, useTableColumnContext } from './Context/TableColumnsContext';
 
 export interface LogsTableHeaderProps extends PropsWithChildren<CustomHeaderRendererProps> {
   fieldIndex: number;
@@ -18,6 +19,9 @@ export interface CustomHeaderRendererProps {
 }
 
 const getStyles = (theme: GrafanaTheme2, isFirstColumn: boolean, isLine: boolean) => ({
+  logLineButton: css({
+    marginLeft: '5px',
+  }),
   tableHeaderMenu: css({
     label: 'tableHeaderMenu',
     width: '100%',
@@ -31,14 +35,21 @@ const getStyles = (theme: GrafanaTheme2, isFirstColumn: boolean, isLine: boolean
     boxShadow: theme.shadows.z3,
     borderRadius: theme.shape.radius.default,
   }),
-  button: css({
-    appearance: 'none',
-    right: '5px',
-    background: 'none',
-    border: 'none',
-    padding: 0,
+  leftAlign: css({
+    label: 'left-align',
+    display: 'flex',
+    width: 'calc(100% - 20px)',
+  }),
+  clearButton: css({
+    marginLeft: '5px',
+  }),
+  rightAlign: css({
+    label: 'right-align',
+    display: 'flex',
+    marginRight: '5px',
   }),
   wrapper: css({
+    label: 'wrapper',
     display: 'flex',
     marginLeft: isFirstColumn ? '56px' : '6px',
     // Body has extra padding then other columns
@@ -62,19 +73,74 @@ export const LogsTableHeader = (props: LogsTableHeaderProps) => {
   const referenceElement = useRef<HTMLButtonElement | null>(null);
   const theme = useTheme2();
   const styles = getStyles(theme, props.fieldIndex === 0, props.field.name === getBodyName(logsFrame));
+  const { columnWidthMap, setColumnWidthMap } = useTableColumnContext();
+  const { setBodyState, bodyState } = useTableColumnContext();
+  const isBodyField = props.field.name === getBodyName(logsFrame);
+
+  const onLogTextToggle = () => {
+    if (bodyState === LogLineState.text) {
+      setBodyState(LogLineState.labels);
+    } else {
+      setBodyState(LogLineState.text);
+    }
+  };
 
   return (
     <span className={styles.wrapper}>
-      <span className={styles.defaultContentWrapper}>{props.defaultContent}</span>
-      <button
-        className={styles.button}
-        ref={referenceElement}
-        onClick={(e) => {
-          setHeaderMenuActive(!isHeaderMenuActive);
-        }}
-      >
-        <Icon title={'Show menu'} name={'ellipsis-v'} />
-      </button>
+      <span className={styles.leftAlign}>
+        <span className={styles.defaultContentWrapper}>{props.defaultContent}</span>
+        {columnWidthMap && setColumnWidthMap && columnWidthMap?.[props.field.name] !== undefined && (
+          <IconButton
+            tooltip={'Reset column width'}
+            tooltipPlacement={'top'}
+            className={styles.clearButton}
+            aria-label={'Reset column width'}
+            name={'x'}
+            onClick={() => {
+              const { [props.field.name]: omit, ...map } = { ...columnWidthMap };
+              setColumnWidthMap?.(map);
+            }}
+          />
+        )}
+        {isBodyField && (
+          <>
+            {bodyState === LogLineState.text ? (
+              <IconButton
+                tooltipPlacement={'top'}
+                tooltip={'Show log labels'}
+                aria-label={'Show log labels'}
+                onClick={onLogTextToggle}
+                className={styles.logLineButton}
+                name={'brackets-curly'}
+                size={'md'}
+              />
+            ) : (
+              <IconButton
+                tooltipPlacement={'top'}
+                tooltip={'Show log text'}
+                aria-label={'Show log text'}
+                onClick={onLogTextToggle}
+                className={styles.logLineButton}
+                name={'text-fields'}
+                size={'md'}
+              />
+            )}
+          </>
+        )}
+      </span>
+      <span className={styles.rightAlign}>
+        <IconButton
+          tooltip={`Show ${props.field.name} menu`}
+          tooltipPlacement={'top'}
+          ref={referenceElement}
+          aria-label={`Show ${props.field.name} menu`}
+          onClick={(e) => {
+            setHeaderMenuActive(!isHeaderMenuActive);
+          }}
+          name={'ellipsis-v'}
+        />
+      </span>
+
       {referenceElement.current && (
         //@ts-ignore
         <Popover

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -184,7 +184,7 @@ test.describe('explore services breakdown page', () => {
     await expect(table.getByRole('columnheader').nth(1)).toContainText('body');
 
     // Open the menu for "Line"
-    await page.getByRole('button', { name: 'Show menu' }).nth(1).click();
+    await page.getByLabel(/Show body|Line menu/).click();
     await page.getByText('Move left').click();
     await expect(table.getByRole('columnheader').nth(0)).toContainText('body');
 
@@ -223,7 +223,7 @@ test.describe('explore services breakdown page', () => {
     await expect(table.getByTestId(testIds.table.rawLogLine)).toHaveCount(0);
 
     // Open menu
-    await page.getByRole('button', { name: 'Show menu' }).nth(1).click();
+    await await page.getByLabel(/Show body|Line menu/).click();
 
     // Show log text option should be visible by default
     await expect(page.getByText('Show log text')).toBeVisible();


### PR DESCRIPTION
Fixes: https://github.com/grafana/explore-logs/issues/980
Fixes: https://github.com/grafana/explore-logs/issues/1059

Updated header menu for log line:
<img width="831" alt="image" src="https://github.com/user-attachments/assets/dae4abef-7e83-4b44-841d-2b909f813811" />
<img width="1722" alt="image" src="https://github.com/user-attachments/assets/a8125e05-7084-42b5-98da-60a89749fe61" />

After resizing column:
<img width="478" alt="image" src="https://github.com/user-attachments/assets/ac2def88-1a4e-48d4-8527-5a75c797a69c" />
<img width="439" alt="image" src="https://github.com/user-attachments/assets/402cf336-251d-4f86-ad53-051ce4d372fa" />


Also moved the column header menu to the right side and converted stuff to IconButtons with tooltips:
<img width="851" alt="image" src="https://github.com/user-attachments/assets/988d5274-fcb5-449b-b430-f6e9d6109b7d" />
<img width="854" alt="image" src="https://github.com/user-attachments/assets/6605c9b3-80d5-433e-a41e-85eeb0433bdb" />
