### PR TITLE
Logs Panel: Display error message when logs fail to load

### DIFF
--- a/src/Components/ServiceScene/LogsPanelError.tsx
+++ b/src/Components/ServiceScene/LogsPanelError.tsx
@@ -28,5 +28,5 @@ function getMessageFromError(error: string) {
     return 'Logs could not be retrieved due to invalid filter parameters. Please review your filters and try again.';
   }
 
-  return 'Logs could not be retrieved. Please review your filters or try a different time interval.';
+  return 'Logs could not be retrieved. Please review your filters or try a different time range.';
 }

--- a/src/Components/ServiceScene/LogsPanelError.tsx
+++ b/src/Components/ServiceScene/LogsPanelError.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { GrotError } from 'Components/GrotError';
+import { Button } from '@grafana/ui';
+
+interface Props {
+  clearFilters(): void;
+  error: string;
+}
+
+export const LogsPanelError = ({ clearFilters, error }: Props) => {
+  return (
+    <GrotError>
+      <div>
+        <p>
+          <strong>No logs found.</strong>
+        </p>
+        <p>{getMessageFromError(error)}</p>
+        <Button variant="secondary" onClick={clearFilters}>
+          Clear filters
+        </Button>
+      </div>
+    </GrotError>
+  );
+};
+
+function getMessageFromError(error: string) {
+  if (error.includes('parse error')) {
+    return 'Logs could not be retrieved due to invalid filter parameters. Please review your filters and try again.';
+  }
+
+  return 'Logs could not be retrieved. Please review your filters or try a different time interval.';
+}

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -96,7 +96,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       .setUnit('short')
       .setMenu(new PanelMenu({ investigationOptions: { labelName: 'level' } }))
       .setCollapsible(true)
-      .setCollapsed(Boolean(getLogsVolumeOption('collapsed')))
+      .setCollapsed(getLogsVolumeOption('collapsed'))
       .setHeaderActions(new LogsVolumeActions({}))
       // 11.5
       // .setShowMenuAlways(true)

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -229,7 +229,7 @@ export function setLogsVolumeOption(option: 'collapsed', value: string | undefin
 }
 
 export function getLogsVolumeOption(option: 'collapsed') {
-  return localStorage.getItem(`${LOGS_VOLUME_LOCALSTORAGE_KEY}.${option}`);
+  return Boolean(localStorage.getItem(`${LOGS_VOLUME_LOCALSTORAGE_KEY}.${option}`));
 }
 
 // Log visualization options


### PR DESCRIPTION
This PR subscribes to the logs query and displays an error component when the log query fails, with the objective of improving how we surface errors to the user, making it clear that the query failed and providing a escape hatch to clear all filters.

Before:

<img src="https://github.com/user-attachments/assets/286640cc-ef69-4c56-971e-5f5930367926" width="600">

After:

<img src="https://github.com/user-attachments/assets/b9a7ad02-a3db-4397-86fa-1bed77960b87" width="100%">