### PR TITLE
Service Selection Pagination: Generate options based on total count

### DIFF
--- a/src/Components/ServiceSelectionScene/ServiceSelectionPaginationScene.test.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionPaginationScene.test.tsx
@@ -1,0 +1,36 @@
+import { getCountOptionsFromTotal } from './ServiceSelectionPaginationScene';
+
+describe('getCountOptionsFromTotal()', () => {
+  test('Generates pagination options', () => {
+    const options = getCountOptionsFromTotal(61);
+    expect(options).toEqual([
+      { value: '20', label: '20' },
+      { value: '40', label: '40' },
+      { value: '60', label: '60' },
+    ]);
+  });
+
+  test('Generates pagination options up to the total count', () => {
+    expect(getCountOptionsFromTotal(60)).toEqual([
+      { value: '20', label: '20' },
+      { value: '40', label: '40' },
+      { value: '60', label: '60' },
+    ]);
+    expect(getCountOptionsFromTotal(59)).toEqual([
+      { value: '20', label: '20' },
+      { value: '40', label: '40' },
+      { value: '60', label: '59' },
+    ]);
+    expect(getCountOptionsFromTotal(40)).toEqual([
+      { value: '20', label: '20' },
+      { value: '40', label: '40' },
+    ]);
+    expect(getCountOptionsFromTotal(39)).toEqual([
+      { value: '20', label: '20' },
+      { value: '40', label: '39' },
+    ]);
+    expect(getCountOptionsFromTotal(20)).toEqual([{ value: '20', label: '20' }]);
+    expect(getCountOptionsFromTotal(19)).toEqual([{ value: '20', label: '19' }]);
+    expect(getCountOptionsFromTotal(1)).toEqual([{ value: '20', label: '1' }]);
+  });
+});


### PR DESCRIPTION
This PR uses the totalCount of values to generate the options for the pagination dropdown, using the total count to determine the amount of options and syncing the visible value to the actual value. For example 60 services will generate 3 options, 40 will generate up to 40, and less than 20 will show the actual number. Internally it still uses the same values, but the visible values change according to the total.

For example:

![imagen](https://github.com/user-attachments/assets/86fd27c0-b2f5-474f-a0a0-1cb82303fa9d)

![imagen](https://github.com/user-attachments/assets/f8809177-f875-426c-b3e6-a09b27233e05)

![imagen](https://github.com/user-attachments/assets/fbf2f1ec-ae6d-430d-ac55-de78222a91e4)

https://github.com/user-attachments/assets/f8fb84b8-d6d8-4932-bdc4-b07c1f8b3b17


