### PR TITLE
fix(ServiceSelectionPagination): check for undefined in options

### DIFF
--- a/src/Components/ServiceSelectionScene/ServiceSelectionPaginationScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionPaginationScene.tsx
@@ -18,7 +18,7 @@ export class ServiceSelectionPaginationScene extends SceneObjectBase<ServiceSele
     const { countPerPage } = serviceSelectionScene.useState();
     const options = getCountOptionsFromTotal(totalCount);
     useEffect(() => {
-      const lastOptionValue = options[options.length - 1].value ?? countPerPage.toString();
+      const lastOptionValue = options[options.length - 1]?.value ?? countPerPage.toString();
       if (countPerPage.toString() > lastOptionValue) {
         serviceSelectionScene.setState({ countPerPage: parseInt(lastOptionValue, 10) });
       }


### PR DESCRIPTION
When options is empty, the resolved value was undefined causing an error when trying to read `.value`